### PR TITLE
rpc: fix generatetoaddress to use Scrypt POW hash and handle PoS blocks

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -125,9 +125,12 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
 
     CChainParams chainparams(Params());
 
-    while (max_tries > 0 && block.nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(UintToArith256(block.GetHash()), block.nBits, chainparams.GetConsensus()) && !ShutdownRequested()) {
-        ++block.nNonce;
-        --max_tries;
+    // Only validate POW for PoW blocks - PoS blocks use different validation
+    if (block.IsProofOfWork()) {
+        while (max_tries > 0 && block.nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(UintToArith256(block.GetPoWHash()), block.nBits, chainparams.GetConsensus()) && !ShutdownRequested()) {
+            ++block.nNonce;
+            --max_tries;
+        }
     }
     if (max_tries == 0 || ShutdownRequested()) {
         return false;


### PR DESCRIPTION
## Fix generatetoaddress to Use Scrypt PoW and Handle PoS Blocks

  ### Summary
  Fixes critical bugs in `GenerateBlock()` used by the `generatetoaddress` RPC command. The function was using the wrong hash function for PoW validation and attempting to mine PoS blocks, causing failures after the PoW→PoS transition in regtest.

  ### Issues Fixed

  **1. Wrong Hash Function**
  ```cpp
  // Before - WRONG hash function
  CheckProofOfWork(UintToArith256(block.GetHash()), ...)

  // After - CORRECT hash function
  CheckProofOfWork(UintToArith256(block.GetPoWHash()), ...)

  Problem:
  - GetHash() returns SHA256d block ID (for block indexing)
  - GetPoWHash() returns Scrypt hash (for mining validation)
  - Reddcoin uses Scrypt for PoW, not SHA256d
  - Mining was validating against wrong hash, causing failures

  2. PoS Block Mining Attempt
  // Before - tried to mine ALL blocks
  while (...&& !CheckProofOfWork(...)) {
      ++block.nNonce;
  }

  // After - only mine PoW blocks
  if (block.IsProofOfWork()) {
      while (...&& !CheckProofOfWork(...)) {
          ++block.nNonce;
      }
  }

  Problem:
  - After PoW→PoS transition (block 30 in regtest), blocks are PoS
  - PoS blocks don't need nonce mining - they use stake validation
  - Code was trying to mine PoS blocks and failing with "nBits below minimum work"

  The Fix

  1. Use GetPoWHash() for Scrypt validation:
  - Returns actual Scrypt hash used for mining
  - Correctly validates against difficulty target

  2. Only mine PoW blocks:
  - Check block.IsProofOfWork() before mining loop
  - PoS blocks skip mining and use stake validation instead

  Impact

  Before this fix:
  # Works for first 30 blocks (PoW)
  reddcoin-cli -regtest generatetoaddress 30 address

  # Fails after block 30 (PoS transition)
  reddcoin-cli -regtest generatetoaddress 1 address
  # Error: "nBits below minimum work" or mining never completes

  After this fix:
  # Works for all blocks
  reddcoin-cli -regtest generatetoaddress 100 address
  # Correctly mines PoW blocks 0-29
  # Correctly creates PoS blocks 30+

  Test Impact

  - ✅ Regtest mining works past PoW→PoS transition
  - ✅ Scrypt PoW validation works correctly
  - ✅ PoS block generation works via RPC

  Files Changed

  - src/rpc/mining.cpp - Fix hash function and add PoW/PoS check