### PR TITLE
Disable blockchain prune mode if -txindex is enabled

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -859,9 +859,9 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     // if using block pruning, then disallow txindex and coinstatsindex
     if (args.GetArg("-prune", 0)) {
         if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX))
-            return InitError(_("Prune mode is incompatible with -txindex."));
+            return InitError(_("Prune mode is incompatible with Reddcoin and -txindex."));
         if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX))
-            return InitError(_("Prune mode is incompatible with -coinstatsindex."));
+            return InitError(_("Prune mode is incompatible with Reddcoin and -coinstatsindex."));
     }
 
     // -bind and -whitebind can't be set when not listening

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -143,9 +143,15 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
 
     const int min_prune_target_GB = std::ceil(MIN_DISK_SPACE_FOR_BLOCK_FILES / 1e9);
     ui->pruneGB->setRange(min_prune_target_GB, std::numeric_limits<int>::max());
-    if (gArgs.GetArg("-prune", 0) > 1) { // -prune=1 means enabled, above that it's a size in MiB
-        ui->prune->setChecked(true);
+    if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX) || gArgs.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
+        ui->prune->setChecked(false);
         ui->prune->setEnabled(false);
+        ui->prune->setToolTip(tr("Blockchain pruning is not compatible with Reddcoin"));
+    } else {
+        if (gArgs.GetArg("-prune", 0) > 1) { // -prune=1 means enabled, above that it's a size in MiB
+            ui->prune->setChecked(true);
+            ui->prune->setEnabled(false);
+        }
     }
     ui->pruneGB->setValue(m_prune_target_gb);
     ui->pruneGB->setToolTip(ui->prune->toolTip());

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -136,7 +136,7 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
     ui->lblExplanation1->setText(ui->lblExplanation1->text()
         .arg(PACKAGE_NAME)
         .arg(m_blockchain_size_gb)
-        .arg(2009)
+        .arg(2014)
         .arg(tr("Reddcoin"))
     );
     ui->lblExplanation2->setText(ui->lblExplanation2->text().arg(PACKAGE_NAME));

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -44,6 +44,11 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->threadsScriptVerif->setMaximum(MAX_SCRIPTCHECK_THREADS);
     ui->pruneWarning->setVisible(false);
     ui->pruneWarning->setStyleSheet("QLabel { color: red; }");
+    if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX) || gArgs.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
+        ui->prune->setChecked(false);
+        ui->prune->setEnabled(false);
+        ui->prune->setToolTip(tr("Blockchain pruning is not compatible with Reddcoin"));
+    }
 
     ui->pruneSize->setEnabled(false);
     connect(ui->prune, &QPushButton::toggled, ui->pruneSize, &QWidget::setEnabled);


### PR DESCRIPTION
-prune mode is not compatible with -txindex or -coinstatsindex

As Reddcoin uses txindex by default, prune mode should be disabled
This PR:
* disables the option to prune during the display of the QT intro screen  
* disables the settings option 
* provides more descriptive error message

addresses issue #223 