### PR TITLE
Walletwiz fixes

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -320,7 +320,7 @@ class WalletClient : public ChainClient
 {
 public:
     //! Create new wallet.
-    virtual std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, const SecureString& passphrase, const int& walletType, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;
+    virtual std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, const SecureString& ssMasterKey, const SecureString& passphrase, const int& walletType, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;
 
    //! Load existing wallet.
    virtual std::unique_ptr<Wallet> loadWallet(const std::string& name, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -409,10 +409,6 @@ void BitcoinGUI::createActions()
     m_close_wallet_action = new QAction(tr("Close Wallet…"), this);
     m_close_wallet_action->setStatusTip(tr("Close wallet"));
 
-    m_create_wallet_action = new QAction(tr("Create Wallet…"), this);
-    m_create_wallet_action->setEnabled(false);
-    m_create_wallet_action->setStatusTip(tr("Create a new wallet"));
-
     m_create_wallet_wiz_action = new QAction(tr("Create/ Restore Wallet…"), this);
     m_create_wallet_wiz_action->setEnabled(false);
     m_create_wallet_wiz_action->setStatusTip(tr("Create or restore a new HD wallet"));
@@ -517,12 +513,6 @@ void BitcoinGUI::createActions()
         connect(m_close_wallet_action, &QAction::triggered, [this] {
             m_wallet_controller->closeWallet(walletFrame->currentWalletModel(), this);
         });
-        connect(m_create_wallet_action, &QAction::triggered, [this] {
-            auto activity = new CreateWalletActivity(m_wallet_controller, this);
-            connect(activity, &CreateWalletActivity::created, this, &BitcoinGUI::setCurrentWallet);
-            connect(activity, &CreateWalletActivity::finished, activity, &QObject::deleteLater);
-            activity->create();
-        });
 
 	connect(m_create_wallet_wiz_action, &QAction::triggered, [this] {
 	    auto activity = new CreateWalletWizardActivity(m_wallet_controller, this);
@@ -555,7 +545,6 @@ void BitcoinGUI::createMenuBar()
     QMenu *file = appMenuBar->addMenu(tr("&File"));
     if(walletFrame)
     {
-        file->addAction(m_create_wallet_action);
         file->addAction(m_create_wallet_wiz_action);
         file->addAction(m_open_wallet_action);
         file->addAction(m_close_wallet_action);
@@ -769,7 +758,6 @@ void BitcoinGUI::setWalletController(WalletController* wallet_controller)
 
     m_wallet_controller = wallet_controller;
 
-    m_create_wallet_action->setEnabled(true);
     m_create_wallet_wiz_action->setEnabled(true);
     m_open_wallet_action->setEnabled(true);
     m_open_wallet_action->setMenu(m_open_wallet_menu);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -111,8 +111,8 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
         /** Create wallet frame and make it the central widget */
         walletFrame = new WalletFrame(_platformStyle, this);
         connect(walletFrame, &WalletFrame::createWalletButtonClicked, [this] {
-            auto activity = new CreateWalletActivity(getWalletController(), this);
-            connect(activity, &CreateWalletActivity::finished, activity, &QObject::deleteLater);
+            auto activity = new CreateWalletWizardActivity(getWalletController(), this);
+            connect(activity, &CreateWalletWizardActivity::finished, activity, &QObject::deleteLater);
             activity->create();
         });
         setCentralWidget(walletFrame);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -167,7 +167,6 @@ private:
     QAction* openAction = nullptr;
     QAction* showHelpMessageAction = nullptr;
     QAction* checkUpdatesAction = nullptr;
-    QAction* m_create_wallet_action{nullptr};
     QAction* m_create_wallet_wiz_action{nullptr};
     QAction* m_open_wallet_action{nullptr};
     QMenu* m_open_wallet_menu{nullptr};

--- a/src/qt/createwalletwizard.cpp
+++ b/src/qt/createwalletwizard.cpp
@@ -455,6 +455,29 @@ wizPage_walletKeystore::wizPage_walletKeystore(QWidget* parent)
     setLayout(verticalLayout);
 }
 
+void wizPage_walletKeystore::initializePage()
+{
+    switch (field("type.wallet").toInt()) {
+    case 0: // BIP32
+        radioButton_importSeed->hide();
+        radioButton_masterKey->show();
+        radioButton_hardware->hide();
+        break;
+    case 1: // BIP39
+        radioButton_importSeed->show();
+        radioButton_masterKey->hide();
+        radioButton_hardware->hide();
+        break;
+    case 2: // BIP44
+        radioButton_importSeed->show();
+        radioButton_masterKey->hide();
+        radioButton_hardware->hide();
+        break;
+    case 4: // Blank
+        break;
+    }
+}
+
 int wizPage_walletKeystore::nextId() const
 {
     if (radioButton_createSeed->isChecked()) {

--- a/src/qt/createwalletwizard.cpp
+++ b/src/qt/createwalletwizard.cpp
@@ -34,11 +34,12 @@
 #include <QWizardPage>
 
 
-CreateWalletWizard::CreateWalletWizard(QWidget* parent, SecureString* ssMnemonic_out, SecureString* ssMnemonicPassphrase_out, int* walletType_out) : QWizard(parent, GUIUtil::dialog_flags),
-                                                                                                                                                     ui(new Ui::CreateWalletWizard),
-                                                                                                                                                     m_ssMnemonic_out(ssMnemonic_out),
-                                                                                                                                                     m_ssMnemonicPassphrase_out(ssMnemonicPassphrase_out),
-                                                                                                                                                     m_wallettype_out(walletType_out)
+CreateWalletWizard::CreateWalletWizard(QWidget* parent, SecureString* ssMnemonic_out, SecureString* ssMnemonicPassphrase_out, SecureString* ssMasterKey_out, int* walletType_out) : QWizard(parent, GUIUtil::dialog_flags),
+                                                                                                                                                                                    ui(new Ui::CreateWalletWizard),
+                                                                                                                                                                                    m_ssMnemonic_out(ssMnemonic_out),
+                                                                                                                                                                                    m_ssMnemonicPassphrase_out(ssMnemonicPassphrase_out),
+                                                                                                                                                                                    m_ssMasterKey_out(ssMasterKey_out),
+                                                                                                                                                                                    m_wallettype_out(walletType_out)
 {
     ui->setupUi(this);
 
@@ -115,10 +116,12 @@ void CreateWalletWizard::accept()
 {
     SecureString ssMnemonic;
     SecureString ssMnemonicPassphrase;
+    SecureString ssMasterKey;
     int wallettype;
 
     ssMnemonic.reserve(MAX_PASSPHRASE_SIZE);
     ssMnemonicPassphrase.reserve(MAX_PASSPHRASE_SIZE);
+    ssMasterKey.reserve(MAX_PASSPHRASE_SIZE);
 
     if (!this->field("generateWords.seed").toString().isEmpty()) {
         ssMnemonic.assign(this->field("generateWords.seed").toString().toStdString().c_str());
@@ -128,8 +131,13 @@ void CreateWalletWizard::accept()
         ssMnemonicPassphrase.assign(this->field("enter.pass").toString().toStdString().c_str());
     }
 
+    if (!this->field("importmaster.key").toString().isEmpty()) {
+	ssMasterKey.assign(this->field("importmaster.key").toString().toStdString().c_str());
+    }
+
     m_ssMnemonic_out->assign(ssMnemonic);
     m_ssMnemonicPassphrase_out->assign(ssMnemonicPassphrase);
+    m_ssMasterKey_out->assign(ssMasterKey);
 
     wallettype = this->field("type.wallet").toInt();
     m_wallettype_out = &wallettype;
@@ -497,6 +505,8 @@ wizPage_walletMasterKey::wizPage_walletMasterKey(QWidget* parent)
     verticalLayout->addItem(verticalSpacer);
 
     setLayout(verticalLayout);
+
+    registerField("importmaster.key", textEdit_importMasterKey, "plainText");
 }
 
 int wizPage_walletMasterKey::nextId() const

--- a/src/qt/createwalletwizard.cpp
+++ b/src/qt/createwalletwizard.cpp
@@ -508,7 +508,7 @@ wizPage_walletMasterKey::wizPage_walletMasterKey(QWidget* parent)
     this->setSubTitle(tr("Please enter your masterkey in order to restore your wallet."));
     verticalLayout = new QVBoxLayout();
 
-    label_12 = new QLabel(tr("To create a watching-only wallet, please enter your master public key (xpub/ypub/zpub). To create a spending wallet, please enter a master private key (xprv/yprv/zprv)."));
+    label_12 = new QLabel(tr("The WIF private key to use as the new HD seed.\nThe seed value can be retrieved using the dumpwallet command or gethdwalletinfo.\nIt is the private key marked hdseed=1."));
     label_12->setWordWrap(true);
 
     verticalLayout->addWidget(label_12);

--- a/src/qt/createwalletwizard.h
+++ b/src/qt/createwalletwizard.h
@@ -137,6 +137,7 @@ class wizPage_walletKeystore : public QWizardPage
 public:
     wizPage_walletKeystore(QWidget* parent = nullptr);
 
+    void initializePage() override;
     int nextId() const override;
 
 private:

--- a/src/qt/createwalletwizard.h
+++ b/src/qt/createwalletwizard.h
@@ -47,7 +47,7 @@ public:
            Page5_confirmSeed,
            Page7_enterSeed,
            Page8_finish };
-    explicit CreateWalletWizard(QWidget* parent, SecureString* m_ssMnemonic_out = nullptr, SecureString* m_ssMnemonicPassphrase_out = nullptr, int* m_wallettype_out = nullptr);
+    explicit CreateWalletWizard(QWidget* parent, SecureString* m_ssMnemonic_out = nullptr, SecureString* m_ssMnemonicPassphrase_out = nullptr, SecureString* m_ssMasterKey_out = nullptr, int* m_wallettype_out = nullptr);
     virtual ~CreateWalletWizard();
 
     void accept() override;
@@ -68,6 +68,7 @@ private:
     bool m_has_signers = false;
     SecureString* m_ssMnemonic_out;
     SecureString* m_ssMnemonicPassphrase_out;
+    SecureString* m_ssMasterKey_out;
     int* m_wallettype_out;
 };
 

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -270,7 +270,7 @@ void CreateWalletActivity::createWallet()
     }
 
     QTimer::singleShot(500, worker(), [this, name, flags] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_ssMnemonic, m_ssMnemonicPassphrase, m_passphrase, m_walletType, flags, m_error_message, m_warning_message);
+        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_ssMnemonic, m_ssMnemonicPassphrase, m_ssMasterKey, m_passphrase, m_walletType, flags, m_error_message, m_warning_message);
 
         if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
 
@@ -372,7 +372,7 @@ void CreateWalletWizardActivity::createWallet()
     }
 
     QTimer::singleShot(500, worker(), [this, name, flags] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_ssMnemonic, m_ssMnemonicPassphrase, m_passphrase, m_walletType, flags, m_error_message, m_warning_message);
+        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_ssMnemonic, m_ssMnemonicPassphrase, m_ssMasterKey, m_passphrase, m_walletType, flags, m_error_message, m_warning_message);
 
         if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
 
@@ -397,7 +397,7 @@ void CreateWalletWizardActivity::finish()
 
 void CreateWalletWizardActivity::create()
 {
-    m_create_wallet_wizard = new CreateWalletWizard(m_parent_widget, &m_ssMnemonic, &m_ssMnemonicPassphrase, &m_walletType);
+    m_create_wallet_wizard = new CreateWalletWizard(m_parent_widget, &m_ssMnemonic, &m_ssMnemonicPassphrase, &m_ssMasterKey, &m_walletType);
 
     std::vector<ExternalSigner> signers;
     try {

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -134,6 +134,7 @@ private:
     SecureString m_passphrase;
     SecureString m_ssMnemonic;
     SecureString m_ssMnemonicPassphrase;
+    SecureString m_ssMasterKey;
     CreateWalletDialog* m_create_wallet_dialog{nullptr};
     AskPassphraseDialog* m_passphrase_dialog{nullptr};
 };
@@ -160,6 +161,7 @@ private:
     SecureString m_passphrase;
     SecureString m_ssMnemonic;
     SecureString m_ssMnemonicPassphrase;
+    SecureString m_ssMasterKey;
     CreateWalletWizard* m_create_wallet_wizard{nullptr};
     AskPassphraseDialog* m_passphrase_dialog{nullptr};
 };

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -221,6 +221,7 @@ struct WalletOptions {
     int bits;
     SecureString ssMnemonic;
     SecureString ssMnemonicPassphrase;
+    SecureString ssMasterKey;
 };
 
 enum class DatabaseStatus {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -539,7 +539,7 @@ public:
     void setMockTime(int64_t time) override { return SetMockTime(time); }
 
     //! WalletClient methods
-    std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, const SecureString& passphrase, const int& walletType, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) override
+    std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, const SecureString& ssMasterKey, const SecureString& passphrase, const int& walletType, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) override
     {
         std::shared_ptr<CWallet> wallet;
         DatabaseOptions options;
@@ -550,6 +550,7 @@ public:
         options.create_passphrase = passphrase;
         walletOptions.ssMnemonic = ssMnemonic;
         walletOptions.ssMnemonicPassphrase = ssMnemonicPassphrase;
+        walletOptions.ssMasterKey = ssMasterKey;
         walletOptions.walletType = walletType;
         return MakeWallet(CreateWallet(*m_context.chain, name, true /* load_on_start */, options, walletOptions, status, error, warnings));
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -429,7 +429,7 @@ bool LegacyScriptPubKeyMan::SetupGeneration(const WalletOptions& walletoptions, 
 
     switch (walletoptions.walletType) {
     case walletType::bip32Wallet: {
-        SetHDSeed(GenerateNewSeed());
+        SetHDSeed(GenerateNewSeed(walletoptions));
         break;
     }
     default:
@@ -1201,6 +1201,26 @@ CPubKey LegacyScriptPubKeyMan::GenerateNewSeed()
     assert(!m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
     CKey key;
     key.MakeNewKey(true);
+    return DeriveNewSeed(key);
+}
+
+CPubKey LegacyScriptPubKeyMan::GenerateNewSeed(const WalletOptions& walletoptions)
+{
+    assert(!m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
+
+    const SecureString& masterkey = walletoptions.ssMasterKey;
+    CKey key;
+
+    if (!masterkey.empty()) {
+        key = DecodeSecret(masterkey.c_str());
+        if (!key.IsValid()) {
+            throw std::runtime_error(std::string(__func__) + ": Invalid private key");
+        }
+    } else {
+        key.MakeNewKey(true);
+    }
+
+
     return DeriveNewSeed(key);
 }
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -473,6 +473,9 @@ public:
     /* Generates a new HD seed (will not be activated) */
     CPubKey GenerateNewSeed();
 
+    /* Generates a new HD seed (will not be activated) */
+    CPubKey GenerateNewSeed(const WalletOptions& walletoptions);
+
     /* Generates a new bip39 HD seed (will not be activated) */
     CPubKey GenerateNewBip39Seed(const WalletOptions& walletoptions);
 


### PR DESCRIPTION
This pull request further improves the Create/ Import wallet wizard.
It allows the importation of masterket (WIF) hdseed from bip32 wallets.
Refining the display of page and options to display in the wizard for bip32, bip44, bip39


It also removes the standard 'Create Wallet...' from the menu and replaces it with 'Create/ Import wallet'.
Connect in the wizard to the create wallet button when no wallets are loaded.