### PR TITLE
enable Versionbits

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -119,28 +119,6 @@ void CBlockIndex::BuildSkip()
         pskip = pprev->GetAncestor(GetSkipHeight(nHeight));
 }
 
-bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned int nRequired)
-{
-    unsigned int nToCheck = 0;
-
-    if (minVersion == 3) {
-        nToCheck = 10000;
-    } else if (minVersion == 4) {
-        nToCheck = 7200;
-    } else if (minVersion == 5) {
-        nToCheck = 10000;
-    }
-
-    unsigned int nFound = 0;
-    for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != nullptr; i++) {
-        if (pstart->nVersion >= minVersion)
-            ++nFound;
-        pstart = pstart->pprev;
-    }
-
-    return (nFound >= nRequired);
-}
-
 arith_uint256 GetBlockTrust(const CBlockIndex& block)
 {
     arith_uint256 bnTarget;

--- a/src/chain.h
+++ b/src/chain.h
@@ -304,13 +304,6 @@ public:
     }
 
     /**
-     * Returns true if there are nRequired or more blocks of minVersion or above
-     * in the last Params().ToCheckBlockUpgradeMajority() blocks, starting at pstart 
-     * and going backwards.
-     */
-    static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned int nRequired);
-
-    /**
      * Check whether this block's and all previous blocks' transactions have been
      * downloaded (and stored to disk) at some point.
      *

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -72,7 +72,7 @@ public:
         consensus.BIP34Height = std::numeric_limits<int>::max();
         consensus.BIP34Hash = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
         consensus.BIP65Height = std::numeric_limits<int>::max();
-        consensus.BIP66Height = std::numeric_limits<int>::max();
+        consensus.BIP66Height = 1564232; // a6e944cc38a0d8c7c5740569501e622ec2a011e7c9dd97a78e5fba40a45b8c61
         consensus.MinBIP9WarningHeight = std::numeric_limits<int>::max();
         consensus.devScript = { CScript() << ParseHex("03c8fc5c87f00bcc32b5ce5c036957f8befeff05bf4d88d2dcde720249f78d9313") << OP_CHECKSIG };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -69,9 +69,6 @@ public:
         consensus.nRevertCoinbase = 254208; //! disregard bip34 from this height (?)
         consensus.nCoinbaseMaturity = 30;
         consensus.BIP16Exception = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
-        consensus.BIP34Height = std::numeric_limits<int>::max();
-        consensus.BIP34Hash = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
-        consensus.BIP65Height = std::numeric_limits<int>::max();
         consensus.POSVHeight = 260800;
         consensus.BIP66Height = 1564232; // a6e944cc38a0d8c7c5740569501e622ec2a011e7c9dd97a78e5fba40a45b8c61
         consensus.DonationHeight = 3382229; // 77ee468ea88227404a53bad63029a8d0aa58f9f6a470a076a2aa91c8494449ac
@@ -300,9 +297,6 @@ public:
         consensus.nLastPowHeight = 1439;
         consensus.nCoinbaseMaturity = 50;
         consensus.BIP16Exception = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
-        consensus.BIP34Height = 1227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
-        consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.POSVHeight = 1440;
         consensus.BIP66Height = 2189; // 84c24e7ec0023d9cf2ba50366f2a1806c30e7256606aaeb31ebd17a4c0a82e9b
         consensus.DonationHeight = 13260; // 7e62ee9c868aa8414909dff2c68d5f9a137d9eb8e9b93c28511cbf8a5cac7280
@@ -471,9 +465,6 @@ public:
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.nCoinbaseMaturity = 30;
         consensus.BIP16Exception = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
-        consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
-        consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.DonationHeight = 3382229; //
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -556,9 +547,6 @@ public:
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.nCoinbaseMaturity = 30;
         consensus.BIP16Exception = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
-        consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
-        consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.DonationHeight = 3382229; //
         consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -72,6 +72,7 @@ public:
         consensus.BIP34Height = std::numeric_limits<int>::max();
         consensus.BIP34Hash = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
         consensus.BIP65Height = std::numeric_limits<int>::max();
+        consensus.POSVHeight = 260800;
         consensus.BIP66Height = 1564232; // a6e944cc38a0d8c7c5740569501e622ec2a011e7c9dd97a78e5fba40a45b8c61
         consensus.DonationHeight = 3382229; // 77ee468ea88227404a53bad63029a8d0aa58f9f6a470a076a2aa91c8494449ac
         consensus.MinBIP9WarningHeight = std::numeric_limits<int>::max();
@@ -302,6 +303,7 @@ public:
         consensus.BIP34Height = 1227931;
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
+        consensus.POSVHeight = 1440;
         consensus.BIP66Height = 2189; // 84c24e7ec0023d9cf2ba50366f2a1806c30e7256606aaeb31ebd17a4c0a82e9b
         consensus.DonationHeight = 13260; // 7e62ee9c868aa8414909dff2c68d5f9a137d9eb8e9b93c28511cbf8a5cac7280
         consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -97,21 +97,31 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
 
+        // Deployment of BIP34.
+        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].bit = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // Sat Oct 01 2022 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT; // Sun Oct 01 2023 00:00:00 GMT+0000
+
+        // Deployment of BIP65.
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].bit = 1;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // Tue Nov 01 2022 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT; // Wed Nov 01 2023 00:00:00 GMT+0000
+
         // Deployment of BIP68, BIP112, and BIP113.
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // Thu Dec 01 2022 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT; // Fri Dec 01 2023 00:00:00 GMT+0000
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 3;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // Sun Jan 01 2023 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT; // Mon Jan 01 2024 00:00:00 GMT+0000
 
         // Deployment of Taproot (BIPs 340-342)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 4;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 709632; // Approximately November 12th, 2021
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
         consensus.defaultAssumeValid = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -317,19 +327,28 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
 
+        // Deployment of BIP34.
+        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].bit = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].nStartTime = 1664582400; // Sat Oct 01 2022 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].nTimeout = 1696118400; // Sun Oct 01 2023 00:00:00 GMT+0000
+
+        // Deployment of BIP65.
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].bit = 1;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].nStartTime = 1667260800; // Tue Nov 01 2022 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].nTimeout = 1698796800; // Wed Nov 01 2023 00:00:00 GMT+0000
 
         // Deployment of BIP68, BIP112, and BIP113.
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1669852800; // Thu Dec 01 2022 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1701388800; // Fri Dec 01 2023 00:00:00 GMT+0000
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 3;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1672531200; // Sun Jan 01 2023 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1704067200; // Mon Jan 01 2024 00:00:00 GMT+0000
 
         // Deployment of Taproot (BIPs 340-342)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 4;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -73,6 +73,7 @@ public:
         consensus.BIP34Hash = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
         consensus.BIP65Height = std::numeric_limits<int>::max();
         consensus.BIP66Height = 1564232; // a6e944cc38a0d8c7c5740569501e622ec2a011e7c9dd97a78e5fba40a45b8c61
+        consensus.DonationHeight = 3382229; // 77ee468ea88227404a53bad63029a8d0aa58f9f6a470a076a2aa91c8494449ac
         consensus.MinBIP9WarningHeight = std::numeric_limits<int>::max();
         consensus.devScript = { CScript() << ParseHex("03c8fc5c87f00bcc32b5ce5c036957f8befeff05bf4d88d2dcde720249f78d9313") << OP_CHECKSIG };
 
@@ -302,6 +303,7 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 2189; // 84c24e7ec0023d9cf2ba50366f2a1806c30e7256606aaeb31ebd17a4c0a82e9b
+        consensus.DonationHeight = 13260; // 7e62ee9c868aa8414909dff2c68d5f9a137d9eb8e9b93c28511cbf8a5cac7280
         consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window
         consensus.devScript = { CScript() << ParseHex("03d4b22ae69b0ff7554f4c343cd213d00fd5131466cc21d8ebfab97c52ec9a00c9") << OP_CHECKSIG, // Correct dev address
                                 CScript() << ParseHex("03081542439583f7632ce9ff7c8851b0e9f56d0a6db9a13645ce102a8809287d4f") << OP_CHECKSIG };
@@ -471,6 +473,7 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.DonationHeight = 3382229; //
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
         consensus.fPowAllowMinDifficultyBlocks = false;
@@ -555,6 +558,7 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.DonationHeight = 3382229; //
         consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -90,8 +90,8 @@ public:
         consensus.nStakeMaxAge = 45 * 24 *  60 * 60; // 45 days
         consensus.nModifierInterval = 13 * 60;
 
-        consensus.nRuleChangeActivationThreshold = 1815; // 90% of 2016
-        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.nRuleChangeActivationThreshold = 12960; // 90% of 14400
+        consensus.nMinerConfirmationWindow = 14400; // (nPowTargetTimespan / nPowTargetSpacing) * 10 (10 Days)
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -98,13 +98,13 @@ public:
 
         // Deployment of BIP34.
         consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // Sat Oct 01 2022 00:00:00 GMT+0000
-        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT; // Sun Oct 01 2023 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].nStartTime = 1667260800; // Tue Nov 01 2022 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_HEIGHTINCB].nTimeout = 1698796800; // Wed Nov 01 2023 00:00:00 GMT+0000
 
         // Deployment of BIP65.
         consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE; // Tue Nov 01 2022 00:00:00 GMT+0000
-        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT; // Wed Nov 01 2023 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].nStartTime = 1668384000; // Tue Nov 14 2022 00:00:00 GMT+0000
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV].nTimeout = 1699920000; // Wed Nov 14 2023 00:00:00 GMT+0000
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 2;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -20,17 +20,17 @@ namespace Consensus {
  */
 enum BuriedDeployment : int16_t {
     // buried deployments get negative values to avoid overlap with DeploymentPos
-    DEPLOYMENT_HEIGHTINCB = std::numeric_limits<int16_t>::min(),
-    DEPLOYMENT_CLTV,
-    DEPLOYMENT_DERSIG,
+    DEPLOYMENT_DERSIG = std::numeric_limits<int16_t>::min(),
 };
 constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_DERSIG; }
 
 enum DeploymentPos : uint16_t {
     DEPLOYMENT_TESTDUMMY,
-    DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
-    DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
-    DEPLOYMENT_TAPROOT, // Deployment of Schnorr/Taproot (BIPs 340-342)
+    DEPLOYMENT_HEIGHTINCB, // Deployment of BIP34.
+    DEPLOYMENT_CLTV,       // Deployment of BIP65.
+    DEPLOYMENT_CSV,        // Deployment of BIP68, BIP112, and BIP113.
+    DEPLOYMENT_SEGWIT,     // Deployment of BIP141, BIP143, and BIP147.
+    DEPLOYMENT_TAPROOT,    // Deployment of Schnorr/Taproot (BIPs 340-342)
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in deploymentinfo.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };
@@ -137,10 +137,6 @@ struct Params {
     int DeploymentHeight(BuriedDeployment dep) const
     {
         switch (dep) {
-        case DEPLOYMENT_HEIGHTINCB:
-            return BIP34Height;
-        case DEPLOYMENT_CLTV:
-            return BIP65Height;
         case DEPLOYMENT_DERSIG:
             return BIP66Height;
         } // no default case, so the compiler can warn about missing cases

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -21,8 +21,9 @@ namespace Consensus {
 enum BuriedDeployment : int16_t {
     // buried deployments get negative values to avoid overlap with DeploymentPos
     DEPLOYMENT_DERSIG = std::numeric_limits<int16_t>::min(),
+    DEPLOYMENT_DEV,
 };
-constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_DERSIG; }
+constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_DEV; }
 
 enum DeploymentPos : uint16_t {
     DEPLOYMENT_TESTDUMMY,
@@ -84,6 +85,8 @@ struct Params {
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
+    /** Block height at which Developer donation address becomes active */
+    int DonationHeight;
     /** Don't warn about unknown BIP 9 activations below this height.
      * This prevents us from warning about the CSV and segwit activations. */
     int MinBIP9WarningHeight;
@@ -139,6 +142,8 @@ struct Params {
         switch (dep) {
         case DEPLOYMENT_DERSIG:
             return BIP66Height;
+        case DEPLOYMENT_DEV:
+            return DonationHeight;
         } // no default case, so the compiler can warn about missing cases
         return std::numeric_limits<int>::max();
     }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -20,7 +20,8 @@ namespace Consensus {
  */
 enum BuriedDeployment : int16_t {
     // buried deployments get negative values to avoid overlap with DeploymentPos
-    DEPLOYMENT_DERSIG = std::numeric_limits<int16_t>::min(),
+    DEPLOYMENT_POSV = std::numeric_limits<int16_t>::min(),
+    DEPLOYMENT_DERSIG,
     DEPLOYMENT_DEV,
 };
 constexpr bool ValidDeployment(BuriedDeployment dep) { return dep <= DEPLOYMENT_DEV; }
@@ -81,6 +82,8 @@ struct Params {
     /** Block height and hash at which BIP34 becomes active */
     int BIP34Height;
     uint256 BIP34Hash;
+    /** Block height at which POSV becomes active */
+    int POSVHeight;
     /** Block height at which BIP65 becomes active */
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
@@ -140,6 +143,8 @@ struct Params {
     int DeploymentHeight(BuriedDeployment dep) const
     {
         switch (dep) {
+        case DEPLOYMENT_POSV:
+            return POSVHeight;
         case DEPLOYMENT_DERSIG:
             return BIP66Height;
         case DEPLOYMENT_DEV:

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -43,6 +43,8 @@ std::string DeploymentName(Consensus::BuriedDeployment dep)
         return "bip65";
     case Consensus::DEPLOYMENT_DERSIG:
         return "bip66";
+    case Consensus::DEPLOYMENT_DEV:
+            return "dev";
     case Consensus::DEPLOYMENT_CSV:
         return "csv";
     case Consensus::DEPLOYMENT_SEGWIT:

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -41,10 +41,12 @@ std::string DeploymentName(Consensus::BuriedDeployment dep)
         return "bip34";
     case Consensus::DEPLOYMENT_CLTV:
         return "bip65";
+    case Consensus::DEPLOYMENT_POSV:
+        return "posv";
     case Consensus::DEPLOYMENT_DERSIG:
         return "bip66";
     case Consensus::DEPLOYMENT_DEV:
-            return "dev";
+        return "dev";
     case Consensus::DEPLOYMENT_CSV:
         return "csv";
     case Consensus::DEPLOYMENT_SEGWIT:

--- a/src/deploymentinfo.cpp
+++ b/src/deploymentinfo.cpp
@@ -12,6 +12,14 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.gbt_force =*/ true,
     },
     {
+        /*.name =*/ "heightincb",
+        /*.gbt_force =*/ true,
+    },
+    {
+        /*.name =*/ "cltv",
+        /*.gbt_force =*/ true,
+    },
+    {
         /*.name =*/ "csv",
         /*.gbt_force =*/ true,
     },

--- a/src/deploymentstatus.cpp
+++ b/src/deploymentstatus.cpp
@@ -30,5 +30,5 @@ static constexpr bool is_minimum()
     return x == std::numeric_limits<U>::min();
 }
 
-static_assert(is_minimum<Consensus::BuriedDeployment, Consensus::DEPLOYMENT_DERSIG>(), "dersig is not minimum value for BuriedDeployment");
+static_assert(is_minimum<Consensus::BuriedDeployment, Consensus::DEPLOYMENT_POSV>(), "posv is not minimum value for BuriedDeployment");
 static_assert(is_minimum<Consensus::DeploymentPos, Consensus::DEPLOYMENT_TESTDUMMY>(), "testdummy is not minimum value for DeploymentPos");

--- a/src/deploymentstatus.cpp
+++ b/src/deploymentstatus.cpp
@@ -30,5 +30,5 @@ static constexpr bool is_minimum()
     return x == std::numeric_limits<U>::min();
 }
 
-static_assert(is_minimum<Consensus::BuriedDeployment, Consensus::DEPLOYMENT_HEIGHTINCB>(), "heightincb is not minimum value for BuriedDeployment");
+static_assert(is_minimum<Consensus::BuriedDeployment, Consensus::DEPLOYMENT_DERSIG>(), "dersig is not minimum value for BuriedDeployment");
 static_assert(is_minimum<Consensus::DeploymentPos, Consensus::DEPLOYMENT_TESTDUMMY>(), "testdummy is not minimum value for DeploymentPos");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -140,7 +140,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     nHeight = pindexPrev->nHeight + 1;
 
     // Set block version
-    pblock->nVersion = CBlockHeader::CURRENT_VERSION;
+    pblock->nVersion = g_versionbitscache.ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
 
     // Add dummy coinbase tx as first transaction
     pblock->vtx.emplace_back();

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -25,6 +25,12 @@ class CBlockHeader
 {
 public:
     // header
+    // Block versions
+    // Block Version 1 : Genesis Block
+    // Block Version 2 : Introduction of POW Block
+    // Block Version 3 : Introduction of POSV Block
+    // Block Version 4 : Introduction of BIP66
+    // Block Version 5 : Introduction of Developers Funding
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1486,6 +1486,7 @@ RPCHelpMan getblockchaininfo()
     const Consensus::Params& consensusParams = Params().GetConsensus();
     UniValue softforks(UniValue::VOBJ);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_HEIGHTINCB);
+    SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_POSV);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_DERSIG);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_DEV);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_CLTV);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1487,6 +1487,7 @@ RPCHelpMan getblockchaininfo()
     UniValue softforks(UniValue::VOBJ);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_HEIGHTINCB);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_DERSIG);
+    SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_DEV);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_CLTV);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_CSV);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_SEGWIT);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3361,8 +3361,9 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
 
     // Reject blocks with outdated version
     if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
-        (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DERSIG)) ||
-        (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CLTV))) {
+        (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_POSV)) ||
+        (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DERSIG)) ||
+        (block.nVersion < 5 && DeploymentActiveAfter(pindexPrev, consensusParams, Consensus::DEPLOYMENT_DEV))) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1931,15 +1931,18 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     // be reset before it reaches block 1,983,702 and starts doing unnecessary
     // BIP30 checking again.
     assert(pindex->pprev);
-    CBlockIndex* pindexBIP34height = pindex->pprev->GetAncestor(m_params.GetConsensus().BIP34Height);
+    // TODO: revisit BIP30 optimisation checks after BIP34 activation, for now
+    // CBlockIndex* pindexBIP34height = pindex->pprev->GetAncestor(m_params.GetConsensus().BIP34Height);
 
     //Only continue to enforce if we're below BIP34 activation height or the block hash at that height doesn't correspond.
-    fEnforceBIP30 = fEnforceBIP30 && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == m_params.GetConsensus().BIP34Hash));
+    // fEnforceBIP30 = fEnforceBIP30 && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == m_params.GetConsensus().BIP34Hash));
 
     // TODO: Remove BIP30 checking from block height 1,983,702 on, once we have a
     // consensus change that ensures coinbases at those heights can not
     // duplicate earlier coinbases.
-    if (fEnforceBIP30 || pindex->nHeight >= BIP34_IMPLIES_BIP30_LIMIT) {
+    // TODO: revisit BIP30 optimisation checks after BIP34 activation, for now
+    // if (fEnforceBIP30 || pindex->nHeight >= BIP34_IMPLIES_BIP30_LIMIT) {
+    if (fEnforceBIP30) {
         bool fProofOfStake = pindex->nHeight > Params().GetConsensus().nLastPowHeight;
         for (const auto& tx : block.vtx) {
             for (size_t o = 0; o < tx->vout.size(); o++) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2102,13 +2102,13 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
             }
 
             // Check output values
-            if (block.nVersion >= 5 && CBlockIndex::IsSuperMajority(5, pindex->pprev, 9000)) {
+            if (block.nVersion >= 5 && pindex->pprev->nHeight >= m_params.GetConsensus().DonationHeight) {
 
                 nCalculatedPoSVEndCredit = nCalculatedStakeReward * 0.92;
                 nCalculatedDevEndCredit = nCalculatedStakeReward - nCalculatedPoSVEndCredit;
                 nDevEndCredit = block.vtx[1]->vout[block.vtx[1]->vout.size() - 1].nValue;
 
-                if (nDevEndCredit != nCalculatedDevEndCredit && CBlockIndex::IsSuperMajority(5, pindex->pprev->pprev, 9000)) {
+                if (nDevEndCredit != nCalculatedDevEndCredit && pindex->pprev->pprev->nHeight >= m_params.GetConsensus().DonationHeight) {
                     LogPrintf("WARNING: nDevEndCredit=%.f != nCalculatedDevEndCredit=%.2f\n", nDevEndCredit, nCalculatedDevEndCredit);
                     if (nDevEndCredit > nCalculatedDevEndCredit) {
                         LogPrintf("ERROR: nDevEndCredit=%.f > nCalculatedDevEndCredit=%.2f\n", nDevEndCredit, nCalculatedDevEndCredit);

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -11,7 +11,7 @@
 #include <map>
 
 /** What block version to use for new blocks (pre versionbits) */
-static const int32_t VERSIONBITS_LAST_OLD_BLOCK_VERSION = 4;
+static const int32_t VERSIONBITS_LAST_OLD_BLOCK_VERSION = 5;
 /** What bits to set in version for versionbits blocks */
 static const int32_t VERSIONBITS_TOP_BITS = 0x20000000UL;
 /** What bitmask determines whether versionbits is in use */


### PR DESCRIPTION
This pull request targets enabling of various versionbit deployments
The purpose is to enable existing versionbit activation's [csv, segwit, taproot] 
and also enable heightincb and cltv which were originally ISM (IsSuperMajority) but never fully enabled on the reddcoin blockchain.
Additionally, bip66, posv, and dev donation are buried

The activation threshold has been extended on mainnet to 10days and 90%