### PR TITLE
Refactor staking notifications

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -156,10 +156,10 @@ public:
     virtual bool getStakeWeight(std::set<CInputCoin>& setCoins, uint64_t& nAverageWeight, uint64_t & nTotalWeight) = 0;
 
     //! Set staking active.
-    virtual void setStakingActive(bool active) = 0;
+    virtual void setNodeStakingActive(bool active) = 0;
 
     //! Get staking active.
-    virtual bool getStakingActive() = 0;
+    virtual bool getNodeStakingActive() = 0;
 
     //! Start wallet staking.
     virtual void setStakeWallet(const std::string& walletname, bool active) = 0;
@@ -232,8 +232,8 @@ public:
     virtual std::unique_ptr<Handler> handleNotifyNetworkActiveChanged(NotifyNetworkActiveChangedFn fn) = 0;
 
     //! Register handler for staking active messages.
-    using NotifyStakingActiveChangedFn = std::function<void(bool staking_active)>;
-    virtual std::unique_ptr<Handler> handleNotifyStakingActiveChanged(NotifyStakingActiveChangedFn fn) = 0;
+    using NotifyNodeStakingActiveChangedFn = std::function<void(bool staking_active)>;
+    virtual std::unique_ptr<Handler> handleNotifyNodeStakingActiveChanged(NotifyNodeStakingActiveChangedFn fn) = 0;
 
     //! Register handler for notify alert messages.
     using NotifyAlertChangedFn = std::function<void()>;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -235,6 +235,10 @@ public:
     using NotifyNodeStakingActiveChangedFn = std::function<void(bool staking_active)>;
     virtual std::unique_ptr<Handler> handleNotifyNodeStakingActiveChanged(NotifyNodeStakingActiveChangedFn fn) = 0;
 
+    //! Register handler for wallet staking active messages.
+    using NotifyWalletStakingActiveChangedFn = std::function<void(bool staking_active)>;
+    virtual std::unique_ptr<Handler> handleNotifyWalletStakingActiveChanged(NotifyWalletStakingActiveChangedFn fn) = 0;
+
     //! Register handler for notify alert messages.
     using NotifyAlertChangedFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -308,6 +308,10 @@ public:
     using StatusChangedFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleStatusChanged(StatusChangedFn fn) = 0;
 
+    //! Register handler for wallet staking status messages.
+    using NotifyWalletStakingStatusChangedFn = std::function<void()>;
+    virtual std::unique_ptr<Handler> handleNotifyWalletStakingStatusChanged(NotifyWalletStakingStatusChangedFn fn) = 0;
+
     //! Register handler for address book changed messages.
     using AddressBookChangedFn = std::function<void(const CTxDestination& address,
         const std::string& label,

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -683,7 +683,6 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                         continue;
                     }
                 }
-                uiInterface.NotifyStakingActiveChanged(true);
                 LogPrintf("Staker thread [%d]: proof-of-stake block found %s\n", thread_id, pblock->GetHash().ToString());
                 ProcessBlockFound(pblock, chainman, &chainman->ActiveChainstate(), Params());
                 reservedest.KeepDestination();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -690,6 +690,9 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 if (!connman->interruptNet.sleep_for(std::chrono::seconds(60 + GetRand(4))))
                     return;
             }
+
+            uiInterface.NotifyWalletStakingActiveChanged(true);
+
             if (!connman->interruptNet.sleep_for(std::chrono::milliseconds(pos_timio)))
                 return;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -599,6 +599,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 if (strMintWarning != strMintMessage) {
                     strMintWarning = strMintMessage;
                     uiInterface.NotifyAlertChanged();
+                    pwallet->NotifyWalletStakingStatusChanged();
                 }
                 fNeedToClear = true;
                 if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
@@ -614,6 +615,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 if (strMintWarning != strMintSyncMessage) {
                     strMintWarning = strMintSyncMessage;
                     uiInterface.NotifyAlertChanged();
+                    pwallet->NotifyWalletStakingStatusChanged();
                 }
                 fNeedToClear = true;
                 if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
@@ -628,6 +630,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 if (strMintWarning != strMintSyncMessage) {
                     strMintWarning = strMintSyncMessage;
                     uiInterface.NotifyAlertChanged();
+                    pwallet->NotifyWalletStakingStatusChanged();
                 }
                 fNeedToClear = true;
                 if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
@@ -636,6 +639,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
             if (fNeedToClear) {
                 strMintWarning = strMintEmpty;
                 uiInterface.NotifyAlertChanged();
+                pwallet->NotifyWalletStakingStatusChanged();
                 fNeedToClear = false;
             }
 
@@ -663,6 +667,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 }
                 strMintWarning = strMintBlockMessage;
                 uiInterface.NotifyAlertChanged();
+                pwallet->NotifyWalletStakingStatusChanged();
                 LogPrintf("Staker thread [%d]: Error in ReddcoinMiner: Keypool ran out, please call keypoolrefill before restarting the mining thread\n", thread_id);
                 if (!connman->interruptNet.sleep_for(std::chrono::seconds(10)))
                    return;
@@ -671,6 +676,8 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
             }
             pblock = &pblocktemplate->block;
             IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
+
+            pwallet->NotifyWalletStakingStatusChanged();
 
             // reddcoin: if proof-of-stake block found then process block
             if (pblock->IsProofOfStake())
@@ -690,8 +697,6 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 if (!connman->interruptNet.sleep_for(std::chrono::seconds(60 + GetRand(4))))
                     return;
             }
-
-            uiInterface.NotifyWalletStakingActiveChanged(true);
 
             if (!connman->interruptNet.sleep_for(std::chrono::milliseconds(pos_timio)))
                 return;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -366,6 +366,10 @@ public:
     {
         return MakeHandler(::uiInterface.NotifyNodeStakingActiveChanged_connect(fn));
     }
+    std::unique_ptr<Handler> handleNotifyWalletStakingActiveChanged(NotifyWalletStakingActiveChangedFn fn) override
+    {
+        return MakeHandler(::uiInterface.NotifyWalletStakingActiveChanged_connect(fn));
+    }
     std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) override
     {
         return MakeHandler(::uiInterface.NotifyAlertChanged_connect(fn));

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -260,7 +260,7 @@ public:
     {
       return GetStakeWeight(setCoins, nAverageWeight, nTotalWeight);
     }
-    void setStakingActive(bool active) override
+    void setNodeStakingActive(bool active) override
     {
         if (m_context->stakeman) {
             m_context->stakeman->SetStakingActive(active);
@@ -281,7 +281,7 @@ public:
             m_context->stakeman->StakeWalletRemove(walletname);
         }
     }
-    bool getStakingActive() override { return m_context->stakeman && m_context->stakeman->GetStakingActive(); }
+    bool getNodeStakingActive() override { return m_context->stakeman && m_context->stakeman->GetNodeStakingActive(); }
     bool getReindex() override { return ::fReindex; }
     bool getImporting() override { return ::fImporting; }
     void setNetworkActive(bool active) override
@@ -362,9 +362,9 @@ public:
     {
         return MakeHandler(::uiInterface.NotifyNetworkActiveChanged_connect(fn));
     }
-    std::unique_ptr<Handler> handleNotifyStakingActiveChanged(NotifyStakingActiveChangedFn fn) override
+    std::unique_ptr<Handler> handleNotifyNodeStakingActiveChanged(NotifyNodeStakingActiveChangedFn fn) override
     {
-        return MakeHandler(::uiInterface.NotifyStakingActiveChanged_connect(fn));
+        return MakeHandler(::uiInterface.NotifyNodeStakingActiveChanged_connect(fn));
     }
     std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) override
     {

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -18,6 +18,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::NotifyNumConnectionsChangedSig> NotifyNumConnectionsChanged;
     boost::signals2::signal<CClientUIInterface::NotifyNetworkActiveChangedSig> NotifyNetworkActiveChanged;
     boost::signals2::signal<CClientUIInterface::NotifyNodeStakingActiveChangedSig> NotifyNodeStakingActiveChanged;
+    boost::signals2::signal<CClientUIInterface::NotifyWalletStakingActiveChangedSig> NotifyWalletStakingActiveChanged;
     boost::signals2::signal<CClientUIInterface::NotifyAlertChangedSig> NotifyAlertChanged;
     boost::signals2::signal<CClientUIInterface::ShowProgressSig> ShowProgress;
     boost::signals2::signal<CClientUIInterface::NotifyBlockTipSig> NotifyBlockTip;
@@ -38,6 +39,7 @@ ADD_SIGNALS_IMPL_WRAPPER(InitMessage);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNumConnectionsChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNetworkActiveChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNodeStakingActiveChanged);
+ADD_SIGNALS_IMPL_WRAPPER(NotifyWalletStakingActiveChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyAlertChanged);
 ADD_SIGNALS_IMPL_WRAPPER(ShowProgress);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyBlockTip);
@@ -50,6 +52,7 @@ void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_s
 void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
 void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
 void CClientUIInterface::NotifyNodeStakingActiveChanged(bool stakingActive) { return g_ui_signals.NotifyNodeStakingActiveChanged(stakingActive); }
+void CClientUIInterface::NotifyWalletStakingActiveChanged(bool stakingActive) { return g_ui_signals.NotifyWalletStakingActiveChanged(stakingActive); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }
 void CClientUIInterface::NotifyBlockTip(SynchronizationState s, const CBlockIndex* i) { return g_ui_signals.NotifyBlockTip(s, i); }

--- a/src/node/ui_interface.cpp
+++ b/src/node/ui_interface.cpp
@@ -17,7 +17,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::InitMessageSig> InitMessage;
     boost::signals2::signal<CClientUIInterface::NotifyNumConnectionsChangedSig> NotifyNumConnectionsChanged;
     boost::signals2::signal<CClientUIInterface::NotifyNetworkActiveChangedSig> NotifyNetworkActiveChanged;
-    boost::signals2::signal<CClientUIInterface::NotifyStakingActiveChangedSig> NotifyStakingActiveChanged;
+    boost::signals2::signal<CClientUIInterface::NotifyNodeStakingActiveChangedSig> NotifyNodeStakingActiveChanged;
     boost::signals2::signal<CClientUIInterface::NotifyAlertChangedSig> NotifyAlertChanged;
     boost::signals2::signal<CClientUIInterface::ShowProgressSig> ShowProgress;
     boost::signals2::signal<CClientUIInterface::NotifyBlockTipSig> NotifyBlockTip;
@@ -37,7 +37,7 @@ ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeQuestion);
 ADD_SIGNALS_IMPL_WRAPPER(InitMessage);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNumConnectionsChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNetworkActiveChanged);
-ADD_SIGNALS_IMPL_WRAPPER(NotifyStakingActiveChanged);
+ADD_SIGNALS_IMPL_WRAPPER(NotifyNodeStakingActiveChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyAlertChanged);
 ADD_SIGNALS_IMPL_WRAPPER(ShowProgress);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyBlockTip);
@@ -49,7 +49,7 @@ bool CClientUIInterface::ThreadSafeQuestion(const bilingual_str& message, const 
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
 void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
-void CClientUIInterface::NotifyStakingActiveChanged(bool stakingActive) { return g_ui_signals.NotifyStakingActiveChanged(stakingActive); }
+void CClientUIInterface::NotifyNodeStakingActiveChanged(bool stakingActive) { return g_ui_signals.NotifyNodeStakingActiveChanged(stakingActive); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }
 void CClientUIInterface::NotifyBlockTip(SynchronizationState s, const CBlockIndex* i) { return g_ui_signals.NotifyBlockTip(s, i); }

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -88,8 +88,8 @@ public:
     /** Network activity state changed. */
     ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkActiveChanged, void, bool networkActive);
 
-    /** Network activity state changed. */
-    ADD_SIGNALS_DECL_WRAPPER(NotifyStakingActiveChanged, void, bool stakingActive);
+    /** Node staking activity state changed. */
+    ADD_SIGNALS_DECL_WRAPPER(NotifyNodeStakingActiveChanged, void, bool stakingActive);
 
     /**
      * Status bar alerts changed.

--- a/src/node/ui_interface.h
+++ b/src/node/ui_interface.h
@@ -91,6 +91,8 @@ public:
     /** Node staking activity state changed. */
     ADD_SIGNALS_DECL_WRAPPER(NotifyNodeStakingActiveChanged, void, bool stakingActive);
 
+    /** Wallet staking activity state changed. */
+    ADD_SIGNALS_DECL_WRAPPER(NotifyWalletStakingActiveChanged, void, bool stakingActive);
     /**
      * Status bar alerts changed.
      */

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1688,8 +1688,6 @@ void BitcoinGUI::updateWalletStatus()
         hdType = HD_ENABLED_32;
     }
     setHDStatus(walletModel->wallet().privateKeysDisabled(), hdType);
-    updateWalletStakingStatus();
-    setWalletStakingActive(walletModel->getWalletStaking());
 }
 #endif // ENABLE_WALLET
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -163,7 +163,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     frameBlocksLayout->setSpacing(3);
     unitDisplayControl = new UnitDisplayStatusBarControl(platformStyle);
     labelWalletEncryptionIcon = new GUIUtil::ClickableLabel(platformStyle);
-    stakingStatusControl = new GUIUtil::ClickableLabel(platformStyle);
+    walletstakingStatusControl = new GUIUtil::ClickableLabel(platformStyle);
     globalstakingStatusControl = new GUIUtil::ClickableLabel(platformStyle);
     labelWalletHDStatusIcon = new GUIUtil::ThemedLabel(platformStyle);
     labelProxyIcon = new GUIUtil::ClickableLabel(platformStyle);
@@ -177,7 +177,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
         frameBlocksLayout->addWidget(labelWalletEncryptionIcon);
         frameBlocksLayout->addWidget(labelWalletHDStatusIcon);
         frameBlocksLayout->addStretch();
-        frameBlocksLayout->addWidget(stakingStatusControl);
+        frameBlocksLayout->addWidget(walletstakingStatusControl);
     }
     frameBlocksLayout->addWidget(labelProxyIcon);
     frameBlocksLayout->addStretch();
@@ -746,7 +746,7 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
         connect(labelWalletEncryptionIcon, &GUIUtil::ClickableLabel::clicked, [this] {
                     GUIUtil::PopupMenu(m_lock_context_menu, QCursor::pos());
                 });
-        connect(stakingStatusControl, &GUIUtil::ClickableLabel::clicked, [this] {
+        connect(walletstakingStatusControl, &GUIUtil::ClickableLabel::clicked, [this] {
                     GUIUtil::PopupMenu(m_wallet_staking_context_menu, QCursor::pos());
                 });
 #endif // ENABLE_WALLET
@@ -842,7 +842,7 @@ void BitcoinGUI::removeWallet(WalletModel* walletModel)
 
     labelWalletHDStatusIcon->hide();
     labelWalletEncryptionIcon->hide();
-    stakingStatusControl->hide();
+    walletstakingStatusControl->hide();
 
     int index = m_wallet_selector->findData(QVariant::fromValue(walletModel));
     m_wallet_selector->removeItem(index);
@@ -1609,7 +1609,7 @@ void BitcoinGUI::updateStakingStatus()
 
     if (staking && m_node.getStakingActive()) {
         msg = tr("Wallet is staking");
-        stakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/staking_on"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
+        walletstakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/staking_on"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
     } else {
         if (walletModel->getEncryptionStatus() == WalletModel::Locked) {
             msg = tr("Not staking because wallet is locked");
@@ -1627,7 +1627,7 @@ void BitcoinGUI::updateStakingStatus()
             msg = tr("Waiting for staking to start");
         }
 
-        stakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/staking_off"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
+        walletstakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/staking_off"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
     }
 
     walletstakingStatusControl->setToolTip(msg);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -827,7 +827,7 @@ void BitcoinGUI::addWallet(WalletModel* walletModel)
         this->message(title, message, style);
     });
     connect(wallet_view, &WalletView::encryptionStatusChanged, this, &BitcoinGUI::updateWalletStatus);
-    connect(wallet_view, &WalletView::stakingStatusChanged, this, &BitcoinGUI::updateStakingStatus);
+    connect(wallet_view, &WalletView::stakingStatusChanged, this, &BitcoinGUI::updateWalletStakingStatus);
     connect(wallet_view, &WalletView::incomingTransaction, this, &BitcoinGUI::incomingTransaction);
     connect(wallet_view, &WalletView::hdEnabledStatusChanged, this, &BitcoinGUI::updateWalletStatus);
     connect(this, &BitcoinGUI::setPrivacy, wallet_view, &WalletView::setPrivacy);
@@ -1548,12 +1548,12 @@ void BitcoinGUI::setEncryptionStatus(int status)
         break;
     }
 
-    updateStakingStatus();
+    updateWalletStakingStatus();
 }
 
 void BitcoinGUI::setWalletStakingActive(bool staking_active)
 {
-    updateStakingStatus();
+    updateWalletStakingStatus();
 
     m_wallet_staking_context_menu->clear();
     m_wallet_staking_context_menu->addAction(
@@ -1572,7 +1572,7 @@ void BitcoinGUI::setWalletStakingActive(bool staking_active)
 	    [this, new_state = !staking_active] { walletFrame->enableStaking(new_state); });
 }
 
-void BitcoinGUI::updateStakingStatus()
+void BitcoinGUI::updateWalletStakingStatus()
 {
     if (!walletFrame) {
         return;
@@ -1653,7 +1653,7 @@ void BitcoinGUI::updateWalletStatus()
         hdType = HD_ENABLED_32;
     }
     setHDStatus(walletModel->wallet().privateKeysDisabled(), hdType);
-    updateStakingStatus();
+    updateWalletStakingStatus();
     setWalletStakingActive(walletModel->getWalletStaking());
 }
 #endif // ENABLE_WALLET

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -716,11 +716,6 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
         });
         connect(_clientModel, &ClientModel::numConnectionsChanged, this, &BitcoinGUI::setNumConnections);
         connect(_clientModel, &ClientModel::networkActiveChanged, this, &BitcoinGUI::setNetworkActive);
-        setNodeStakingActive(m_node.getStakingActive());
-        connect(nodestakingStatusControl, &GUIUtil::ClickableLabel::clicked, [this] {
-                    GUIUtil::PopupMenu(m_node_staking_context_menu, QCursor::pos());
-                });
-        connect(_clientModel, &ClientModel::stakingActiveChanged, this, &BitcoinGUI::setNodeStakingActive);
 
         modalOverlay->setKnownBestHeight(tip_info->header_height, QDateTime::fromTime_t(tip_info->header_time));
         setNumBlocks(tip_info->block_height, QDateTime::fromTime_t(tip_info->block_time), tip_info->verification_progress, false, SynchronizationState::INIT_DOWNLOAD);
@@ -743,13 +738,18 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
         {
             walletFrame->setClientModel(_clientModel);
         }
-        updateNodeStakingStatus();
         connect(labelWalletEncryptionIcon, &GUIUtil::ClickableLabel::clicked, [this] {
                     GUIUtil::PopupMenu(m_lock_context_menu, QCursor::pos());
                 });
         connect(walletstakingStatusControl, &GUIUtil::ClickableLabel::clicked, [this] {
                     GUIUtil::PopupMenu(m_wallet_staking_context_menu, QCursor::pos());
                 });
+        setNodeStakingActive(m_node.getNodeStakingActive());
+        connect(nodestakingStatusControl, &GUIUtil::ClickableLabel::clicked, [this] {
+                    GUIUtil::PopupMenu(m_node_staking_context_menu, QCursor::pos());
+                });
+        updateNodeStakingStatus();
+        connect(_clientModel, &ClientModel::nodeStakingActiveChanged, this, &BitcoinGUI::setNodeStakingActive);
 #endif // ENABLE_WALLET
         unitDisplayControl->setOptionsModel(_clientModel->getOptionsModel());
 
@@ -1597,7 +1597,7 @@ void BitcoinGUI::updateWalletStakingStatus()
         staking = nLastCoinStakeSearchInterval && nAverageWeight;
     }
 
-    if (staking && m_node.getStakingActive()) {
+    if (staking && m_node.getNodeStakingActive()) {
         msg = tr("Wallet is staking");
         walletstakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/staking_on"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
     } else {
@@ -1611,7 +1611,7 @@ void BitcoinGUI::updateWalletStakingStatus()
             msg = tr("Not staking because you don't have mature coins");
         } else if (!walletModel->getWalletStaking()) {
             msg = tr("Wallet staking is disabled");
-        } else if (!m_node.getStakingActive()) {
+        } else if (!m_node.getNodeStakingActive()) {
             msg = tr("Staking is not enabled");
         } else if (!staking) {
             msg = tr("Waiting for staking to start");
@@ -1635,13 +1635,13 @@ void BitcoinGUI::setNodeStakingActive(bool staking_active)
             tr("Disable Node Staking") :
             //: A context menu item. The stake state activity was disabled previously.
             tr("Enable Node Staking"),
-        [this, new_state = !staking_active] { m_node.setStakingActive(new_state); });
+        [this, new_state = !staking_active] { m_node.setNodeStakingActive(new_state); });
 }
 
 void BitcoinGUI::updateNodeStakingStatus()
 {
   QString msg;
-  if (m_node.getStakingActive()) {
+  if (m_node.getNodeStakingActive()) {
       msg = tr("Staking is enabled");
       nodestakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/global_staking_on"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
   } else {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -828,6 +828,7 @@ void BitcoinGUI::addWallet(WalletModel* walletModel)
         this->message(title, message, style);
     });
     connect(wallet_view, &WalletView::encryptionStatusChanged, this, &BitcoinGUI::updateWalletStatus);
+    connect(wallet_view, &WalletView::stakingActiveChanged, this, &BitcoinGUI::setWalletStakingActive);
     connect(wallet_view, &WalletView::stakingStatusChanged, this, &BitcoinGUI::updateWalletStakingStatus);
     connect(wallet_view, &WalletView::incomingTransaction, this, &BitcoinGUI::incomingTransaction);
     connect(wallet_view, &WalletView::hdEnabledStatusChanged, this, &BitcoinGUI::updateWalletStatus);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -716,7 +716,6 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
         });
         connect(_clientModel, &ClientModel::numConnectionsChanged, this, &BitcoinGUI::setNumConnections);
         connect(_clientModel, &ClientModel::networkActiveChanged, this, &BitcoinGUI::setNetworkActive);
-
         modalOverlay->setKnownBestHeight(tip_info->header_height, QDateTime::fromTime_t(tip_info->header_time));
         setNumBlocks(tip_info->block_height, QDateTime::fromTime_t(tip_info->block_time), tip_info->verification_progress, false, SynchronizationState::INIT_DOWNLOAD);
         connect(_clientModel, &ClientModel::numBlocksChanged, this, &BitcoinGUI::setNumBlocks);
@@ -750,6 +749,7 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
                 });
         updateNodeStakingStatus();
         connect(_clientModel, &ClientModel::nodeStakingActiveChanged, this, &BitcoinGUI::setNodeStakingActive);
+        connect(_clientModel, &ClientModel::walletStakingActiveChanged, this, &BitcoinGUI::updateWalletStakingStatus);
 #endif // ENABLE_WALLET
         unitDisplayControl->setOptionsModel(_clientModel->getOptionsModel());
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -164,7 +164,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     unitDisplayControl = new UnitDisplayStatusBarControl(platformStyle);
     labelWalletEncryptionIcon = new GUIUtil::ClickableLabel(platformStyle);
     walletstakingStatusControl = new GUIUtil::ClickableLabel(platformStyle);
-    globalstakingStatusControl = new GUIUtil::ClickableLabel(platformStyle);
+    nodestakingStatusControl = new GUIUtil::ClickableLabel(platformStyle);
     labelWalletHDStatusIcon = new GUIUtil::ThemedLabel(platformStyle);
     labelProxyIcon = new GUIUtil::ClickableLabel(platformStyle);
     connectionsControl = new GUIUtil::ClickableLabel(platformStyle);
@@ -187,7 +187,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     frameBlocksLayout->addStretch();
     if (enableWallet)
     {
-        frameBlocksLayout->addWidget(globalstakingStatusControl);
+        frameBlocksLayout->addWidget(nodestakingStatusControl);
         frameBlocksLayout->addStretch();
     }
 
@@ -717,7 +717,7 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
         connect(_clientModel, &ClientModel::numConnectionsChanged, this, &BitcoinGUI::setNumConnections);
         connect(_clientModel, &ClientModel::networkActiveChanged, this, &BitcoinGUI::setNetworkActive);
         setNodeStakingActive(m_node.getStakingActive());
-        connect(globalstakingStatusControl, &GUIUtil::ClickableLabel::clicked, [this] {
+        connect(nodestakingStatusControl, &GUIUtil::ClickableLabel::clicked, [this] {
                     GUIUtil::PopupMenu(m_node_staking_context_menu, QCursor::pos());
                 });
         connect(_clientModel, &ClientModel::stakingActiveChanged, this, &BitcoinGUI::setNodeStakingActive);
@@ -1643,13 +1643,13 @@ void BitcoinGUI::updateNodeStakingStatus()
   QString msg;
   if (m_node.getStakingActive()) {
       msg = tr("Staking is enabled");
-      globalstakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/global_staking_on"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
+      nodestakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/global_staking_on"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
   } else {
       msg = tr("Staking is disabled");
-      globalstakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/global_staking_off"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
+      nodestakingStatusControl->setThemedPixmap(QStringLiteral(":/icons/global_staking_off"), STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
   }
 
-  globalstakingStatusControl->setToolTip(msg);
+  nodestakingStatusControl->setToolTip(msg);
 
   updateWalletStakingStatus();
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -50,6 +50,7 @@
 #include <QComboBox>
 #include <QCursor>
 #include <QDateTime>
+#include <QDebug>
 #include <QDesktopServices>
 #include <QDragEnterEvent>
 #include <QListWidget>
@@ -1559,6 +1560,7 @@ void BitcoinGUI::setEncryptionStatus(int status)
 
 void BitcoinGUI::setWalletStakingActive(bool staking_active)
 {
+    qDebug() << QString("BitcoinGUI::%1: Staking updated to %2").arg(__func__).arg(staking_active);
     updateWalletStakingStatus();
 
     m_wallet_staking_context_menu->clear();
@@ -1598,6 +1600,7 @@ void BitcoinGUI::updateWalletStakingStatus()
     QString msg;
     QString icon = "";
     if (walletModel) {
+        qDebug() << QString("BitcoinGUI::%1: wallet %2 updated").arg(__func__).arg(walletModel->getDisplayName());
         walletModel->GetStakeWeight(nAverageWeight, nTotalWeight);
         nLastCoinStakeSearchInterval = walletModel->wallet().getLastCoinStakeSearchInterval();
         staking = nLastCoinStakeSearchInterval && nAverageWeight;
@@ -1640,6 +1643,7 @@ void BitcoinGUI::updateWalletStakingStatus()
 
 void BitcoinGUI::setNodeStakingActive(bool staking_active)
 {
+    qDebug() << QString("BitcoinGUI::%1: Staking updated to %2").arg(__func__).arg(staking_active);
     updateNodeStakingStatus();
 
     m_node_staking_context_menu->clear();
@@ -1654,6 +1658,7 @@ void BitcoinGUI::setNodeStakingActive(bool staking_active)
 
 void BitcoinGUI::updateNodeStakingStatus()
 {
+  qDebug() << QString("BitcoinGUI::%1: Staking updated to %2").arg(__func__).arg(m_node.getNodeStakingActive());
   QString msg;
   if (m_node.getNodeStakingActive()) {
       msg = tr("Staking is enabled");

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -35,7 +35,6 @@ class OptionsModel;
 class PlatformStyle;
 class RPCConsole;
 class SendCoinsRecipient;
-class StakingStatusBarControl;
 class UnitDisplayStatusBarControl;
 class WalletController;
 class WalletFrame;
@@ -140,7 +139,7 @@ private:
     GUIUtil::ClickableLabel* labelBlocksIcon = nullptr;
     GUIUtil::ClickableLabel* labelCheckUpdate = nullptr;
     GUIUtil::ClickableLabel* labelStakingIcon = nullptr;
-    StakingStatusBarControl* stakingStatusControl = nullptr;
+    GUIUtil::ClickableLabel* stakingStatusControl = nullptr;
     GUIUtil::ClickableLabel* globalstakingStatusControl = nullptr;
     QLabel* progressBarLabel = nullptr;
     GUIUtil::ClickableProgressBar* progressBar = nullptr;
@@ -204,7 +203,7 @@ private:
 
     QMenu* m_network_context_menu = new QMenu(this);
     QMenu* m_lock_context_menu = new QMenu(this);
-    QMenu* m_staking_context_menu = new QMenu(this);
+    QMenu* m_wallet_staking_context_menu = new QMenu(this);
 
 #ifdef Q_OS_MAC
     CAppNapInhibitor* m_app_nap_inhibitor = nullptr;
@@ -275,7 +274,7 @@ public Q_SLOTS:
     void updateWalletStatus();
     void updateStakingStatus();
     /** Set staking state shown in the UI */
-    void setStakingActive(bool staking_active);
+    void setWalletStakingActive(bool staking_active);
     void setWalletLocked(bool wallet_locked);
 
 private:
@@ -403,55 +402,4 @@ private Q_SLOTS:
     /** Tells underlying optionsModel to update its current display unit. */
     void onMenuSelection(QAction* action);
 };
-
-class StakingStatusBarControl : public QLabel
-{
-  Q_OBJECT
-
-public:
-    explicit StakingStatusBarControl(const PlatformStyle *platformStyle);
-    /** Lets the control know about the Wallet Frame Model (and its signals) */
-    void setWalletFrame(WalletFrame *walletFrame);
-    /** Lets the control know about the RPC Console Model (and its signals) */
-    void setRPCConsole(RPCConsole* rpcConsole);
-    void setThemedPixmap(const QString& image_filename, int width, int height);
-    /** Set staking state shown in the UI */
-    void setStakingActive(bool stake_active);
-
-protected:
-    /** So that it responds to left-button clicks */
-    void mousePressEvent(QMouseEvent *event) override;
-    void changeEvent(QEvent* e) override;
-
-private:
-    // OptionsModel *optionsModel;
-    WalletFrame *walletFrame;
-    RPCConsole* rpcConsole;
-    QMenu* menu;
-    QAction* enableStakingAction = nullptr;
-    QAction* disableStakingAction = nullptr;
-    QAction* displayStakingAction = nullptr;
-    const PlatformStyle* m_platform_style;
-    QString m_image_filename;
-    int m_pixmap_width;
-    int m_pixmap_height;
-    void updateThemedPixmap();
-    void showDebugWindow();
-
-    /** Shows context menu with Lock wallet options by the mouse coordinates */
-    void onLockWalletClicked(const QPoint& point);
-    /** Creates context menu, its actions, and wires up all the relevant signals for mouse events. */
-    void createContextMenu();
-
-Q_SIGNALS:
-    /** Signal raised when RPC console shown */
-    void consoleShown(RPCConsole* console);
-
-private Q_SLOTS:
-    /** When wallet lock status is changed on walletFrame it will refresh the display text of the control on the status bar */
-    void updateLockWallet(int newUnits);
-    /** Tells underlying walletFrame to update its current status. */
-    void onMenuSelection(QAction* action);
-};
-
 #endif // BITCOIN_QT_BITCOINGUI_H

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -139,7 +139,7 @@ private:
     GUIUtil::ClickableLabel* labelBlocksIcon = nullptr;
     GUIUtil::ClickableLabel* labelCheckUpdate = nullptr;
     GUIUtil::ClickableLabel* labelStakingIcon = nullptr;
-    GUIUtil::ClickableLabel* stakingStatusControl = nullptr;
+    GUIUtil::ClickableLabel* walletstakingStatusControl = nullptr;
     GUIUtil::ClickableLabel* globalstakingStatusControl = nullptr;
     QLabel* progressBarLabel = nullptr;
     GUIUtil::ClickableProgressBar* progressBar = nullptr;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -272,7 +272,7 @@ public Q_SLOTS:
     /** Set the UI status indicators based on the currently selected wallet.
     */
     void updateWalletStatus();
-    void updateStakingStatus();
+    void updateWalletStakingStatus();
     /** Set staking state shown in the UI */
     void setWalletStakingActive(bool staking_active);
     void setWalletLocked(bool wallet_locked);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -29,7 +29,6 @@
 #include <memory>
 
 class ClientModel;
-class LockWalletStatusBarControl;
 class NetworkStyle;
 class Notificator;
 class OptionsModel;
@@ -134,8 +133,7 @@ private:
     WalletFrame* walletFrame = nullptr;
 
     UnitDisplayStatusBarControl* unitDisplayControl = nullptr;
-    LockWalletStatusBarControl* labelWalletEncryptionIcon = nullptr;
-    // GUIUtil::ThemedLabel* labelWalletEncryptionIcon = nullptr;
+    GUIUtil::ClickableLabel* labelWalletEncryptionIcon = nullptr;
     GUIUtil::ThemedLabel* labelWalletHDStatusIcon = nullptr;
     GUIUtil::ClickableLabel* labelProxyIcon = nullptr;
     GUIUtil::ClickableLabel* connectionsControl = nullptr;
@@ -278,6 +276,7 @@ public Q_SLOTS:
     void updateStakingStatus();
     /** Set staking state shown in the UI */
     void setStakingActive(bool staking_active);
+    void setWalletLocked(bool wallet_locked);
 
 private:
     /** Set the encryption status as shown in the UI.
@@ -402,46 +401,6 @@ private Q_SLOTS:
     /** When Display Units are changed on OptionsModel it will refresh the display text of the control on the status bar */
     void updateDisplayUnit(int newUnits);
     /** Tells underlying optionsModel to update its current display unit. */
-    void onMenuSelection(QAction* action);
-};
-
-class LockWalletStatusBarControl : public QLabel
-{
-  Q_OBJECT
-
-public:
-    explicit LockWalletStatusBarControl(const PlatformStyle *platformStyle);
-    /** Lets the control know about the Wallet Frame Model (and its signals) */
-    void setWalletFrame(WalletFrame *walletFrame);
-    void setThemedPixmap(const QString& image_filename, int width, int height);
-    void setLockState(bool lock_active);
-
-protected:
-    /** So that it responds to left-button clicks */
-    void mousePressEvent(QMouseEvent *event) override;
-    void changeEvent(QEvent* e) override;
-
-private:
-    // OptionsModel *optionsModel;
-    WalletFrame *walletFrame;
-    QMenu* menu;
-    QAction* unlockWalletAction = nullptr;
-    QAction* lockWalletAction = nullptr;
-    const PlatformStyle* m_platform_style;
-    QString m_image_filename;
-    int m_pixmap_width;
-    int m_pixmap_height;
-    void updateThemedPixmap();
-
-    /** Shows context menu with Lock wallet options by the mouse coordinates */
-    void onLockWalletClicked(const QPoint& point);
-    /** Creates context menu, its actions, and wires up all the relevant signals for mouse events. */
-    void createContextMenu();
-
-private Q_SLOTS:
-    /** When wallet lock status is changed on walletFrame it will refresh the display text of the control on the status bar */
-    void updateLockWallet(int newUnits);
-    /** Tells underlying walletFrame to update its current status. */
     void onMenuSelection(QAction* action);
 };
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -204,6 +204,7 @@ private:
     QMenu* m_network_context_menu = new QMenu(this);
     QMenu* m_lock_context_menu = new QMenu(this);
     QMenu* m_wallet_staking_context_menu = new QMenu(this);
+    QMenu* m_node_staking_context_menu = new QMenu(this);
 
 #ifdef Q_OS_MAC
     CAppNapInhibitor* m_app_nap_inhibitor = nullptr;
@@ -273,8 +274,10 @@ public Q_SLOTS:
     */
     void updateWalletStatus();
     void updateWalletStakingStatus();
+    void updateNodeStakingStatus();
     /** Set staking state shown in the UI */
     void setWalletStakingActive(bool staking_active);
+    void setNodeStakingActive(bool staking_active);
     void setWalletLocked(bool wallet_locked);
 
 private:

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -140,7 +140,7 @@ private:
     GUIUtil::ClickableLabel* labelCheckUpdate = nullptr;
     GUIUtil::ClickableLabel* labelStakingIcon = nullptr;
     GUIUtil::ClickableLabel* walletstakingStatusControl = nullptr;
-    GUIUtil::ClickableLabel* globalstakingStatusControl = nullptr;
+    GUIUtil::ClickableLabel* nodestakingStatusControl = nullptr;
     QLabel* progressBarLabel = nullptr;
     GUIUtil::ClickableProgressBar* progressBar = nullptr;
     QProgressDialog* progressDialog = nullptr;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -163,6 +163,11 @@ void ClientModel::updateNodeStakingActive(bool stakingActive)
     Q_EMIT nodeStakingActiveChanged(stakingActive);
 }
 
+void ClientModel::updateWalletStakingActive(bool stakingActive)
+{
+    Q_EMIT walletStakingActiveChanged(stakingActive);
+}
+
 void ClientModel::updateAlert()
 {
     Q_EMIT alertsChanged(getStatusBarWarnings());
@@ -283,6 +288,14 @@ static void NotifyNodeStakingActiveChanged(ClientModel *clientmodel, bool stakin
     assert(invoked);
 }
 
+static void NotifyWalletStakingActiveChanged(ClientModel *clientmodel, bool stakingActive)
+{
+    qDebug() << QString("%1: Wallet Staking updated to %2").arg(__func__).arg(stakingActive);
+    bool invoked = QMetaObject::invokeMethod(clientmodel, "updateWalletStakingActive", Qt::QueuedConnection,
+                              Q_ARG(bool, stakingActive));
+    assert(invoked);
+}
+
 static void NotifyAlertChanged(ClientModel *clientmodel)
 {
     qDebug() << "NotifyAlertChanged";
@@ -333,6 +346,7 @@ void ClientModel::subscribeToCoreSignals()
     m_handler_notify_num_connections_changed = m_node.handleNotifyNumConnectionsChanged(std::bind(NotifyNumConnectionsChanged, this, std::placeholders::_1));
     m_handler_notify_network_active_changed = m_node.handleNotifyNetworkActiveChanged(std::bind(NotifyNetworkActiveChanged, this, std::placeholders::_1));
     m_handler_notify_nodestaking_active_changed = m_node.handleNotifyNodeStakingActiveChanged(std::bind(NotifyNodeStakingActiveChanged, this, std::placeholders::_1));
+    m_handler_notify_walletstaking_active_changed = m_node.handleNotifyWalletStakingActiveChanged(std::bind(NotifyWalletStakingActiveChanged, this, std::placeholders::_1));
     m_handler_notify_alert_changed = m_node.handleNotifyAlertChanged(std::bind(NotifyAlertChanged, this));
     m_handler_banned_list_changed = m_node.handleBannedListChanged(std::bind(BannedListChanged, this));
     m_handler_notify_block_tip = m_node.handleNotifyBlockTip(std::bind(BlockTipChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, false));
@@ -346,6 +360,7 @@ void ClientModel::unsubscribeFromCoreSignals()
     m_handler_notify_num_connections_changed->disconnect();
     m_handler_notify_network_active_changed->disconnect();
     m_handler_notify_nodestaking_active_changed->disconnect();
+    m_handler_notify_walletstaking_active_changed->disconnect();
     m_handler_notify_alert_changed->disconnect();
     m_handler_banned_list_changed->disconnect();
     m_handler_notify_block_tip->disconnect();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -158,9 +158,9 @@ void ClientModel::updateNetworkActive(bool networkActive)
     Q_EMIT networkActiveChanged(networkActive);
 }
 
-void ClientModel::updateStakingActive(bool stakingActive)
+void ClientModel::updateNodeStakingActive(bool stakingActive)
 {
-    Q_EMIT stakingActiveChanged(stakingActive);
+    Q_EMIT nodeStakingActiveChanged(stakingActive);
 }
 
 void ClientModel::updateAlert()
@@ -275,10 +275,10 @@ static void NotifyNetworkActiveChanged(ClientModel *clientmodel, bool networkAct
     assert(invoked);
 }
 
-static void NotifyStakingActiveChanged(ClientModel *clientmodel, bool stakingActive)
+static void NotifyNodeStakingActiveChanged(ClientModel *clientmodel, bool stakingActive)
 {
-    qDebug() << QString("%1: Staking updated to %2").arg(__func__).arg(stakingActive);
-    bool invoked = QMetaObject::invokeMethod(clientmodel, "updateStakingActive", Qt::QueuedConnection,
+    qDebug() << QString("%1: Node Staking updated to %2").arg(__func__).arg(stakingActive);
+    bool invoked = QMetaObject::invokeMethod(clientmodel, "updateNodeStakingActive", Qt::QueuedConnection,
                               Q_ARG(bool, stakingActive));
     assert(invoked);
 }
@@ -332,7 +332,7 @@ void ClientModel::subscribeToCoreSignals()
     m_handler_show_progress = m_node.handleShowProgress(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
     m_handler_notify_num_connections_changed = m_node.handleNotifyNumConnectionsChanged(std::bind(NotifyNumConnectionsChanged, this, std::placeholders::_1));
     m_handler_notify_network_active_changed = m_node.handleNotifyNetworkActiveChanged(std::bind(NotifyNetworkActiveChanged, this, std::placeholders::_1));
-    m_handler_notify_staking_active_changed = m_node.handleNotifyStakingActiveChanged(std::bind(NotifyStakingActiveChanged, this, std::placeholders::_1));
+    m_handler_notify_nodestaking_active_changed = m_node.handleNotifyNodeStakingActiveChanged(std::bind(NotifyNodeStakingActiveChanged, this, std::placeholders::_1));
     m_handler_notify_alert_changed = m_node.handleNotifyAlertChanged(std::bind(NotifyAlertChanged, this));
     m_handler_banned_list_changed = m_node.handleBannedListChanged(std::bind(BannedListChanged, this));
     m_handler_notify_block_tip = m_node.handleNotifyBlockTip(std::bind(BlockTipChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, false));
@@ -345,7 +345,7 @@ void ClientModel::unsubscribeFromCoreSignals()
     m_handler_show_progress->disconnect();
     m_handler_notify_num_connections_changed->disconnect();
     m_handler_notify_network_active_changed->disconnect();
-    m_handler_notify_staking_active_changed->disconnect();
+    m_handler_notify_nodestaking_active_changed->disconnect();
     m_handler_notify_alert_changed->disconnect();
     m_handler_banned_list_changed->disconnect();
     m_handler_notify_block_tip->disconnect();

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -95,7 +95,7 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;
     std::unique_ptr<interfaces::Handler> m_handler_notify_num_connections_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_network_active_changed;
-    std::unique_ptr<interfaces::Handler> m_handler_notify_staking_active_changed;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_nodestaking_active_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_alert_changed;
     std::unique_ptr<interfaces::Handler> m_handler_banned_list_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
@@ -116,7 +116,7 @@ Q_SIGNALS:
     void numBlocksChanged(int count, const QDateTime& blockDate, double nVerificationProgress, bool header, SynchronizationState sync_state);
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
     void networkActiveChanged(bool networkActive);
-    void stakingActiveChanged(bool stakingActive);
+    void nodeStakingActiveChanged(bool stakingActive);
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
 
@@ -129,7 +129,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void updateNumConnections(int numConnections);
     void updateNetworkActive(bool networkActive);
-    void updateStakingActive(bool stakingActive);
+    void updateNodeStakingActive(bool stakingActive);
     void updateAlert();
     void updateBanlist();
 };

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -96,6 +96,7 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_notify_num_connections_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_network_active_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_nodestaking_active_changed;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_walletstaking_active_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_alert_changed;
     std::unique_ptr<interfaces::Handler> m_handler_banned_list_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
@@ -117,6 +118,7 @@ Q_SIGNALS:
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
     void networkActiveChanged(bool networkActive);
     void nodeStakingActiveChanged(bool stakingActive);
+    void walletStakingActiveChanged(bool stakingActive);
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
 
@@ -130,6 +132,7 @@ public Q_SLOTS:
     void updateNumConnections(int numConnections);
     void updateNetworkActive(bool networkActive);
     void updateNodeStakingActive(bool stakingActive);
+    void updateWalletStakingActive(bool stakingActive);
     void updateAlert();
     void updateBanlist();
 };

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -227,11 +227,11 @@ void WalletFrame::unlockWallet()
         walletView->unlockWallet();
 }
 
-void WalletFrame::lockWallet()
+void WalletFrame::lockWallet(bool lock_wallet)
 {
     WalletView *walletView = currentWalletView();
     if (walletView)
-        walletView->lockWallet();
+        walletView->lockWallet(lock_wallet);
 }
 
 void WalletFrame::enableStaking()

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -106,6 +106,7 @@ void WalletFrame::setCurrentWallet(WalletModel* wallet_model)
     walletStack->setCurrentWidget(walletView);
     walletView->updateEncryptionStatus();
     walletView->updateStakingStatus();
+    walletView->updateStakingActive();
 }
 
 void WalletFrame::removeWallet(WalletModel* wallet_model)

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -234,18 +234,11 @@ void WalletFrame::lockWallet(bool lock_wallet)
         walletView->lockWallet(lock_wallet);
 }
 
-void WalletFrame::enableStaking()
+void WalletFrame::enableStaking(bool enable_staking)
 {
     WalletView *walletView = currentWalletView();
     if (walletView)
-        walletView->enableStaking();
-}
-
-void WalletFrame::disableStaking()
-{
-    WalletView *walletView = currentWalletView();
-    if (walletView)
-        walletView->disableStaking();
+        walletView->enableStaking(enable_staking);
 }
 
 void WalletFrame::usedSendingAddresses()

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -97,8 +97,7 @@ public Q_SLOTS:
     void lockWallet(bool lock_wallet);
 
     /** Enable/Disable staking */
-    void enableStaking();
-    void disableStaking();
+    void enableStaking(bool enable_staking);
 
     /** Show used sending addresses */
     void usedSendingAddresses();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -94,7 +94,7 @@ public Q_SLOTS:
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
-    void lockWallet();
+    void lockWallet(bool lock_wallet);
 
     /** Enable/Disable staking */
     void enableStaking();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -99,6 +99,11 @@ void WalletModel::updateStakingStatus()
     Q_EMIT stakingStatusChanged();
 }
 
+void WalletModel::updateStakingActive()
+{
+    Q_EMIT stakingActiveChanged(m_wallet->getEnableStaking());
+}
+
 void WalletModel::pollBalanceChanged()
 {
     // Avoid recomputing wallet balances unless a TransactionChanged or
@@ -386,7 +391,7 @@ bool WalletModel::setWalletStaking(bool stakingEnabled)
     qDebug() << QString("%1: Staking updated to %2").arg(__func__).arg(stakingEnabled);
     m_wallet->setEnableStaking(stakingEnabled);
     m_node.setStakeWallet(m_wallet->getWalletName(), stakingEnabled);
-    Q_EMIT stakingStatusChanged();
+    Q_EMIT stakingActiveChanged(m_wallet->getEnableStaking());
     return m_wallet->getEnableStaking();
 }
 
@@ -398,7 +403,7 @@ bool WalletModel::getWalletStaking()
 bool WalletModel::setWalletUnlockStaking(bool unlockStaking)
 {
     m_wallet->setUnlockWalletStaking(unlockStaking);
-    Q_EMIT stakingStatusChanged();
+    Q_EMIT stakingActiveChanged(m_wallet->getEnableStaking());
     return m_wallet->getUnlockWalletStaking();
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -57,9 +57,6 @@ WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel
     mintingTableModel = new MintingTableModel(this);
     transactionTableModel = new TransactionTableModel(platformStyle, this);
     recentRequestsTableModel = new RecentRequestsTableModel(this);
-    nAverageStakeWeight = 0;
-    nTotalStakeWeight = 0;
-    updateStakeWeight = true;
 
     subscribeToCoreSignals();
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -385,7 +385,7 @@ bool WalletModel::setWalletLocked(bool locked, const SecureString &passPhrase)
 
 bool WalletModel::setWalletStaking(bool stakingEnabled)
 {
-    qDebug() << QString("%1: Staking updated to %2").arg(__func__).arg(stakingEnabled);
+    qDebug() << QString("WalletModel::%1: Staking updated to %2").arg(__func__).arg(stakingEnabled);
     m_wallet->setEnableStaking(stakingEnabled);
     m_node.setStakeWallet(m_wallet->getWalletName(), stakingEnabled);
     Q_EMIT stakingActiveChanged(m_wallet->getEnableStaking());
@@ -432,7 +432,7 @@ static void NotifyKeyStoreStatusChanged(WalletModel *walletmodel)
 
 static void NotifyWalletStakingStatusChanged(WalletModel *walletmodel)
 {
-    qDebug() << QString("%1: Wallet Staking updated").arg(__func__);
+    qDebug() << QString("WalletModel::%1: Wallet Staking updated").arg(__func__);
     bool invoked = QMetaObject::invokeMethod(walletmodel, "updateStakingStatus", Qt::QueuedConnection);
     assert(invoked);
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -220,6 +220,9 @@ Q_SIGNALS:
     // Staking status of wallet changed
     void stakingStatusChanged();
 
+    // Staking active of wallet changed
+    void stakingActiveChanged(bool staking);
+
     // Signal emitted when wallet needs to be unlocked
     // It is valid behaviour for listeners to keep the wallet locked after this signal;
     // this means that the unlocking failed or was cancelled.
@@ -251,6 +254,8 @@ public Q_SLOTS:
 
     /* Wallet status might have changed */
     void updateStatus();
+    /* Wallet staking active might have changed */
+    void updateStakingActive();
     /* Wallet staking status might have changed */
     void updateStakingStatus();
     /* New transaction, or transaction changed status */

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -163,9 +163,6 @@ public:
     bool isMultiwallet();
 
     bool GetStakeWeight(uint64_t& nAverageWeight, uint64_t& nTotalWeight);
-    std::atomic<bool> updateStakeWeight;
-    uint64_t nAverageStakeWeight;
-    uint64_t nTotalStakeWeight;
 
     AddressTableModel* getAddressTableModel() const { return addressTableModel; }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -177,6 +177,7 @@ private:
     std::unique_ptr<interfaces::Wallet> m_wallet;
     std::unique_ptr<interfaces::Handler> m_handler_unload;
     std::unique_ptr<interfaces::Handler> m_handler_status_changed;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_walletstaking_status_changed;
     std::unique_ptr<interfaces::Handler> m_handler_address_book_changed;
     std::unique_ptr<interfaces::Handler> m_handler_transaction_changed;
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;
@@ -250,6 +251,8 @@ public Q_SLOTS:
 
     /* Wallet status might have changed */
     void updateStatus();
+    /* Wallet staking status might have changed */
+    void updateStakingStatus();
     /* New transaction, or transaction changed status */
     void updateTransaction();
     /* New, updated or removed address book entry */

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -31,6 +31,7 @@
 #include <QActionGroup>
 #include <QApplication>
 #include <QClipboard>
+#include <QDebug>
 #include <QFileDialog>
 #include <QHBoxLayout>
 #include <QProgressDialog>
@@ -280,6 +281,7 @@ void WalletView::updateEncryptionStatus()
 
 void WalletView::updateStakingStatus()
 {
+    qDebug() << QString("%1: Staking updated").arg(__func__);
     Q_EMIT stakingStatusChanged();
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -136,9 +136,12 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
         connect(_walletModel, &WalletModel::encryptionStatusChanged, this, &WalletView::encryptionStatusChanged);
         updateEncryptionStatus();
 
+        // Handle changes in staking active
+        connect(_walletModel, &WalletModel::stakingActiveChanged, this, &WalletView::stakingActiveChanged);
+        updateStakingActive();
+
         // Handle changes in staking status
         connect(_walletModel, &WalletModel::stakingStatusChanged, this, &WalletView::stakingStatusChanged);
-        updateStakingStatus();
 
         // update HD status
         Q_EMIT hdEnabledStatusChanged();
@@ -277,6 +280,12 @@ void WalletView::showOutOfSyncWarning(bool fShow)
 void WalletView::updateEncryptionStatus()
 {
     Q_EMIT encryptionStatusChanged();
+}
+
+void WalletView::updateStakingActive()
+{
+    qDebug() << QString("%1: Staking updated to %2").arg(__func__).arg(walletModel->getWalletStaking());
+    Q_EMIT stakingActiveChanged(walletModel->getWalletStaking());
 }
 
 void WalletView::updateStakingStatus()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -284,13 +284,13 @@ void WalletView::updateEncryptionStatus()
 
 void WalletView::updateStakingActive()
 {
-    qDebug() << QString("%1: Staking updated to %2").arg(__func__).arg(walletModel->getWalletStaking());
+    qDebug() << QString("WalletView::%1: Staking updated to %2").arg(__func__).arg(walletModel->getWalletStaking());
     Q_EMIT stakingActiveChanged(walletModel->getWalletStaking());
 }
 
 void WalletView::updateStakingStatus()
 {
-    qDebug() << QString("%1: Staking updated").arg(__func__);
+    qDebug() << QString("WalletView::%1: Staking updated").arg(__func__);
     Q_EMIT stakingStatusChanged();
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -353,20 +353,12 @@ void WalletView::lockWallet(bool lock_wallet)
     }
 }
 
-void WalletView::enableStaking()
+void WalletView::enableStaking(bool enable_staking)
 {
     if(!walletModel)
         return;
 
-    walletModel->setWalletStaking(true);
-}
-
-void WalletView::disableStaking()
-{
-    if(!walletModel)
-        return;
-
-    walletModel->setWalletStaking(false);
+    walletModel->setWalletStaking(enable_staking);
 }
 
 void WalletView::usedSendingAddresses()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -334,13 +334,23 @@ void WalletView::unlockWallet()
     }
 }
 
-void WalletView::lockWallet()
+void WalletView::lockWallet(bool lock_wallet)
 {
-    if(!walletModel)
+    if (!walletModel)
         return;
-    // Lock wallet when requested by wallet model
-    walletModel->setWalletLocked(true);
 
+    if (lock_wallet) {
+        // Lock wallet when requested by wallet model
+        walletModel->setWalletLocked(lock_wallet);
+        return;
+    }
+
+    // Unlock wallet when requested by wallet model
+    if (walletModel->getEncryptionStatus() == WalletModel::Locked) {
+        AskPassphraseDialog dlg(AskPassphraseDialog::Unlock, this);
+        dlg.setModel(walletModel);
+        dlg.exec();
+    }
 }
 
 void WalletView::enableStaking()

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -108,8 +108,7 @@ public Q_SLOTS:
     void lockWallet(bool lock_wallet);
 
     /** Enable/Disable staking */
-    void enableStaking();
-    void disableStaking();
+    void enableStaking(bool enable_staking);
 
     /** Show used sending addresses */
     void usedSendingAddresses();

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -105,7 +105,7 @@ public Q_SLOTS:
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
-    void lockWallet();
+    void lockWallet(bool lock_wallet);
 
     /** Enable/Disable staking */
     void enableStaking();

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -118,6 +118,9 @@ public Q_SLOTS:
     /** Re-emit encryption status signal */
     void updateEncryptionStatus();
 
+    /** Re-emit staking active signal */
+    void updateStakingActive();
+
     /** Re-emit staking status signal */
     void updateStakingStatus();
 
@@ -132,6 +135,8 @@ Q_SIGNALS:
     void message(const QString &title, const QString &message, unsigned int style);
     /** Encryption status of wallet changed */
     void encryptionStatusChanged();
+    /** Staking active of wallet changed */
+    void stakingActiveChanged(bool staking);
     /** Staking status of wallet changed */
     void stakingStatusChanged();
     /** HD-Enabled status of wallet changed (only possible during startup) */

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -95,6 +95,7 @@ bool CStakeman::Start()
     if (!fStakingActive) {
         return false;
     }
+    uiInterface.NotifyNodeStakingActiveChanged(fStakingActive);
     InitWallets();
     LogPrintf("CStakeman::%s\n", __func__);
 
@@ -187,7 +188,7 @@ void CStakeman::StopThreads()
         tm_.clear();
     }
 
-    uiInterface.NotifyStakingActiveChanged(false);
+    uiInterface.NotifyNodeStakingActiveChanged(false);
     LogPrintf("CStakeman::%s done!\n", __func__);
 }
 
@@ -201,8 +202,6 @@ void CStakeman::SetStakingActive(bool active)
 
     fStakingActive = active;
     gArgs.ForceSetArg("-staking", active ? "1" : "0");
-
-    uiInterface.NotifyStakingActiveChanged(fStakingActive);
 }
 
 void CStakeman::StakeWalletAdd(const std::string& walletname)
@@ -246,7 +245,6 @@ void CStakeman::StakeWalletRemove(const std::string& walletname)
 
         tm_.erase(walletname);
         LogPrintf("CStakeman::%s Thread %s removed\n", __func__, walletname);
-        uiInterface.NotifyStakingActiveChanged(false);
     }
 }
 
@@ -263,7 +261,7 @@ void CStakeman::ThreadStaker(CWallet* pwallet, ChainstateManager* chainman, CCon
     }
     pwallet->SetLastCoinStakeSearchInterval(0);
     LogPrintf("CStakeman::%s Staking thread [%s] stopped\n", __func__, thread_id);
-    uiInterface.NotifyStakingActiveChanged(false);
+    uiInterface.NotifyNodeStakingActiveChanged(false);
 }
 
 

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -224,7 +224,7 @@ void CStakeman::StakeWalletAdd(const std::string& walletname)
                 }
 
                 LogPrintf("CStakeman::%s Launching wallet..  [%s]\n", __func__, wallet->GetName());
-                uiInterface.NotifyStakingActiveChanged(true);
+                uiInterface.NotifyWalletStakingActiveChanged(true);
             }
         }
     }
@@ -245,6 +245,7 @@ void CStakeman::StakeWalletRemove(const std::string& walletname)
 
         tm_.erase(walletname);
         LogPrintf("CStakeman::%s Thread %s removed\n", __func__, walletname);
+        uiInterface.NotifyWalletStakingActiveChanged(false);
     }
 }
 

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -5,6 +5,7 @@
 #include <staker.h>
 
 #include <fs.h>
+#include <interfaces/wallet.h>
 #include <logging.h>
 #include <miner.h>
 #include <net_processing.h>
@@ -224,7 +225,7 @@ void CStakeman::StakeWalletAdd(const std::string& walletname)
                 }
 
                 LogPrintf("CStakeman::%s Launching wallet..  [%s]\n", __func__, wallet->GetName());
-                uiInterface.NotifyWalletStakingActiveChanged(true);
+                wallet.get()->NotifyWalletStakingStatusChanged();
             }
         }
     }
@@ -262,7 +263,7 @@ void CStakeman::ThreadStaker(CWallet* pwallet, ChainstateManager* chainman, CCon
     }
     pwallet->SetLastCoinStakeSearchInterval(0);
     LogPrintf("CStakeman::%s Staking thread [%s] stopped\n", __func__, thread_id);
-    uiInterface.NotifyNodeStakingActiveChanged(false);
+    pwallet->NotifyWalletStakingStatusChanged();
 }
 
 

--- a/src/staker.h
+++ b/src/staker.h
@@ -51,7 +51,7 @@ public:
     {
         StopThreads();
     };
-    bool GetStakingActive() const { return fStakingActive; };
+    bool GetNodeStakingActive() const { return fStakingActive; };
     void SetStakingActive(bool active);
     int GetStakingThreadCount()
     {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -507,6 +507,10 @@ public:
     {
         return MakeHandler(m_wallet->NotifyStatusChanged.connect([fn](CWallet*) { fn(); }));
     }
+    std::unique_ptr<Handler> handleNotifyWalletStakingStatusChanged(NotifyWalletStakingStatusChangedFn fn) override
+    {
+        return MakeHandler(m_wallet->NotifyWalletStakingStatusChanged.connect(fn));
+    }
     std::unique_ptr<Handler> handleAddressBookChanged(AddressBookChangedFn fn) override
     {
         return MakeHandler(m_wallet->NotifyAddressBookChanged.connect(

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -786,6 +786,10 @@ public:
      * Note: Called without locks held.
      */
     boost::signals2::signal<void (CWallet* wallet)> NotifyStatusChanged;
+    /**
+     * Walletstaking status
+     */
+    boost::signals2::signal<void ()> NotifyWalletStakingStatusChanged;
 
     /** Inquire whether this wallet broadcasts transactions. */
     bool GetBroadcastTransactions() const { return fBroadcastTransactions; }


### PR DESCRIPTION
The goal of this pull request is to improve the UI notifications for staking status.

It removed the usage of 2 custom classes and took advantage of GUIUtil::ClickableLabel

Split node and wallet staking signals

closes #289 