### PR TITLE
rpc: fix setstaking to actually start staking threads

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -304,7 +304,19 @@ static RPCHelpMan setstaking()
                 } else if (pwallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
                     result.pushKV("error", "Blank wallet flag set.");
                 } else {
-                    pwallet->SetEnableStaking(request.params[0].getBool());
+                    bool enable = request.params[0].getBool();
+                    pwallet->SetEnableStaking(enable);
+
+                    // Notify CStakeman to start/stop staking thread for this wallet
+                    NodeContext& node = EnsureAnyNodeContext(request.context);
+                    if (node.stakeman) {
+                        if (enable) {
+                            node.stakeman->StakeWalletAdd(pwallet->GetName());
+                        } else {
+                            node.stakeman->StakeWalletRemove(pwallet->GetName());
+                        }
+                    }
+
                     if (!request.params[1].isNull()) {
                         interfaces::Chain& chain = pwallet->chain();
                         std::string name = pwallet->GetName();


### PR DESCRIPTION
## Fix setstaking RPC to Actually Start Staking

  ### Summary
  Fixes critical bug where `setstaking true` RPC command only set the wallet flag but never launched the actual staking thread. Wallets appeared enabled for staking but no PoS mining was happening.

  ### The Bug
  ```cpp
  // Before - only sets wallet flag
  pwallet->SetEnableStaking(request.params[0].getBool());
  // CStakeman never notified!
  // Result: flag set, but no staking thread running

  Broken flow:
  1. User calls reddcoin-cli -rpcwallet=test setstaking true
  2. Wallet flag EnableStaking set to true ✅
  3. No staking thread launched ❌
  4. No PoS blocks created ❌

  The Fix

  // After - sets flag AND launches staking thread
  bool enable = request.params[0].getBool();
  pwallet->SetEnableStaking(enable);

  // Notify CStakeman to start/stop staking thread
  NodeContext& node = EnsureAnyNodeContext(request.context);
  if (node.stakeman) {
      if (enable) {
          node.stakeman->StakeWalletAdd(pwallet->GetName());
      } else {
          node.stakeman->StakeWalletRemove(pwallet->GetName());
      }
  }

  Fixed flow:
  1. User calls reddcoin-cli -rpcwallet=test setstaking true
  2. Wallet flag EnableStaking set to true ✅
  3. CStakeman::StakeWalletAdd() called ✅
  4. PoSMiner thread launched for wallet ✅
  5. Staking actively attempts to create PoS blocks ✅

  Impact

  Before this fix:
  - setstaking true appeared to work but didn't actually enable staking
  - Users would think staking was active but earn no rewards
  - Manual wallet restarts or node restarts required to activate staking

  After this fix:
  - setstaking true immediately starts staking thread
  - setstaking false immediately stops staking thread
  - RPC command works as expected and documented

  Use Case

  # Enable staking on a specific wallet
  reddcoin-cli -rpcwallet=mywallet setstaking true

  # Now actually starts staking instead of just setting a flag

  Files Changed

  - src/rpc/mining.cpp - Add CStakeman notification to setstaking RPC