### PR TITLE
qt: functions override a member function but is not marked 'override'

### DIFF
--- a/src/qt/mintingtablemodel.h
+++ b/src/qt/mintingtablemodel.h
@@ -37,11 +37,11 @@ public:
 
 
     void setMintingProxyModel(MintingFilterProxy *mintingProxy);
-    int rowCount(const QModelIndex &parent) const;
-    int columnCount(const QModelIndex &parent) const;
-    QVariant data(const QModelIndex &index, int role) const;
-    QVariant headerData(int section, Qt::Orientation orientation, int role) const;
-    QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
+    int rowCount(const QModelIndex &parent) const override;
+    int columnCount(const QModelIndex &parent) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const override;
 
     void setMintingInterval(int interval);
 


### PR DESCRIPTION
fix a number of overrides a member function but is not marked 'override'
