### PR TITLE
depends: add windres

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -137,8 +137,8 @@ include packages/packages.mk
 #     2. Before including packages/*.mk (excluding packages/packages.mk), since
 #        they rely on the build_id variables
 #
-build_id:=$(shell env CC='$(build_CC)' CXX='$(build_CXX)' AR='$(build_AR)' RANLIB='$(build_RANLIB)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
-$(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' CXX='$(host_CXX)' AR='$(host_AR)' RANLIB='$(host_RANLIB)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' ./gen_id '$(HOST_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
+build_id:=$(shell env CC='$(build_CC)' CXX='$(build_CXX)' AR='$(build_AR)' RANLIB='$(build_RANLIB)' WINDRES='$(build_WINDRES)' STRIP='$(build_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' ./gen_id '$(BUILD_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
+$(host_arch)_$(host_os)_id:=$(shell env CC='$(host_CC)' CXX='$(host_CXX)' AR='$(host_AR)' RANLIB='$(host_RANLIB)' WINDRES='$(host_WINDRES)' STRIP='$(host_STRIP)' SHA256SUM='$(build_SHA256SUM)' DEBUG='$(DEBUG)' ./gen_id '$(HOST_ID_SALT)' 'GUIX_ENVIRONMENT=$(realpath $(GUIX_ENVIRONMENT))')
 
 qrencode_packages_$(NO_QR) = $(qrencode_packages)
 
@@ -216,6 +216,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@CXX@|$(host_CXX)|' \
             -e 's|@AR@|$(host_AR)|' \
             -e 's|@RANLIB@|$(host_RANLIB)|' \
+            -e 's|@WINDRES@|$(host_WINDRES)|' \
             -e 's|@NM@|$(host_NM)|' \
             -e 's|@STRIP@|$(host_STRIP)|' \
             -e 's|@build_os@|$(build_os)|' \

--- a/depends/builders/default.mk
+++ b/depends/builders/default.mk
@@ -4,6 +4,7 @@ default_build_AR = ar
 default_build_RANLIB = ranlib
 default_build_STRIP = strip
 default_build_NM = nm
+default_build_WINDRES = windres
 default_build_OTOOL = otool
 default_build_INSTALL_NAME_TOOL = install_name_tool
 
@@ -12,7 +13,7 @@ build_$(build_os)_$1 ?= $$(default_build_$1)
 build_$(build_arch)_$(build_os)_$1 ?= $$(build_$(build_os)_$1)
 build_$1=$$(build_$(build_arch)_$(build_os)_$1)
 endef
-$(foreach var,CC CXX AR RANLIB NM STRIP SHA256SUM DOWNLOAD OTOOL INSTALL_NAME_TOOL,$(eval $(call add_build_tool_func,$(var))))
+$(foreach var,CC CXX AR RANLIB NM WINDRES STRIP SHA256SUM DOWNLOAD OTOOL INSTALL_NAME_TOOL,$(eval $(call add_build_tool_func,$(var))))
 define add_build_flags_func
 build_$(build_arch)_$(build_os)_$1 += $(build_$(build_os)_$1)
 build_$1=$$(build_$(build_arch)_$(build_os)_$1)

--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -8,6 +8,7 @@ $(1)_ar=$$($$($(1)_type)_AR)
 $(1)_ranlib=$$($$($(1)_type)_RANLIB)
 $(1)_libtool=$$($$($(1)_type)_LIBTOOL)
 $(1)_nm=$$($$($(1)_type)_NM)
+$(1)_windres=$$($$($(1)_type)_WINDRES)
 $(1)_cflags=$$($$($(1)_type)_CFLAGS) \
             $$($$($(1)_type)_$$(release_type)_CFLAGS)
 $(1)_cxxflags=$$($$($(1)_type)_CXXFLAGS) \
@@ -152,6 +153,9 @@ $(1)_autoconf += NM="$$($(1)_nm)"
 endif
 ifneq ($($(1)_ranlib),)
 $(1)_autoconf += RANLIB="$$($(1)_ranlib)"
+endif
+ifneq ($($(1)_windres),)
+$(1)_autoconf += WINDRES="$$($(1)_windres)"
 endif
 ifneq ($($(1)_ar),)
 $(1)_autoconf += AR="$$($(1)_ar)"

--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -6,6 +6,7 @@ default_host_CC = $(host_toolchain)gcc
 default_host_CXX = $(host_toolchain)g++
 default_host_AR = $(host_toolchain)ar
 default_host_RANLIB = $(host_toolchain)ranlib
+default_host_WINDRES = $(host_toolchain)windres
 default_host_STRIP = $(host_toolchain)strip
 default_host_LIBTOOL = $(host_toolchain)libtool
 default_host_INSTALL_NAME_TOOL = $(host_toolchain)install_name_tool
@@ -35,5 +36,5 @@ host_$1 = $$($(host_arch)_$(host_os)_$1)
 host_$(release_type)_$1 = $$($(host_arch)_$(host_os)_$(release_type)_$1)
 endef
 
-$(foreach tool,CC CXX AR RANLIB STRIP NM LIBTOOL OTOOL INSTALL_NAME_TOOL,$(eval $(call add_host_tool_func,$(tool))))
+$(foreach tool,CC CXX AR RANLIB WINDRES STRIP NM LIBTOOL OTOOL INSTALL_NAME_TOOL,$(eval $(call add_host_tool_func,$(tool))))
 $(foreach flags,CFLAGS CXXFLAGS CPPFLAGS LDFLAGS, $(eval $(call add_host_flags_func,$(flags))))

--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -14,6 +14,7 @@ i686_linux_CC=gcc -m32
 i686_linux_CXX=g++ -m32
 i686_linux_AR=ar
 i686_linux_RANLIB=ranlib
+i686_linux_WINDRES=windres
 i686_linux_NM=nm
 i686_linux_STRIP=strip
 
@@ -21,6 +22,7 @@ x86_64_linux_CC=gcc -m64
 x86_64_linux_CXX=g++ -m64
 x86_64_linux_AR=ar
 x86_64_linux_RANLIB=ranlib
+x86_64_linux_WINDRES=windres
 x86_64_linux_NM=nm
 x86_64_linux_STRIP=strip
 else

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -74,6 +74,7 @@ These variables may be set to override or append their default values.
     $(package)_objcxx
     $(package)_ar
     $(package)_ranlib
+    $(package)_windres
     $(package)_libtool
     $(package)_nm
     $(package)_cflags

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -6,7 +6,7 @@ $(package)_file_name=$(package)-$($(package)_version)$($(package)_version_suffix
 $(package)_sha256_hash=c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa
 
 define $(package)_set_vars
-$(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
+$(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)" RC="$($(package)_windres)"
 $(package)_config_opts=--prefix=$(host_prefix) --openssldir=$(host_prefix)/etc/openssl
 $(package)_config_opts+=no-camellia
 $(package)_config_opts+=no-capieng


### PR DESCRIPTION
when building/ cross-compiling depends with openssl 1.1.1s and mingw32, the compiler is not able to find windres.

This change adds to the configuration such that x86_64-w64-mingw32 is prepended to windres during x86_64-w64-mingw32 builds
x86_64-w64-mingw32-windres
