### PR TITLE
init: check config for prune mode being enabled on start and disable

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -98,6 +98,8 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("bPrune", false);
     if (!settings.contains("nPruneSize"))
         settings.setValue("nPruneSize", DEFAULT_PRUNE_TARGET_GB);
+    if (settings.value("bPrune").toBool()) // Reddcoin does not support blockchain pruning, disable if previously enabled
+        settings.setValue("bPrune", false);
     SetPruneEnabled(settings.value("bPrune").toBool());
 
     if (!settings.contains("nDatabaseCache"))


### PR DESCRIPTION
prune mode is incompatible with Reddcoin

Check the setting in config file when starting, and set to false if it is enabled

closes #270 