### PR TITLE
return inputs to wallet after orphaned stake

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -158,8 +158,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
     coinbaseTx.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
 
-    if (pwallet)  // attempt to find a coinstake
+    if (pwallet)
     {
+        // flush orphaned coinstakes
+        pwallet->AbandonOrphanedCoinstakes();
+
+        // attempt to find a coinstake
         *pfPoSCancel = true;
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
         CMutableTransaction txCoinStake;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1714,6 +1714,21 @@ void CWallet::ReacceptWalletTransactions()
     }
 }
 
+void CWallet::AbandonOrphanedCoinstakes()
+{
+    for (std::pair<const uint256, CWalletTx>& item : mapWallet) {
+        const uint256& wtxid = item.first;
+        CWalletTx& wtx = item.second;
+        assert(wtx.GetHash() == wtxid);
+        if (wtx.GetDepthInMainChain() == 0 && !wtx.isAbandoned() && wtx.IsCoinStake()) {
+            LogPrint(BCLog::STAKE, "Abandoning coinstake wtx %s\n", wtx.GetHash().ToString());
+            if (!AbandonTransaction(wtxid)) {
+                LogPrint(BCLog::STAKE, "Failed to abandon coinstake tx %s\n", wtx.GetHash().ToString());
+            }
+        }
+    }
+}
+
 bool CWalletTx::SubmitMemoryPoolAndRelay(std::string& err_string, bool relay)
 {
     // Can't relay if wallet is not broadcasting

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -805,6 +805,9 @@ public:
     /* Returns true if the wallet can give out new addresses. This means it has keys in the keypool or can generate new keys */
     bool CanGetAddresses(bool internal = false) const;
 
+    /* Function that will remove potentially abandoned coinstakes, returning the input to the wallet. */
+    void AbandonOrphanedCoinstakes();
+
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current
      * chain at the time this function is entered


### PR DESCRIPTION
refactored version of ce99d55fa5aace724e38e935b47133b93da43577 and 722a87cb8, that returns unused inputs to the wallet in the case of a stale/abandoned proof of stake block.