### PR TITLE
validation: set nTimeMax during block index creation

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3083,8 +3083,8 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block)
         pindexNew->nHeight = pindexNew->pprev->nHeight + 1;
         pindexNew->BuildSkip();
     }
-
     pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
+    pindexNew->nTimeMax = (pindexNew->pprev ? std::max(pindexNew->pprev->nTimeMax, pindexNew->nTime) : pindexNew->nTime);
     pindexNew->RaiseValidity(BLOCK_VALID_TREE);
     if (pindexBestHeader == nullptr || pindexBestHeader->nChainWork < pindexNew->nChainWork)
         pindexBestHeader = pindexNew;


### PR DESCRIPTION

 ## Fix nTimeMax Initialization in AddToBlockIndex

  ### Summary
  Fixes bug where `nTimeMax` was not set when creating new block indexes, causing `GetBlockTimeMax()` to return 0 for freshly processed blocks. This led to mocktime issues in tests.

  ### The Bug
  ```cpp
  // AddToBlockIndex() - missing nTimeMax initialization
  pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
  // nTimeMax not set here!
  pindexNew->RaiseValidity(BLOCK_VALID_TREE);

  Two code paths set block index fields:
  1. LoadBlockIndex() - loads from disk, sets nTimeMax ✅
  2. AddToBlockIndex() - processes new blocks, missing nTimeMax ❌

  Impact:
  - Freshly created blocks had nTimeMax = 0
  - GetBlockTimeMax() returned 0 instead of actual time
  - Tests using mocktime would reset to epoch time (1970-01-01)
  - Inconsistent behavior between loaded and newly created blocks

  The Fix

  // Now sets nTimeMax consistently with LoadBlockIndex formula
  pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
  pindexNew->nTimeMax = (pindexNew->pprev ? std::max(pindexNew->pprev->nTimeMax, pindexNew->nTime) : pindexNew->nTime);
  pindexNew->RaiseValidity(BLOCK_VALID_TREE);

  Formula: nTimeMax = max(parent->nTimeMax, current_block->nTime)

  This matches the logic already present in LoadBlockIndex(), ensuring consistency.

  Use Case for nTimeMax

  nTimeMax tracks the maximum timestamp seen in a chain fork. Used by:
  - GetBlockTimeMax() - returns max time for chain selection
  - Test frameworks - mocktime calculations
  - Chain comparison logic

  Impact

  - Tests: Fixes mocktime reset issues
  - Production: Ensures consistent nTimeMax calculation
  - Chain validation: Proper timestamp tracking for all blocks

  Files Changed

  - src/validation.cpp - Add nTimeMax initialization in AddToBlockIndex