### PR TITLE
net: fix thread-safety analysis error in ProcessMessage

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3001,6 +3001,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         const auto current_time = GetTime<std::chrono::microseconds>();
         uint256* best_block{nullptr};
+        CNodeState* node_state = State(pfrom.GetId());
 
         for (CInv& inv : vInv) {
             if (interruptMsgProc) return;
@@ -3008,7 +3009,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             // Ignore INVs that don't match wtxidrelay setting.
             // Note that orphan parent fetching always uses MSG_TX GETDATAs regardless of the wtxidrelay setting.
             // This is fine as no INV messages are involved in that process.
-            if (State(pfrom.GetId())->m_wtxid_relay) {
+            if (node_state->m_wtxid_relay) {
                 if (inv.IsMsgTx()) continue;
             } else {
                 if (inv.IsMsgWtx()) continue;
@@ -3057,14 +3058,13 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             // block to sync with as well, to sync quicker in the case where
             // our initial peer is unresponsive (but less bandwidth than we'd
             // use if we turned on sync with all peers).
-            CNodeState& state{*Assert(State(pfrom.GetId()))};
-            if (state.fSyncStarted || (!peer->m_inv_triggered_getheaders_before_sync && *best_block != m_last_block_inv_triggering_headers_sync)) {
+            if (node_state->fSyncStarted || (!peer->m_inv_triggered_getheaders_before_sync && *best_block != m_last_block_inv_triggering_headers_sync)) {
                 if (MaybeSendGetHeaders(pfrom, m_chainman.ActiveChain().GetLocator(pindexBestHeader), *peer)) {
                     LogPrint(BCLog::NET, "getheaders (%d) %s to peer=%d\n",
                             pindexBestHeader->nHeight, best_block->ToString(),
                             pfrom.GetId());
                 }
-                if (!state.fSyncStarted) {
+                if (!node_state->fSyncStarted) {
                     peer->m_inv_triggered_getheaders_before_sync = true;
                     // Update the last block hash that triggered a new headers
                     // sync, so that we don't turn on headers sync with more


### PR DESCRIPTION
Problem

  In PeerManagerImpl::ProcessMessage(), the INV message handler calls State(pfrom.GetId()) multiple times within a LOCK(cs_main) scope. The thread-safety analyzer is conservative about the lock being held after potential early returns in the inventory processing loop (line 3007: if (interruptMsgProc) return;).

  While the lock is technically held, calling State() multiple times is inefficient and confuses the static analyzer.

  Solution

  Cache the CNodeState* pointer once at the beginning of the locked section and reuse it throughout the function. This:
  - Satisfies the thread-safety analyzer
  - Improves performance by avoiding redundant lookups
  - Makes the code cleaner

  Affected Code

  File: src/net_processing.cppLines: ~3000-3075 (INV message handler in ProcessMessage)

Reuse CNodeState pointer instead of calling State() multiple times to satisfy thread-safety analyzer. The analyzer was conservative about the lock being held after potential early returns in the loop.

closes #332 
