### PR TITLE
gui: dont calculate stake weight while syncing

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -194,6 +194,12 @@ public:
     //! Get unspent outputs associated with a transaction.
     virtual bool getUnspentOutput(const COutPoint& output, Coin& coin) = 0;
 
+    //! Get node synchronization information.
+    virtual void getSyncInfo(int& numBlocks, bool& isSyncing) = 0;
+
+    //! Try to get node synchronization information.
+    virtual bool tryGetSyncInfo(int& numBlocks, bool& isSyncing) = 0;
+
     //! Get wallet client.
     virtual WalletClient& walletClient() = 0;
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -57,6 +57,9 @@ WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel
     mintingTableModel = new MintingTableModel(this);
     transactionTableModel = new TransactionTableModel(platformStyle, this);
     recentRequestsTableModel = new RecentRequestsTableModel(this);
+    nAverageStakeWeight = 0;
+    nTotalStakeWeight = 0;
+    updateStakeWeight = true;
 
     subscribeToCoreSignals();
 }
@@ -154,13 +157,22 @@ bool WalletModel::validateAddress(const QString &address)
 
 bool WalletModel::GetStakeWeight(uint64_t& nAverageWeight, uint64_t& nTotalWeight)
 {
+    int numBlocks = -1;
+    bool isSyncing = false;
+
+    if (!m_node.tryGetSyncInfo(numBlocks, isSyncing))
+        return false;
+
+    if (isSyncing)
+        return false;
+
     std::set<CInputCoin> setCoins;
-    if(!m_wallet->GetStakeWeightSet(setCoins))
+    if (!m_wallet->GetStakeWeightSet(setCoins))
         return false;
     if (setCoins.empty())
         return false;
 
-    if(!m_node.getStakeWeight(setCoins, nAverageWeight, nTotalWeight))
+    if (!m_node.getStakeWeight(setCoins, nAverageWeight, nTotalWeight))
         return false;
 
     return true;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -163,6 +163,9 @@ public:
     bool isMultiwallet();
 
     bool GetStakeWeight(uint64_t& nAverageWeight, uint64_t& nTotalWeight);
+    std::atomic<bool> updateStakeWeight;
+    uint64_t nAverageStakeWeight;
+    uint64_t nTotalStakeWeight;
 
     AddressTableModel* getAddressTableModel() const { return addressTableModel; }
 


### PR DESCRIPTION
calculating stakeweight is expensive call. and there is no need during resync or reindex
Wait until sync is (near) before querying
