### PR TITLE
rpc: add rpc commands getinflation and getinflationmultipier

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -434,6 +434,76 @@ static RPCHelpMan getdifficulty()
     };
 }
 
+static RPCHelpMan getinflation()
+{
+    return RPCHelpMan{
+        "getinflation",
+        "\nReturns details on the current inflation.\n",
+        {
+            {"height", RPCArg::Type::NUM, RPCArg::Default{0}, "Block height (default=current block tip)."},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "", {
+                                              {RPCResult::Type::NUM, "height", "Block height"},
+                                              {RPCResult::Type::NUM, "inflation", "Current inflation"},
+                                          }},
+        RPCExamples{HelpExampleCli("getinflation", "") + HelpExampleRpc("getinflation", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            ChainstateManager& chainman = EnsureAnyChainman(request.context);
+
+            int height;
+            LOCK(cs_main);
+
+            if (!request.params[1].isNull() && request.params[1].get_int() > 0) {
+                height = request.params[0].get_int();
+            } else {
+                height = chainman.ActiveChain().Height();
+            }
+
+            UniValue ret(UniValue::VOBJ);
+            ret.pushKV("height", chainman.ActiveChain().Height());
+            ret.pushKV("inflation", GetInflation(&chainman.ActiveChainstate(), Params().GetConsensus()));
+            return ret;
+        },
+    };
+}
+
+static RPCHelpMan getinflationmultiplier()
+{
+    return RPCHelpMan{
+        "getinflationmultiplier",
+        "\nReturns details on the current inflationmultiplier.\n",
+        {
+            {"height", RPCArg::Type::NUM, RPCArg::Default{0}, "Block height (default=current block tip)."},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "", {
+                                              {RPCResult::Type::NUM, "height", "Block height"},
+                                              {RPCResult::Type::NUM, "inflation", "Current inflation"},
+                                              {RPCResult::Type::NUM, "multiplier", "Current inflation multiplier"},
+                                          }},
+        RPCExamples{HelpExampleCli("getinflationmultiplier", "") + HelpExampleRpc("getinflationmultiplier", "")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            ChainstateManager& chainman = EnsureAnyChainman(request.context);
+
+            int height;
+            LOCK(cs_main);
+
+            if (!request.params[1].isNull() && request.params[1].get_int() > 0) {
+                height = request.params[0].get_int();
+            } else {
+                height = chainman.ActiveChain().Height();
+            }
+
+            UniValue ret(UniValue::VOBJ);
+            ret.pushKV("height", chainman.ActiveChain().Height());
+            ret.pushKV("inflation", GetInflation(&chainman.ActiveChainstate(), Params().GetConsensus()));
+            ret.pushKV("multiplier", GetInflationAdjustment(&chainman.ActiveChainstate(), Params().GetConsensus()));
+            return ret;
+        },
+    };
+}
+
 static std::vector<RPCResult> MempoolEntryDescription() { return {
     RPCResult{RPCResult::Type::NUM, "vsize", "virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted."},
     RPCResult{RPCResult::Type::NUM, "weight", "transaction weight as defined in BIP 141."},
@@ -2627,6 +2697,8 @@ static const CRPCCommand commands[] =
     { "blockchain",         &getblockheader,                     },
     { "blockchain",         &getchaintips,                       },
     { "blockchain",         &getdifficulty,                      },
+    { "blockchain",         &getinflation,                       },
+    { "blockchain",         &getinflationmultiplier,                       },
     { "blockchain",         &getmempoolancestors,                },
     { "blockchain",         &getmempooldescendants,              },
     { "blockchain",         &getmempoolentry,                    },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -197,6 +197,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setstaking", 1, "load_on_startup" },
     { "getinterest", 0, "start" },
     { "getinterest", 1, "end" },
+    { "getinflation", 0, "height" },
+    { "getinflationmultiplier", 0, "height" },
 };
 // clang-format on
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -1075,6 +1075,7 @@ CAmount GetProofOfWorkReward(unsigned int nBits);
 CAmount GetProofOfStakeReward(int64_t nCoinAge, const CAmount& nFees);
 CAmount GetProofOfStakeReward(int64_t nCoinAge, const CAmount& nFees, double fInflationAdjustment);
 double GetInflationAdjustment(CChainState* active_chainstate, const Consensus::Params& consensusParams);
+double GetInflation(CChainState* active_chainstate, const Consensus::Params& consensusParams);
 bool VerifyHashTarget(CChainState* active_chainstate, CBlockIndex* pindexPrev, const CBlock& block, uint256& hashProof);
 
 #endif // BITCOIN_VALIDATION_H


### PR DESCRIPTION
Add back in 2 RPC commands and supporting functions

* getinflation
* getinflationmultipier

missing from previous 3.10

closes #278 