### PR TITLE
Check if a wallet is loaded before working with stake thread

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -277,11 +277,13 @@ static RPCHelpMan staking()
         NodeContext& node = EnsureAnyNodeContext(request.context);
         gArgs.ForceSetArg("-staking", fGenerate ? "1" : "0");
 
-        MintStake(gArgs.GetBoolArg("-staking", true), GetWallets()[0], node.chainman.get(), &node.chainman->ActiveChainstate(), node.connman.get(), node.mempool.get());
+        if (HasWallets() && GetWallets()[0]) {
+            MintStake(gArgs.GetBoolArg("-staking", true), GetWallets()[0], node.chainman.get(), &node.chainman->ActiveChainstate(), node.connman.get(), node.mempool.get());
 
-        if (!fGenerate) {
-            InterruptStaking();
-            StopStaking();
+            if (!fGenerate) {
+                InterruptStaking();
+                StopStaking();
+            }
         }
     }
 


### PR DESCRIPTION
It is needed to check if there is actually a wallet available, otherwise there will be segfault.