### PR TITLE
Enable rescan of wallet when importing seed

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -339,7 +339,7 @@ class WalletClient : public ChainClient
 {
 public:
     //! Create new wallet.
-    virtual std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, const SecureString& ssMasterKey, const SecureString& passphrase, const int& walletType, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;
+    virtual std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, const SecureString& ssMasterKey, const SecureString& passphrase, const int& walletType, const bool& importing, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;
 
    //! Load existing wallet.
    virtual std::unique_ptr<Wallet> loadWallet(const std::string& name, bilingual_str& error, std::vector<bilingual_str>& warnings) = 0;

--- a/src/qt/createwalletwizard.cpp
+++ b/src/qt/createwalletwizard.cpp
@@ -34,12 +34,13 @@
 #include <QWizardPage>
 
 
-CreateWalletWizard::CreateWalletWizard(QWidget* parent, SecureString* ssMnemonic_out, SecureString* ssMnemonicPassphrase_out, SecureString* ssMasterKey_out, int* walletType_out) : QWizard(parent, GUIUtil::dialog_flags),
+CreateWalletWizard::CreateWalletWizard(QWidget* parent, SecureString* ssMnemonic_out, SecureString* ssMnemonicPassphrase_out, SecureString* ssMasterKey_out, int* walletType_out, bool* importing_out) : QWizard(parent, GUIUtil::dialog_flags),
                                                                                                                                                                                     ui(new Ui::CreateWalletWizard),
                                                                                                                                                                                     m_ssMnemonic_out(ssMnemonic_out),
                                                                                                                                                                                     m_ssMnemonicPassphrase_out(ssMnemonicPassphrase_out),
                                                                                                                                                                                     m_ssMasterKey_out(ssMasterKey_out),
-                                                                                                                                                                                    m_wallettype_out(walletType_out)
+                                                                                                                                                                                    m_wallettype_out(walletType_out),
+                                                                                                                                                                                    m_importing_out(importing_out)
 {
     ui->setupUi(this);
 
@@ -100,6 +101,11 @@ int CreateWalletWizard::getWalletType() const
     return this->field("type.wallet").toInt();
 }
 
+bool CreateWalletWizard::getImporting() const
+{
+    return this->field("importing").toBool();
+}
+
 void CreateWalletWizard::setSigners(const std::vector<ExternalSigner>& signers)
 {
     m_has_signers = !signers.empty();
@@ -118,6 +124,7 @@ void CreateWalletWizard::accept()
     SecureString ssMnemonicPassphrase;
     SecureString ssMasterKey;
     int wallettype;
+    bool importing;
 
     ssMnemonic.reserve(MAX_PASSPHRASE_SIZE);
     ssMnemonicPassphrase.reserve(MAX_PASSPHRASE_SIZE);
@@ -140,7 +147,9 @@ void CreateWalletWizard::accept()
     m_ssMasterKey_out->assign(ssMasterKey);
 
     wallettype = this->field("type.wallet").toInt();
+    importing = this->field("importing").toBool();
     m_wallettype_out = &wallettype;
+    m_importing_out = &importing;
 
     QDialog::accept();
 }
@@ -451,6 +460,11 @@ wizPage_walletKeystore::wizPage_walletKeystore(QWidget* parent)
     verticalSpacer_1 = new QSpacerItem(20, 96, QSizePolicy::Minimum, QSizePolicy::Expanding);
 
     verticalLayout->addItem(verticalSpacer_1);
+
+    registerField("importing", radioButton_importSeed);
+    connect(radioButton_importSeed, &QCheckBox::toggled, [this](bool checked) {
+        setField("importing", checked);
+    });
 
     setLayout(verticalLayout);
 }

--- a/src/qt/createwalletwizard.h
+++ b/src/qt/createwalletwizard.h
@@ -47,7 +47,7 @@ public:
            Page5_confirmSeed,
            Page7_enterSeed,
            Page8_finish };
-    explicit CreateWalletWizard(QWidget* parent, SecureString* m_ssMnemonic_out = nullptr, SecureString* m_ssMnemonicPassphrase_out = nullptr, SecureString* m_ssMasterKey_out = nullptr, int* m_wallettype_out = nullptr);
+    explicit CreateWalletWizard(QWidget* parent, SecureString* m_ssMnemonic_out = nullptr, SecureString* m_ssMnemonicPassphrase_out = nullptr, SecureString* m_ssMasterKey_out = nullptr, int* m_wallettype_out = nullptr, bool* m_importing_out = nullptr);
     virtual ~CreateWalletWizard();
 
     void accept() override;
@@ -62,6 +62,7 @@ public:
     bool isDescriptorWalletChecked() const;
     bool isExternalSignerChecked() const;
     int getWalletType() const;
+    bool getImporting() const;
 
 private:
     Ui::CreateWalletWizard* ui;
@@ -70,6 +71,7 @@ private:
     SecureString* m_ssMnemonicPassphrase_out;
     SecureString* m_ssMasterKey_out;
     int* m_wallettype_out;
+    bool* m_importing_out;
 };
 
 

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -271,7 +271,7 @@ void CreateWalletActivity::createWallet()
     }
 
     QTimer::singleShot(500, worker(), [this, name, flags] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_ssMnemonic, m_ssMnemonicPassphrase, m_ssMasterKey, m_passphrase, m_walletType, flags, m_error_message, m_warning_message);
+        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_ssMnemonic, m_ssMnemonicPassphrase, m_ssMasterKey, m_passphrase, m_walletType, m_importing, flags, m_error_message, m_warning_message);
 
         if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
 
@@ -373,7 +373,7 @@ void CreateWalletWizardActivity::createWallet()
     }
 
     QTimer::singleShot(500, worker(), [this, name, flags] {
-        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_ssMnemonic, m_ssMnemonicPassphrase, m_ssMasterKey, m_passphrase, m_walletType, flags, m_error_message, m_warning_message);
+        std::unique_ptr<interfaces::Wallet> wallet = node().walletClient().createWallet(name, m_ssMnemonic, m_ssMnemonicPassphrase, m_ssMasterKey, m_passphrase, m_walletType, m_importing, flags, m_error_message, m_warning_message);
 
         if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
 
@@ -398,7 +398,7 @@ void CreateWalletWizardActivity::finish()
 
 void CreateWalletWizardActivity::create()
 {
-    m_create_wallet_wizard = new CreateWalletWizard(m_parent_widget, &m_ssMnemonic, &m_ssMnemonicPassphrase, &m_ssMasterKey, &m_walletType);
+    m_create_wallet_wizard = new CreateWalletWizard(m_parent_widget, &m_ssMnemonic, &m_ssMnemonicPassphrase, &m_ssMasterKey, &m_walletType, &m_importing);
 
     std::vector<ExternalSigner> signers;
     try {
@@ -419,6 +419,7 @@ void CreateWalletWizardActivity::create()
     });
     connect(m_create_wallet_wizard, &QDialog::accepted, [this] {
         m_walletType = m_create_wallet_wizard->getWalletType();
+        m_importing = m_create_wallet_wizard->getImporting();
         if (m_create_wallet_wizard->isEncryptWalletChecked()) {
             askPassphrase();
         } else {

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -132,6 +132,7 @@ private:
     void finish();
 
     int m_walletType;
+    bool m_importing;
     SecureString m_passphrase;
     SecureString m_ssMnemonic;
     SecureString m_ssMnemonicPassphrase;
@@ -159,6 +160,7 @@ private:
     void finish();
 
     int m_walletType;
+    bool m_importing;
     SecureString m_passphrase;
     SecureString m_ssMnemonic;
     SecureString m_ssMnemonicPassphrase;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -220,6 +220,7 @@ enum walletType {
 struct WalletOptions {
     int walletType;
     int bits;
+    bool importing;
     SecureString ssMnemonic;
     SecureString ssMnemonicPassphrase;
     SecureString ssMasterKey;

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -561,7 +561,7 @@ public:
     void setMockTime(int64_t time) override { return SetMockTime(time); }
 
     //! WalletClient methods
-    std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, const SecureString& ssMasterKey, const SecureString& passphrase, const int& walletType, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) override
+    std::unique_ptr<Wallet> createWallet(const std::string& name, const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, const SecureString& ssMasterKey, const SecureString& passphrase, const int& walletType, const bool& importing, uint64_t wallet_creation_flags, bilingual_str& error, std::vector<bilingual_str>& warnings) override
     {
         std::shared_ptr<CWallet> wallet;
         DatabaseOptions options;
@@ -574,6 +574,7 @@ public:
         walletOptions.ssMnemonicPassphrase = ssMnemonicPassphrase;
         walletOptions.ssMasterKey = ssMasterKey;
         walletOptions.walletType = walletType;
+        walletOptions.importing = importing;
         return MakeWallet(CreateWallet(*m_context.chain, name, true /* load_on_start */, options, walletOptions, status, error, warnings));
     }
     std::unique_ptr<Wallet> loadWallet(const std::string& name, bilingual_str& error, std::vector<bilingual_str>& warnings) override

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -268,6 +268,10 @@ private:
      * Used to keep track of last coinstake interval */
     int64_t nLastCoinStakeSearchInterval = 0;
     /**
+     * Was this wallet imported
+     */
+    bool fImporting = false;
+    /**
      * Used to keep track of spent outpoints, and
      * detect and report conflicts (double-spends or
      * mutated transactions where the mutant gets mined).
@@ -797,6 +801,11 @@ public:
     bool GetEnableStaking() const { return fEnableStaking; }
     /** Set whether this wallet unlocked for staking only. */
     void SetEnableStaking(bool enableStaking) { fEnableStaking = enableStaking; }
+
+    /** Inquire whether this wallet unlocked for staking only. */
+    bool GetImporting() const { return fImporting; }
+    /** Set whether this wallet unlocked for staking only. */
+    void SetImporting(bool importing) { fImporting = importing; }
 
     /** Inquire for this wallet last coinstake search interval. */
     int64_t GetLastCoinStakeSearchInterval() const { return nLastCoinStakeSearchInterval; }


### PR DESCRIPTION
Allow the re scanning of wallet when importing a seed phrase.

closes #271 