### PR TITLE
miner: fix PoS block creation bugs in CreateNewBlock

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -184,7 +184,12 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         *pfPoSCancel = true;
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
         CMutableTransaction txCoinStake;
+        txCoinStake.nTime = GetAdjustedTime(); // Initialize to current time for stake search
         int64_t nSearchTime = txCoinStake.nTime; // search to current time
+        // Handle mock time reset (e.g. between tests) - if time went backwards, reset search time
+        if (nSearchTime < nLastCoinStakeSearchTime) {
+            nLastCoinStakeSearchTime = nSearchTime - 1;
+        }
         if (nSearchTime > nLastCoinStakeSearchTime)
         {
             if (CreateCoinStake(pwallet, &m_chainstate, pblock->nBits, nSearchTime-nLastCoinStakeSearchTime, txCoinStake, chainparams.GetConsensus()))


### PR DESCRIPTION
## Fix PoS Block Creation Bugs in CreateNewBlock

  ### Summary
  Fixes two critical bugs in `CreateNewBlock()` that prevented PoS block creation in tests. Both issues involved uninitialized/stale time values causing stake validation failures.

  ### Issues Fixed

  **1. Uninitialized txCoinStake.nTime**
  ```cpp
  // Before - UNINITIALIZED
  CMutableTransaction txCoinStake;
  int64_t nSearchTime = txCoinStake.nTime; // Using garbage value!

  // After - INITIALIZED
  CMutableTransaction txCoinStake;
  txCoinStake.nTime = GetAdjustedTime(); // Properly set to current time
  int64_t nSearchTime = txCoinStake.nTime;

  Problem:
  - txCoinStake.nTime was never initialized before use
  - Contains random garbage value from memory
  - Passed to CreateCoinStake() which uses it for coin age calculation
  - Coin age validation would fail with invalid time values

  Impact: PoS block creation always failed due to invalid stake time.

  2. Stale Search Time Across Tests
  // Static variable persists across test runs
  static int64_t nLastCoinStakeSearchTime = 0;

  // Tests reset mock time to epoch, but static variable remains at high value
  // Result: nSearchTime (100) < nLastCoinStakeSearchTime (1000000)
  // Condition fails: if (nSearchTime > nLastCoinStakeSearchTime)
  // No stake search performed!

  Added fix:
  // Handle mock time reset (e.g. between tests)
  if (nSearchTime < nLastCoinStakeSearchTime) {
      nLastCoinStakeSearchTime = nSearchTime - 1;
  }

  Problem:
  - nLastCoinStakeSearchTime is static and persists across test runs
  - Test frameworks reset mock time to epoch between tests
  - Second test would have nSearchTime = 100 but nLastCoinStakeSearchTime = 1000000
  - Condition nSearchTime > nLastCoinStakeSearchTime would fail
  - No stake search would occur

  Impact: First PoS test would work, all subsequent tests would fail.

  The Fix

  1. Initialize txCoinStake.nTime:
  txCoinStake.nTime = GetAdjustedTime();

  2. Reset search time when time goes backwards:
  if (nSearchTime < nLastCoinStakeSearchTime) {
      nLastCoinStakeSearchTime = nSearchTime - 1;
  }

  This handles mock time resets in test environments while preserving normal behavior in production.

  Test Impact

  Before:
  - ❌ First PoS test might work (luck with uninitialized memory)
  - ❌ Subsequent PoS tests always fail
  - ❌ TestChain100Setup cannot create PoS blocks

  After:
  - ✅ All PoS tests work consistently
  - ✅ TestChain100Setup successfully creates PoS blocks
  - ✅ Mock time resets handled correctly

  Use Case

  Enables test frameworks to:
  TestChain100Setup test;
  test.CreatePoSBlock(); // Now works reliably

  Files Changed

  - src/miner.cpp - Fix time initialization and mock time handling