### PR TITLE
Fix kernalrecord probability page display

### DIFF
--- a/src/pos/kernelrecord.h
+++ b/src/pos/kernelrecord.h
@@ -47,6 +47,7 @@ public:
     std::string getTxID();
     int64_t getAge() const;
     int64_t getCoinAge() const;
+    int64_t getCoinAgeWeight(int nTimeOffset = 0) const;
     double getProbToMintStake(double difficulty, int timeOffset = 0) const;
     double getProbToMintWithinNMinutes(double difficulty, int minutes);
 protected:

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -292,7 +292,7 @@ static void NotifyTransactionChanged(MintingTableModel *ttm, const uint256 &hash
 MintingTableModel::MintingTableModel(WalletModel *parent) :
         QAbstractTableModel(parent),
         walletModel(parent),
-        mintingInterval(1),
+        mintingInterval(60),
         priv(new MintingTablePriv(walletModel, this)),
         cachedNumBlocks(0)
 {
@@ -380,7 +380,7 @@ QVariant MintingTableModel::data(const QModelIndex &index, int role) const
         switch(index.column())
         {
         case MintProbability:
-            int interval = this->mintingInterval;
+            int interval = this->mintingInterval / 60;
             QString unit = tr("minutes");
 
             int hours = interval / 60;
@@ -461,8 +461,9 @@ double MintingTableModel::getDayToMint(KernelRecord *wtx) const
 {
     // const CBlockIndex *p = GetLastBlockIndex(::ChainActive().Tip(), true);
     double difficulty = walletModel->node().getDifficulty(); //p->GetBlockDifficulty();
+    int nIntervalMins = mintingInterval / 60;
 
-    double prob = wtx->getProbToMintWithinNMinutes(difficulty, mintingInterval);
+    double prob = wtx->getProbToMintWithinNMinutes(difficulty, nIntervalMins);
     prob = prob * 100;
     return prob;
 }

--- a/src/qt/mintingview.cpp
+++ b/src/qt/mintingview.cpp
@@ -159,27 +159,26 @@ void MintingView::setModel(WalletModel *model)
 
 void MintingView::chooseMintingInterval(int idx)
 {
-    int interval = 1;
-    switch(mintingCombo->itemData(idx).toInt())
-    {
-        case Minting1min:
-            interval = 1;
-            break;
-        case Minting10min:
-            interval = 10;
-            break;
-        case Minting1hour:
-            interval = 60;
-            break;
-        case Minting1day:
-            interval = 60*24;
-            break;
-        case Minting30days:
-            interval = 60*24*30;
-            break;
-        case Minting90days:
-            interval = 60*24*90;
-            break;
+    int interval = 60;
+    switch (mintingCombo->itemData(idx).toInt()) {
+    case Minting1min:
+        interval = 60;
+        break;
+    case Minting10min:
+        interval = 60 * 10;
+        break;
+    case Minting1hour:
+        interval = 60 * 60;
+        break;
+    case Minting1day:
+        interval = 60 * 60 * 24;
+        break;
+    case Minting30days:
+        interval = 60 * 60 * 24 * 30;
+        break;
+    case Minting90days:
+        interval = 60 * 60 * 24 * 90;
+        break;
     }
     model->getMintingTableModel()->setMintingInterval(interval);
     mintingProxyModel->invalidate();


### PR DESCRIPTION
Fix Staking Probability display

the calculated values need to use posv parameters in order to be able to display valid output.

fixes #60 