### PR TITLE
gui: fix for lockwallet not working from menu

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -500,7 +500,7 @@ void BitcoinGUI::createActions()
         connect(backupWalletAction, &QAction::triggered, walletFrame, &WalletFrame::backupWallet);
         connect(changePassphraseAction, &QAction::triggered, walletFrame, &WalletFrame::changePassphrase);
         connect(unlockWalletAction, &QAction::triggered, walletFrame, &WalletFrame::unlockWallet);
-        connect(lockWalletAction, &QAction::triggered, walletFrame, &WalletFrame::lockWallet);
+        connect(lockWalletAction, &QAction::triggered, [this]{walletFrame->lockWallet(true); });
         connect(enableStakingAction, &QAction::triggered, [this]{ walletFrame->enableStaking(true); });
         connect(disableStakingAction, &QAction::triggered, [this]{ walletFrame->enableStaking(false); });
 


### PR DESCRIPTION
This PR fixes the lock wallet menu item

closes #308 