### PR TITLE
remove testnet assert used during initial testing

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -801,9 +801,6 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // specified in default section of config file, but not overridden
     // on the command line or in this network's section of the config file.
 
-    // temporary measure for others to test wallet in full testnet mode
-    assert (Params().NetworkIDString() == CBaseChainParams::TESTNET);
-
     std::string network = args.GetChainName();
     if (network == CBaseChainParams::SIGNET) {
         LogPrintf("Signet derived magic (message start): %s\n", HexStr(chainparams.MessageStart()));


### PR DESCRIPTION
This removes the assert thrown if not running on testnet.