### PR TITLE
validation: add PoW and timestamp validation to CheckBlockHeader

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3144,6 +3144,20 @@ void CChainState::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pi
 
 static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
+    // Check proof of work matches claimed amount
+    if (block.GetBlockTime() > CHECK_POW_FROM_NTIME) {
+        if (fCheckPOW && block.IsProofOfWork()) {
+            if (!CheckProofOfWork(block.GetPoWHash(), block.nBits, consensusParams)) {
+                return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "proof of work failed");
+            }
+        }
+    }
+
+    // Check timestamp
+    if (block.GetBlockTime() > FutureDrift(GetAdjustedTime())) {
+        return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "time-too-new", "block timestamp too far in the future");
+    }
+
     return true;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -101,6 +101,12 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to >= 550 MiB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
+// PoSV
+inline int64_t PastDrift(int64_t nTime)   { return nTime - 2 * 60 * 60; } // up to 2 hours from the past
+inline int64_t FutureDrift(int64_t nTime) { return nTime + 2 * 60 * 60; } // up to 2 hours from the future
+/** Start checking POW after block 44877 http://live.reddcoin.com/block/4253e7618d40aded00d11b664e874245ae74d55b976f4ac087d1a9db2f5f3cda */
+static const int64_t CHECK_POW_FROM_NTIME = 1394048078;
+
 /** Current sync state passed to tip changed callbacks. */
 enum class SynchronizationState {
     INIT_REINDEX,


### PR DESCRIPTION
## Add PoW and Timestamp Validation to CheckBlockHeader

  ### Summary
  Adds two critical missing validation checks to `CheckBlockHeader()` that are essential for consensus enforcement. Without these checks, invalid block headers could pass initial validation.

  ### Missing Validations Added

  **1. Proof-of-Work Hash Validation**
  ```cpp
  // Check proof of work matches claimed amount
  if (block.GetBlockTime() > CHECK_POW_FROM_NTIME) {
      if (fCheckPOW && block.IsProofOfWork()) {
          if (!CheckProofOfWork(block.GetPoWHash(), block.nBits, consensusParams)) {
              return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER,
                                 "high-hash", "proof of work failed");
          }
      }
  }

  Problem before:
  - PoW blocks were not validated at header level
  - Invalid PoW hashes could pass initial checks
  - Validation only occurred later in full block processing

  Solution:
  - Validates PoW hash meets difficulty target
  - Only for blocks after CHECK_POW_FROM_NTIME (block 44877, timestamp 1394048078)
  - Rejects invalid PoW blocks immediately

  2. Future Timestamp Validation
  // Check timestamp
  if (block.GetBlockTime() > FutureDrift(GetAdjustedTime())) {
      return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER,
                         "time-too-new", "block timestamp too far in the future");
  }

  Problem before:
  - Blocks with future timestamps could pass header validation
  - Attackers could create blocks with far-future timestamps
  - No drift limit enforcement at header level

  Solution:
  - Rejects blocks more than 2 hours in the future
  - Uses FutureDrift() helper function
  - Consistent with network consensus rules

  Helper Functions Added

  // PoSV timestamp drift helpers
  inline int64_t PastDrift(int64_t nTime)   { return nTime - 2 * 60 * 60; }
  inline int64_t FutureDrift(int64_t nTime) { return nTime + 2 * 60 * 60; }

  Purpose:
  - Provides consistent 2-hour drift window
  - Used across validation code for timestamp checks
  - PastDrift() - up to 2 hours from the past
  - FutureDrift() - up to 2 hours from the future

  Security Impact

  Before this fix:
  - ⚠️ Invalid PoW blocks could pass header validation
  - ⚠️ Future-timestamped blocks accepted
  - ⚠️ Delayed validation = wasted processing

  After this fix:
  - ✅ Invalid PoW blocks rejected immediately at header level
  - ✅ Future timestamp attacks prevented
  - ✅ Early validation = better DoS protection

  Consensus Rules

  CHECK_POW_FROM_NTIME:
  - Timestamp: 1394048078 (March 5, 2014)
  - Block: 44877
  - Hash: 4253e7618d40aded00d11b664e874245ae74d55b976f4ac087d1a9db2f5f3cda
  - PoW validation starts after this block

  Timestamp Drift:
  - Maximum future drift: 2 hours
  - Maximum past drift: 2 hours
  - Consistent with PoSV consensus rules

  Files Changed

  - src/validation.h - Add helper functions and CHECK_POW_FROM_NTIME constant
  - src/validation.cpp - Add validation checks to CheckBlockHeader