### PR TITLE
staking: reset the lastcoinstakesearchinterval when staking is stopped

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -787,6 +787,7 @@ void static ThreadStakeMinter(CWallet* pwallet, ChainstateManager* chainman, CCo
     } catch (...) {
         PrintExceptionContinue(NULL, "ThreadStakeMinter()");
     }
+    pwallet->SetLastCoinStakeSearchInterval(0);
     LogPrintf("Staking thread [%s] stopped\n", thread_id);
     uiInterface.NotifyStakingActiveChanged(false);
 }


### PR DESCRIPTION
lastcoinstakesearchinterval is stored per wallet.
reset when staking has been stopped