### PR TITLE
Multiwallet staking

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,9 +1,9 @@
-4.22.5rc1 Release Notes
+4.22.5rc2 Release Notes
 ==================
 
-Reddcoin Core version 4.22.5rc1 is now available from:
+Reddcoin Core version 4.22.5rc2 is now available from:
 
-  <https://download.reddcoin.com/bin/reddcoin-core-4.22.5/rc1/>
+  <https://download.reddcoin.com/bin/reddcoin-core-4.22.5/rc2/>
 
 This release includes new features, various bug fixes and performance
 improvements, as well as updated translations.
@@ -65,9 +65,12 @@ P2P and network changes
 New and Updated RPCs
 --------------------
 
-- New `checkupdates` RPC will return an object with the currently installed version and the latest available remote version from githubs.
+- New `setstaking` RPC will return the current staking state for all loaded wallets. Setting a boolean value (true|false) will 
+  enable/ disable staking for the selected wallet according. Additionally the state for the selected wallet can be stored to load during startup (settings.json).  
 
-- New `staking` RPC will return the current staking state. Setting a boolean value (true|false) will enable/ disable staking accordingly.
+- Updated `checkupdates` RPC will return an object with the currently installed version and the latest available remote version from github.
+
+- Updated `staking` RPC will return the current staking state. Setting a boolean value (true|false) will enable/ disable staking accordingly.
 
 - New `gethdwalletinfo` RPC returns an object containing the following fields, `hdseed`, `mnemonic`,
   `mnemonicpassphrase`, `rootprivkey`, `extendedprivkey`, `extendedpubkey` if hdseed is available.
@@ -167,6 +170,7 @@ Files
 New settings
 ------------
 
+- The `-stake` option has been added to load wallets for staking. The option can be called multiple times to load more than 1 wallet.
 - The `-checkupdates` option has been added to detect if a newer version is available to download.
 
 - The `-natpmp` option has been added to use NAT-PMP to map the listening port.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1815,7 +1815,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     StartupNotify(args);
 #endif
 
-    MintStake(node.chainman.get(), &node.chainman->ActiveChainstate(), node.connman.get(), node.mempool.get());
+    MintStake(node.chainman.get(), node.connman.get(), node.mempool.get());
 
     return true;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1815,6 +1815,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     StartupNotify(args);
 #endif
 
+    InitStakeWallet();
     MintStake(node.chainman.get(), node.connman.get(), node.mempool.get());
 
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1815,9 +1815,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     StartupNotify(args);
 #endif
 
-    if (HasWallets() && GetWallets()[0]) {
-        MintStake(gArgs.GetBoolArg("-staking", true), GetWallets()[0], node.chainman.get(), &node.chainman->ActiveChainstate(), node.connman.get(), node.mempool.get());
-    }
+    MintStake(node.chainman.get(), &node.chainman->ActiveChainstate(), node.connman.get(), node.mempool.get());
 
     return true;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -787,6 +787,11 @@ void MintStake(ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempo
 
     int thread_id = 0;
 
+    if (GetStakingThreadCount() > 0) {
+        InterruptStaking();
+        StopStaking();
+    }
+
     fEnableStaking = true;
     std::vector<std::shared_ptr<CWallet>> m_stake_wallets = GetWallets();
     for (const auto &wallet : m_stake_wallets) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -534,7 +534,7 @@ static bool ProcessBlockFound(const CBlock* pblock, ChainstateManager* chainman,
 void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, int thread_id)
 {
     LogPrintf("CPUMiner [%d] started for proof-of-stake wallet [%s]\n", thread_id, pwallet->GetName());
-    util::ThreadRename(strprintf("reddcoin-stake-minter-%d", thread_id));
+    util::ThreadRename(strprintf("staker-%d", thread_id));
 
     unsigned int nExtraNonce = 0;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -759,8 +759,10 @@ void MintStake(ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempo
              continue;
          }
 
-         threadStakeMinterGroup.push_back(std::thread(&ThreadStakeMinter, std::move(wallet.get()), std::move(chainman), std::move(connman), std::move(mempool), std::move(thread_id)));
-         thread_id++;
+         if (wallet->GetEnableStaking()) {
+             threadStakeMinterGroup.push_back(std::thread(&ThreadStakeMinter, std::move(wallet.get()), std::move(chainman), std::move(connman), std::move(mempool), std::move(thread_id)));
+             thread_id++;
+         }
     }
 
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -721,6 +721,41 @@ static void UpdateStakeSetting(interfaces::Chain& chain,
     }
 }
 
+void InitStakeWallet()
+{
+    try {
+        std::set<fs::path> wallet_paths;
+        for (const std::string& wallet_name : gArgs.GetArgs("-stake")) {
+            if (!wallet_paths.insert(wallet_name).second) {
+                continue;
+            }
+
+            std::shared_ptr<CWallet> pwallet = GetWallet(wallet_name);
+            if (!pwallet) {
+                return;
+            }
+
+            LogPrintf("[%s] Init for staking\n", wallet_name);
+
+            if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+                LogPrintf("[%s] error: Disable private keys flag set.\n", wallet_name);
+                continue;
+            } else if (pwallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
+                LogPrintf("[%s] error: Blank wallet flag set.\n", wallet_name);
+                continue;
+            } else {
+                pwallet->SetEnableStaking(true);
+            }
+        }
+
+        return;
+    } catch (const std::runtime_error& e) {
+        LogPrintf("%s\n", e.what());
+
+        return;
+    }
+}
+
 void StakeWallet(interfaces::Chain& chain, const std::string& name, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings)
 {
     UpdateStakeSetting(chain, name, load_on_start, warnings);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -807,6 +807,11 @@ void MintStake(ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempo
 
 }
 
+int GetStakingThreadCount()
+{
+    return threadStakeMinterGroup.size();
+}
+
 void InterruptStaking()
 {
     LogPrintf("Interrupting ThreadStakeMinter threads\n");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -721,6 +721,11 @@ static void UpdateStakeSetting(interfaces::Chain& chain,
     }
 }
 
+void StakeWallet(interfaces::Chain& chain, const std::string& name, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings)
+{
+    UpdateStakeSetting(chain, name, load_on_start, warnings);
+}
+
 // reddcoin: stake minter thread
 void static ThreadStakeMinter(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, int thread_id)
 {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -754,6 +754,9 @@ void MintStake(ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempo
          if (wallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
              LogPrintf("Disable private keys flag set.. skipping [%s]\n", wallet->GetName());
              continue;
+         } else if (wallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
+             LogPrintf("Blank wallet flag set.. skipping [%s]\n", wallet->GetName());
+             continue;
          }
 
          threadStakeMinterGroup.push_back(std::thread(&ThreadStakeMinter, std::move(wallet.get()), std::move(chainman), std::move(connman), std::move(mempool), std::move(thread_id)));

--- a/src/miner.h
+++ b/src/miner.h
@@ -211,8 +211,10 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
+void InitStakeWallet();
 void MintStake(ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool);
 void StakeWallet(interfaces::Chain& chain, const std::string& name, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings);
+
 
 /** Returns true if a staking is enabled, false otherwise. */
 bool EnableStaking();

--- a/src/miner.h
+++ b/src/miner.h
@@ -211,7 +211,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
-void MintStake(ChainstateManager* chainman, CChainState* chainstate, CConnman* connman, CTxMemPool* mempool);
+void MintStake(ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool);
 /** Returns true if a staking is enabled, false otherwise. */
 bool EnableStaking();
 void InterruptStaking();

--- a/src/miner.h
+++ b/src/miner.h
@@ -212,6 +212,8 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
 void MintStake(ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool);
+void StakeWallet(interfaces::Chain& chain, const std::string& name, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings);
+
 /** Returns true if a staking is enabled, false otherwise. */
 bool EnableStaking();
 void InterruptStaking();

--- a/src/miner.h
+++ b/src/miner.h
@@ -213,6 +213,7 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
 void InitStakeWallet();
 void MintStake(ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool);
+int GetStakingThreadCount();
 void StakeWallet(interfaces::Chain& chain, const std::string& name, std::optional<bool> load_on_start, std::vector<bilingual_str>& warnings);
 
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -211,7 +211,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
-void MintStake(bool fGenerate, std::shared_ptr<CWallet> pwallet, ChainstateManager* chainman, CChainState* chainstate, CConnman* connman, CTxMemPool* mempool);
+void MintStake(ChainstateManager* chainman, CChainState* chainstate, CConnman* connman, CTxMemPool* mempool);
 /** Returns true if a staking is enabled, false otherwise. */
 bool EnableStaking();
 void InterruptStaking();

--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -135,7 +135,7 @@ bool GetStakeWeight(const CWallet* pwallet, uint64_t& nAverageWeight, uint64_t &
   return true;
 }
 
-// peercoin: create coin stake transaction
+// Reddcoin: create coin stake transaction
 typedef std::vector<unsigned char> valtype;
 bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams)
 {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -192,8 +192,9 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnodeaddresses", 0, "count"},
     { "addpeeraddress", 1, "port"},
     { "stop", 0, "wait" },
-    { "staking", 0, "generate" },
-    { "staking", 1, "load_on_startup" },
+    { "staking", 0, "enable" },
+    { "setstaking", 0, "enable" },
+    { "setstaking", 1, "load_on_startup" },
     { "getinterest", 0, "start" },
     { "getinterest", 1, "end" },
 };

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -192,9 +192,10 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getnodeaddresses", 0, "count"},
     { "addpeeraddress", 1, "port"},
     { "stop", 0, "wait" },
-	{ "staking", 0, "generate" },
-	{ "getinterest", 0, "start" },
-	{ "getinterest", 1, "end" },
+    { "staking", 0, "generate" },
+    { "staking", 1, "load_on_startup" },
+    { "getinterest", 0, "start" },
+    { "getinterest", 1, "end" },
 };
 // clang-format on
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -329,8 +329,6 @@ static RPCHelpMan staking()
             "When called with an argument, enables or disables staking.\n",
             {
                 {"enabled", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "To enable or disable staking."},
-                {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Save wallet name to persistent settings and load on startup. True to add wallet to staking list, false to remove, null to leave unchanged."},
-
             },
             RPCResult{
                 RPCResult::Type::OBJ, "", "",
@@ -352,23 +350,7 @@ static RPCHelpMan staking()
             },
             [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
-    if (!wallet) return NullUniValue;
-    CWallet* const pwallet = wallet.get();
-
     UniValue result(UniValue::VOBJ);
-
-    UniValue msg(UniValue::VOBJ);
-    if (request.params[0].isBool()) {
-        if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
-            msg.pushKV("error", "Disable private keys flag set.");
-        } else if (pwallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
-            msg.pushKV("error", "Blank wallet flag set.");
-        } else {
-            pwallet->SetEnableStaking(request.params[0].getBool());
-        }
-    }
-
     UniValue staking(UniValue::VARR);
 
     std::vector<std::shared_ptr<CWallet>> m_stake_wallets = GetWallets();
@@ -395,7 +377,6 @@ static RPCHelpMan staking()
 
     result.pushKV("enabled", gArgs.GetBoolArg("-staking",true));
     result.pushKV("enabled_wallet", staking);
-    result.pushKV("result", msg);
     return result;
 },
     };

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -280,7 +280,7 @@ static RPCHelpMan staking()
         gArgs.ForceSetArg("-staking", fGenerate ? "1" : "0");
 
         if (HasWallets() && GetWallets().size() > 0) {
-            MintStake(node.chainman.get(), &node.chainman->ActiveChainstate(), node.connman.get(), node.mempool.get());
+            MintStake(node.chainman.get(), node.connman.get(), node.mempool.get());
 
             if (!fGenerate) {
                 InterruptStaking();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -376,6 +376,7 @@ static RPCHelpMan staking()
     }
 
     result.pushKV("enabled", gArgs.GetBoolArg("-staking",true));
+    result.pushKV("running", GetStakingThreadCount() > 0 ? true : false);
     result.pushKV("enabled_wallet", staking);
     return result;
 },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -336,6 +336,14 @@ static RPCHelpMan staking()
                 RPCResult::Type::OBJ, "", "",
                 {
                     {RPCResult::Type::BOOL, "enabled", "if staking is active or not. false:inactive, true:active"},
+                    {RPCResult::Type::ARR, "enabled_wallet", "",
+                        {
+                            {RPCResult::Type::OBJ, "", "",
+                            {
+                                {RPCResult::Type::BOOL, "wallet_name", "If staking is enabled for wallet or not. false:inactive, true:active"},
+                            }},
+                        }
+                    },
                 }
             },
             RPCExamples{

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -278,8 +278,8 @@ static RPCHelpMan staking()
         NodeContext& node = EnsureAnyNodeContext(request.context);
         gArgs.ForceSetArg("-staking", fGenerate ? "1" : "0");
 
-        if (HasWallets() && GetWallets()[0]) {
-            MintStake(gArgs.GetBoolArg("-staking", true), GetWallets()[0], node.chainman.get(), &node.chainman->ActiveChainstate(), node.connman.get(), node.mempool.get());
+        if (HasWallets() && GetWallets().size() > 0) {
+            MintStake(node.chainman.get(), &node.chainman->ActiveChainstate(), node.connman.get(), node.mempool.get());
 
             if (!fGenerate) {
                 InterruptStaking();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -248,6 +248,78 @@ static RPCHelpMan generatetodescriptor()
     };
 }
 
+static RPCHelpMan setstaking()
+{
+    return RPCHelpMan{
+        "setstaking",
+        "Gets or sets the current staking configuration.\n"
+        "When called without an argument, returns the current status of staking for all loaded wallets.\n"
+        "When called with an argument, enables or disables staking for the currently selected wallet.\n",
+        {
+            {"enabled", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "To enable or disable staking."},
+            {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Save wallet name to persistent settings and load on startup. True to add wallet to staking list, false to remove, null to leave unchanged."},
+
+        },
+        {
+            RPCResult{"for enabled = null",
+                      RPCResult::Type::ARR,
+                      "",
+                      "",
+                      {
+                          {RPCResult::Type::OBJ, "", "", {
+                                                             {RPCResult::Type::BOOL, "wallet_name", "If staking is enabled for wallet or not. false:inactive, true:active"},
+                                                         }},
+                      }},
+            RPCResult{"for enabled = true|false", RPCResult::Type::OBJ, "", "", {
+                                                                                    {RPCResult::Type::BOOL, "enabled", "If staking is enabled for wallet or not. false:inactive, true:active"},
+                                                                                    {RPCResult::Type::STR, "error", "Error Message"},
+                                                                                    {RPCResult::Type::STR, "warning", "Warning Message"},
+                                                                                }},
+        },
+        RPCExamples{HelpExampleCli("staking", "\"[\\\"all\\\"]\" \"[\\\"http\\\"]\"") + HelpExampleRpc("staking", "[\"all\"], [\"libevent\"]")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+            if (!wallet) return NullUniValue;
+            CWallet* const pwallet = wallet.get();
+
+            if (request.params[0].isNull()) {
+                UniValue result(UniValue::VARR);
+
+                std::vector<std::shared_ptr<CWallet>> m_stake_wallets = GetWallets();
+                for (const auto& wallet : m_stake_wallets) {
+                    UniValue entry(UniValue::VOBJ);
+                    entry.pushKV(wallet->GetName(), wallet->GetEnableStaking());
+                    result.push_back(entry);
+                }
+                return result;
+            }
+
+            UniValue result(UniValue::VOBJ);
+            std::vector<bilingual_str> warnings;
+
+            if (!request.params[0].isNull()) {
+                if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+                    result.pushKV("error", "Disable private keys flag set.");
+                } else if (pwallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
+                    result.pushKV("error", "Blank wallet flag set.");
+                } else {
+                    pwallet->SetEnableStaking(request.params[0].getBool());
+                    if (!request.params[1].isNull()) {
+                        interfaces::Chain& chain = pwallet->chain();
+                        std::string name = pwallet->GetName();
+                        std::optional<bool> load_on_start = request.params[1].isNull() ? std::nullopt : std::optional<bool>(request.params[1].get_bool());
+
+                        StakeWallet(chain, name, load_on_start, warnings);
+                    }
+                }
+            }
+
+            result.pushKV("enabled", wallet->GetEnableStaking());
+            result.pushKV("warning", Join(warnings, Untranslated("\n")).original);
+            return result;
+        },
+    };
+}
 
 static RPCHelpMan staking()
 {
@@ -256,14 +328,14 @@ static RPCHelpMan staking()
             "When called without an argument, returns the current status of staking.\n"
             "When called with an argument, enables or disables staking.\n",
             {
-                {"generate", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "To enable or disable staking."},
+                {"enabled", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "To enable or disable staking."},
                 {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Save wallet name to persistent settings and load on startup. True to add wallet to staking list, false to remove, null to leave unchanged."},
 
             },
             RPCResult{
                 RPCResult::Type::OBJ, "", "",
                 {
-                    {RPCResult::Type::BOOL, "staking", "if staking is active or not. false:inactive, true:active"},
+                    {RPCResult::Type::BOOL, "enabled", "if staking is active or not. false:inactive, true:active"},
                 }
             },
             RPCExamples{
@@ -313,7 +385,7 @@ static RPCHelpMan staking()
         }
     }
 
-    result.pushKV("generate", gArgs.GetBoolArg("-staking",true));
+    result.pushKV("enabled", gArgs.GetBoolArg("-staking",true));
     result.pushKV("enabled_wallet", staking);
     result.pushKV("result", msg);
     return result;
@@ -1421,6 +1493,7 @@ static const CRPCCommand commands[] =
     { "generating",          &generatetodescriptor,    },
     { "generating",          &generateblock,           },
     { "generating",          &staking,                 },
+    { "generating",          &setstaking,              },
 
     { "util",                &estimatesmartfee,        },
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -257,6 +257,7 @@ static RPCHelpMan staking()
             "When called with an argument, enables or disables staking.\n",
             {
                 {"generate", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "To enable or disable staking."},
+                {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Save wallet name to persistent settings and load on startup. True to add wallet to staking list, false to remove, null to leave unchanged."},
 
             },
             RPCResult{

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -72,6 +72,7 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
 #endif
     argsman.AddArg("-spendzeroconfchange", strprintf("Spend unconfirmed change when sending transactions (default: %u)", DEFAULT_SPEND_ZEROCONF_CHANGE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-checkupdates", strprintf("Check github for newer version (default: %u)", DEFAULT_CHECK_GITHUB), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    argsman.AddArg("-stake=<path>", "Specify wallet name to stake at startup. Can be used multiple times to load multiple wallets. Path is to a directory containing wallet data and log files. If the path is not absolute, it is interpreted relative to <walletdir>. This only loads existing wallets.", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::WALLET);
     argsman.AddArg("-staking", strprintf("Enable staking (default: %u)", DEFAULT_ENABLE_STAKING), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-staketimio=<n>", strprintf("Proof of stake timeout. (default: %u)", DEFAULT_STAKETIMIO), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     argsman.AddArg("-txconfirmtarget=<n>", strprintf("If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)", DEFAULT_TX_CONFIRM_TARGET), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
@@ -113,6 +114,10 @@ bool WalletInit::ParameterInteraction() const
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         for (const std::string& wallet : gArgs.GetArgs("-wallet")) {
             LogPrintf("%s: parameter interaction: -disablewallet -> ignoring -wallet=%s\n", __func__, wallet);
+        }
+
+        for (const std::string& wallet : gArgs.GetArgs("-stake")) {
+            LogPrintf("%s: parameter interaction: -disablewallet -> ignoring -stake=%s\n", __func__, wallet);
         }
 
         return true;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -263,6 +263,10 @@ private:
      * serves to disable the trivial sendmoney when OS account compromised
      * provides no real security */
     bool fWalletUnlockStakingOnly = false;
+    /** optional setting to enable wallet for staking
+     * serves to disable the trivial sendmoney when OS account compromised
+     * provides no real security */
+    bool fEnableStaking = false;
     /**
      * Used to keep track of spent outpoints, and
      * detect and report conflicts (double-spends or
@@ -788,6 +792,11 @@ public:
     bool GetIsStakingOnly() const { return fWalletUnlockStakingOnly; }
     /** Set whether this wallet unlocked for staking only. */
     void SetIsStakingOnly(bool stakingOnly) { fWalletUnlockStakingOnly = stakingOnly; }
+
+    /** Inquire whether this wallet unlocked for staking only. */
+    bool GetEnableStaking() const { return fEnableStaking; }
+    /** Set whether this wallet unlocked for staking only. */
+    void SetEnableStaking(bool enableStaking) { fEnableStaking = enableStaking; }
 
     /** Return whether transaction can be abandoned */
     bool TransactionCanBeAbandoned(const uint256& hashTx) const;


### PR DESCRIPTION
This PR will allow the staking of multiple open wallets.

The core wallet allows the opening and various activities for multiple wallets.
The following commits allow a user to select which wallets can be set to staking.

- Separate thread for each wallet.
- Checks if wallet type can stake (blank, and disable priv keys cannot stake by virtue)
- Enable set staking on wallet start-up
- additional logging to track thread and wallet_name)
- RPC calls (setstaking, and staking) to manage staking configuration
