### PR TITLE
avoid incorrectly flagging the blockindex as corrupt

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1623,7 +1623,8 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
     }
 
     // undo transactions in reverse order
-    for (int i = block.vtx.size() - 1; i >= 0; i--) {
+    bool pos_offset = block.IsProofOfStake();
+    for (int i = block.vtx.size() - 1; i >= pos_offset; i--) {
         const CTransaction &tx = *(block.vtx[i]);
         uint256 hash = tx.GetHash();
         bool is_coinbase = tx.IsCoinBase();


### PR DESCRIPTION
bitcoin tests all coinbase/vtx on init, testing whether the resulting outputs are able to be spent. once this has been confirmed, the undo data is applied to ensure that, during disconnectblock; the integrity of the utxo set is maintained. unfortunately, the first 'coinbase' entry for a coinstake is actually null - that being the primary way a coinstake is identified.

we simply avoid checking vtx[0], if we know the block is proof of stake.

