### PR TITLE
Complier backports

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -22,6 +22,9 @@
 #endif
 
 #include <algorithm>
+#include <limits>
+#include <stdexcept>
+#include <utility>
 #ifdef ARENA_DEBUG
 #include <iomanip>
 #include <iostream>

--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_SUPPORT_LOCKEDPOOL_H
 #define BITCOIN_SUPPORT_LOCKEDPOOL_H
 
-#include <stdint.h>
+#include <cstddef>
 #include <list>
 #include <map>
-#include <mutex>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 /**

--- a/src/util/bip32.h
+++ b/src/util/bip32.h
@@ -6,6 +6,7 @@
 #define BITCOIN_UTIL_BIP32_H
 
 #include <attributes.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <locale>
 #include <sstream>


### PR DESCRIPTION
74f1b704a1bedb2a003805121e7ef4814d36946e 23.x Add missing includes to fix gcc-13 compile error (fanquake)
d333114eff5a1a3b44b0737b5259451653965a96 Add missing includes to fix gcc-13 compile error (MarcoFalke)

addresses issue #224