### PR TITLE
gui: create theme chooser

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -373,6 +373,10 @@ public Q_SLOTS:
     void showProgress(const QString &title, int nProgress);
 
     void showModalOverlay();
+
+    void updateStyle(const QString &styleName);
+
+    void updateTheme(const QString &themeName);
 };
 
 class UnitDisplayStatusBarControl : public QLabel

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>560</width>
-    <height>440</height>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -51,20 +51,20 @@
         </spacer>
        </item>
        <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_Main_Prune">
-        <item>
-         <widget class="QCheckBox" name="prune">
-          <property name="toolTip">
-           <string>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</string>
-          </property>
-          <property name="text">
-           <string>Prune &amp;block storage to</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="pruneSize"/>
-        </item>
+        <layout class="QHBoxLayout" name="horizontalLayout_Main_Prune">
+         <item>
+          <widget class="QCheckBox" name="prune">
+           <property name="toolTip">
+            <string>Enabling pruning significantly reduces the disk space required to store transactions. All blocks are still fully validated. Reverting this setting requires re-downloading the entire blockchain.</string>
+           </property>
+           <property name="text">
+            <string>Prune &amp;block storage to</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="pruneSize"/>
+         </item>
          <item>
           <widget class="QLabel" name="pruneSizeUnitLabel">
            <property name="text">
@@ -235,27 +235,27 @@
           <string>External Signer (e.g. hardware wallet)</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayoutHww">
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayoutHww">
-             <item>
-              <widget class="QLabel" name="externalSignerPathLabel">
-               <property name="text">
-                <string>&amp;External signer script path</string>
-               </property>
-               <property name="buddy">
-                <cstring>externalSignerPath</cstring>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="externalSignerPath">
-                <property name="toolTip">
-                  <string>Full path to a Reddcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</string>
-                </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayoutHww">
+            <item>
+             <widget class="QLabel" name="externalSignerPathLabel">
+              <property name="text">
+               <string>&amp;External signer script path</string>
+              </property>
+              <property name="buddy">
+               <cstring>externalSignerPath</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="externalSignerPath">
+              <property name="toolTip">
+               <string>Full path to a Reddcoin Core compatible script (e.g. C:\Downloads\hwi.exe or /Users/you/Downloads/hwi.py). Beware: malware can steal your coins!</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>
@@ -663,6 +663,42 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_1_Display">
          <item>
+          <widget class="QLabel" name="styleLabel">
+           <property name="text">
+            <string>User Interface Style:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QValueComboBox" name="style">
+           <property name="toolTip">
+            <string>Choose the default theme to display on the UI.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2_Display">
+         <item>
+          <widget class="QLabel" name="themeLabel">
+           <property name="text">
+            <string>User Interface Theme:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QValueComboBox" name="theme">
+           <property name="toolTip">
+            <string>Choose the default theme to display on the UI.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3_Display">
+         <item>
           <widget class="QLabel" name="langLabel">
            <property name="text">
             <string>User Interface &amp;language:</string>
@@ -685,7 +721,7 @@
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2_Display">
+        <layout class="QHBoxLayout" name="horizontalLayout_4_Display">
          <item>
           <widget class="QLabel" name="unitLabel">
            <property name="text">
@@ -709,7 +745,7 @@
         </layout>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3_Display">
+        <layout class="QHBoxLayout" name="horizontalLayout_5_Display">
          <item>
           <widget class="QLabel" name="thirdPartyTxUrlsLabel">
            <property name="toolTip">
@@ -851,35 +887,35 @@
       </layout>
      </widget>
      <widget class="QWidget" name="tabUpdate">
-            <attribute name="title">
-                <string>&amp;Update</string>
-            </attribute>
-            <layout class="QVBoxLayout" name="verticalLayout_Window">
-                <item>
-                    <widget class="QCheckBox" name="checkGithub">
-                        <property name="toolTip">
-                            <string>Whether to check official github  repository for wallet updates on startup.</string>
-                        </property>
-                        <property name="text">
-                            <string>&amp;Check github for updates on startup</string>
-                        </property>
-                    </widget>
-                </item>
-                <item>
-                    <spacer name="verticalSpacer_Update">
-                        <property name="orientation">
-                            <enum>Qt::Vertical</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                            <size>
-                                <width>20</width>
-                                <height>40</height>
-                            </size>
-                        </property>
-                    </spacer>
-                </item>
-            </layout>
+      <attribute name="title">
+       <string>&amp;Update</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_Update">
+       <item>
+        <widget class="QCheckBox" name="checkGithub">
+         <property name="toolTip">
+          <string>Whether to check official github  repository for wallet updates on startup.</string>
+         </property>
+         <property name="text">
+          <string>&amp;Check github for updates on startup</string>
+         </property>
         </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_Update">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -983,7 +1019,6 @@
        </property>
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -26,6 +26,8 @@
 #include <QLocale>
 #include <QMessageBox>
 #include <QSettings>
+#include <QStyle>
+#include <QStyleFactory>
 #include <QSystemTrayIcon>
 #include <QTimer>
 
@@ -72,6 +74,32 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->proxyIpTor->setEnabled(false);
     ui->proxyPortTor->setEnabled(false);
     ui->proxyPortTor->setValidator(new QIntValidator(1, 65535, this));
+
+    const QString defaultStyleName = QApplication::style()->objectName();
+    QStringList styleNames = QStyleFactory::keys();
+
+    QDir styles(":themes");
+
+    for (const QString& styleStr : styles.entryList()) {
+        styleNames.append(styleStr);
+    }
+
+    for (int i = 1, size = styleNames.size(); i < size; ++i) {
+        if (defaultStyleName.compare(styleNames.at(i), Qt::CaseInsensitive) == 0) {
+            styleNames.swap(0, i);
+            break;
+        }
+    }
+
+    ui->style->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
+
+    for (const QString& stylename : styleNames) {
+	    ui->style->addItem(stylename, QVariant(stylename));
+    }
+
+    ui->theme->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
+    ui->theme->addItem(tr("Dark"), QVariant("dark"));
+    ui->theme->addItem(tr("Light"), QVariant("light"));
 
     connect(ui->connectSocks, &QPushButton::toggled, ui->proxyIp, &QWidget::setEnabled);
     connect(ui->connectSocks, &QPushButton::toggled, ui->proxyPort, &QWidget::setEnabled);
@@ -274,6 +302,8 @@ void OptionsDialog::setMapper()
     /* Display */
     mapper->addMapping(ui->lang, OptionsModel::Language);
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
+    mapper->addMapping(ui->style, OptionsModel::Style);
+    mapper->addMapping(ui->theme, OptionsModel::Theme);
     mapper->addMapping(ui->thirdPartyTxUrls, OptionsModel::ThirdPartyTxUrls);
     mapper->addMapping(ui->embeddedFont_radioButton, OptionsModel::UseEmbeddedMonospacedFont);
 }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -85,6 +85,14 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("fCoinControlFeatures", false);
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
 
+    if (!settings.contains("strTheme"))
+        settings.setValue("strTheme", "");
+    strTheme = settings.value("strTheme").toString();
+
+    if (!settings.contains("strStyle"))
+        settings.setValue("strStyle", "");
+    strStyle = settings.value("strStyle").toString();
+
     // These are shared with the core or have a command-line parameter
     // and we want command-line parameters to overwrite the GUI settings.
     //
@@ -350,6 +358,10 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return strThirdPartyTxUrls;
         case Language:
             return settings.value("language");
+        case Theme:
+            return strTheme;
+        case Style:
+            return strStyle;
         case UseEmbeddedMonospacedFont:
             return m_use_embedded_monospaced_font;
         case CoinControlFeatures:
@@ -491,6 +503,12 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 setRestartRequired(true);
             }
             break;
+        case Theme:
+            setUITheme(value);
+            break;
+        case Style:
+            setUIStyle(value);
+            break;
         case UseEmbeddedMonospacedFont:
             m_use_embedded_monospaced_font = value.toBool();
             settings.setValue("UseEmbeddedMonospacedFont", m_use_embedded_monospaced_font);
@@ -553,6 +571,27 @@ void OptionsModel::setDisplayUnit(const QVariant &value)
     }
 }
 
+void OptionsModel::setUITheme(const QVariant &value)
+{
+    if (!value.isNull())
+    {
+        QSettings settings;
+        strTheme = value.toString();
+        settings.setValue("strTheme", strTheme);
+        Q_EMIT uiThemeChanged(strTheme);
+    }
+}
+
+void OptionsModel::setUIStyle(const QVariant &value)
+{
+    if (!value.isNull())
+    {
+        QSettings settings;
+        strStyle = value.toString();
+        settings.setValue("strStyle", strStyle);
+        Q_EMIT uiStyleChanged(strStyle);
+    }
+}
 void OptionsModel::setRestartRequired(bool fRequired)
 {
     QSettings settings;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -60,6 +60,8 @@ public:
         DisplayUnit,            // BitcoinUnits::Unit
         ThirdPartyTxUrls,       // QString
         Language,               // QString
+        Style,                  // QString
+        Theme,                  // QString
         UseEmbeddedMonospacedFont, // bool
         CoinControlFeatures,    // bool
         ThreadsScriptVerif,     // int
@@ -81,6 +83,10 @@ public:
     bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
     /** Updates current unit in memory, settings and emits displayUnitChanged(newUnit) signal */
     void setDisplayUnit(const QVariant &value);
+    /** Updates current theme and emits uiThemeChanged(newTheme) signal */
+    void setUITheme(const QVariant &value);
+    /** Updates current style and emits uiStyleChanged(newStyle) signal */
+    void setUIStyle(const QVariant &value);
 
     /* Explicit getters */
     bool getShowTrayIcon() const { return m_show_tray_icon; }
@@ -91,6 +97,8 @@ public:
     bool getUseEmbeddedMonospacedFont() const { return m_use_embedded_monospaced_font; }
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
+    QString getTheme() const { return strTheme; }
+    QString getStyle() const { return strStyle; }
 
     /* Explicit setters */
     void SetPruneEnabled(bool prune, bool force = false);
@@ -110,6 +118,8 @@ private:
     bool fMinimizeToTray;
     bool fMinimizeOnClose;
     QString language;
+    QString strTheme;
+    QString strStyle;
     int nDisplayUnit;
     QString strThirdPartyTxUrls;
     bool m_use_embedded_monospaced_font;
@@ -127,6 +137,8 @@ Q_SIGNALS:
     void coinControlFeaturesChanged(bool);
     void showTrayIconChanged(bool);
     void useEmbeddedMonospacedFontChanged(bool);
+    void uiThemeChanged(QString themeName);
+    void uiStyleChanged(QString styleName);
 };
 
 #endif // BITCOIN_QT_OPTIONSMODEL_H

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -8,6 +8,7 @@
 #include <QColor>
 #include <QImage>
 #include <QPalette>
+#include <QStyle>
 
 static const struct {
     const char *platformId;
@@ -135,3 +136,67 @@ const PlatformStyle *PlatformStyle::instantiate(const QString &platformId)
     return nullptr;
 }
 
+void PlatformStyle::SetTheme(const QString& themeName) const
+{
+    QPalette palette;
+
+    if (themeName == "") {
+        palette = QApplication::style()->standardPalette();
+
+    } else if (themeName == "dark") {
+        QPalette darkPalette;
+        // modify palette to dark
+        darkPalette.setColor(QPalette::Window, QColor(53, 53, 53));
+        darkPalette.setColor(QPalette::WindowText, Qt::white);
+        darkPalette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));
+        darkPalette.setColor(QPalette::Base, QColor(42, 42, 42));
+        darkPalette.setColor(QPalette::AlternateBase, QColor(66, 66, 66));
+        darkPalette.setColor(QPalette::ToolTipBase, Qt::white);
+        darkPalette.setColor(QPalette::ToolTipText, QColor(53, 53, 53));
+        darkPalette.setColor(QPalette::Text, Qt::white);
+        darkPalette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+        darkPalette.setColor(QPalette::Dark, QColor(35, 35, 35));
+        darkPalette.setColor(QPalette::Shadow, QColor(20, 20, 20));
+        darkPalette.setColor(QPalette::Button, QColor(53, 53, 53));
+        darkPalette.setColor(QPalette::ButtonText, Qt::white);
+        darkPalette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127));
+        darkPalette.setColor(QPalette::BrightText, Qt::red);
+        darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
+        darkPalette.setColor(QPalette::Highlight, QColor(255, 147, 51));
+        darkPalette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+        // darkPalette.setColor(QPalette::HighlightedText, Qt::white);
+        darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+        darkPalette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(127, 127, 127));
+
+        palette = darkPalette;
+    }
+
+    else if (themeName == "light") {
+        QPalette lightPalette;
+        // modify palette to light
+        lightPalette = QApplication::style()->standardPalette();
+        lightPalette.setColor(QPalette::Window, QColor(240, 240, 240));
+        lightPalette.setColor(QPalette::WindowText, QColor(0, 0, 0));
+        lightPalette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(120, 120, 120));
+        lightPalette.setColor(QPalette::Base, QColor(255, 255, 255));
+        lightPalette.setColor(QPalette::AlternateBase, QColor(233, 231, 227));
+        lightPalette.setColor(QPalette::ToolTipBase, QColor(255, 255, 220));
+        lightPalette.setColor(QPalette::ToolTipText, QColor(0, 0, 0));
+        lightPalette.setColor(QPalette::Text, QColor(0, 0, 0));
+        lightPalette.setColor(QPalette::Disabled, QPalette::Text, QColor(120, 120, 120));
+        lightPalette.setColor(QPalette::Dark, QColor(160, 160, 160));
+        lightPalette.setColor(QPalette::Shadow, QColor(105, 105, 105));
+        lightPalette.setColor(QPalette::Button, QColor(240, 240, 240));
+        lightPalette.setColor(QPalette::ButtonText, QColor(0, 0, 0));
+        lightPalette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(120, 120, 120));
+        lightPalette.setColor(QPalette::BrightText, QColor(0, 0, 255));
+        lightPalette.setColor(QPalette::Link, QColor(51, 153, 255));
+        lightPalette.setColor(QPalette::Highlight, QColor(0, 0, 255));
+        lightPalette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(51, 153, 255));
+        lightPalette.setColor(QPalette::HighlightedText, QColor(255, 255, 255));
+        lightPalette.setColor(QPalette::Disabled, QPalette::HighlightedText, QColor(255, 255, 255));
+
+        palette = lightPalette;
+    }
+    QApplication::setPalette(palette);
+}

--- a/src/qt/platformstyle.h
+++ b/src/qt/platformstyle.h
@@ -36,6 +36,8 @@ public:
     /** Colorize an icon (given object) with the text color */
     QIcon TextColorIcon(const QIcon& icon) const;
 
+    void SetTheme(const QString& themeName) const;
+
 private:
     PlatformStyle(const QString &name, bool imagesOnButtons, bool colorizeIcons, bool useExtraSpacing);
 

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -316,3 +316,15 @@ void ReceiveCoinsDialog::copyAmount()
 {
     copyColumnToClipboard(RecentRequestsTableModel::Amount);
 }
+
+void ReceiveCoinsDialog::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::PaletteChange) {
+        ui->clearButton->setIcon(platformStyle->SingleColorIcon(":/icons/remove"));
+        ui->receiveButton->setIcon(platformStyle->SingleColorIcon(":/icons/receiving_addresses"));
+        ui->showRequestButton->setIcon(platformStyle->SingleColorIcon(":/icons/edit"));
+        ui->removeRequestButton->setIcon(platformStyle->SingleColorIcon(":/icons/remove"));
+    }
+
+    QDialog::changeEvent(e);
+}

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -49,6 +49,10 @@ public Q_SLOTS:
     void reject() override;
     void accept() override;
 
+protected:
+    /** So that it updates icons */
+    void changeEvent(QEvent* e) override;
+
 private:
     Ui::ReceiveCoinsDialog *ui;
     WalletModel *model;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -914,6 +914,7 @@ void RPCConsole::changeEvent(QEvent* e)
         ui->fontBiggerButton->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/fontbigger")));
         ui->fontSmallerButton->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/fontsmaller")));
         ui->promptIcon->setIcon(platformStyle->SingleColorIcon(QStringLiteral(":/icons/prompticon")));
+        ui->openDebugLogfileButton->setIcon(platformStyle->SingleColorIcon(":/icons/export"));
 
         for (int i = 0; ICON_MAPPING[i].url; ++i) {
             ui->messagesWidget->document()->addResource(

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -52,7 +52,7 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     QHBoxLayout *hbox_buttons = new QHBoxLayout();
     transactionView = new TransactionView(platformStyle, this);
     vbox->addWidget(transactionView);
-    QPushButton *exportButton = new QPushButton(tr("&Export"), this);
+    exportButton = new QPushButton(tr("&Export"), this);
     exportButton->setToolTip(tr("Export the data in the current tab to a file"));
     if (platformStyle->getImagesOnButtons()) {
         exportButton->setIcon(platformStyle->SingleColorIcon(":/icons/export"));
@@ -409,4 +409,13 @@ void WalletView::showProgress(const QString &title, int nProgress)
             progressDialog->setValue(nProgress);
         }
     }
+}
+
+void WalletView::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::PaletteChange) {
+        exportButton->setIcon(platformStyle->SingleColorIcon(":/icons/export"));
+    }
+
+    QStackedWidget::changeEvent(e);
 }

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -8,6 +8,7 @@
 
 #include <amount.h>
 
+#include <QPushButton>
 #include <QStackedWidget>
 
 class ClientModel;
@@ -24,6 +25,7 @@ class AddressBookPage;
 QT_BEGIN_NAMESPACE
 class QModelIndex;
 class QProgressDialog;
+class QPushButton;
 QT_END_NAMESPACE
 
 /*
@@ -55,6 +57,10 @@ public:
 
     void showOutOfSyncWarning(bool fShow);
 
+protected:
+    /** So that it updates icons */
+    void changeEvent(QEvent* e) override;
+
 private:
     ClientModel *clientModel;
     WalletModel *walletModel;
@@ -66,6 +72,7 @@ private:
     SendCoinsDialog *sendCoinsPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
+    QPushButton *exportButton = nullptr;
 
     TransactionView *transactionView;
     MintingView *mintingView;


### PR DESCRIPTION
Add feature to select themes and styles from the UI

Current options 
- Default
- Dark
- Light

Add 2 themes (Dark and Light)
Provide a method to save settings for persistence
Update some of the UI to use QPalette where needed
Add some missing ::changeEvent to widgets to allow for updates when palette is switched

 closes #234 
