### PR TITLE
test: pos serialization fixes

### DIFF
--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -113,6 +113,7 @@ class TestHeaderAndShortIDs {
 public:
     CBlockHeader header;
     uint64_t nonce;
+    std::vector<unsigned char> vchBlockSig;  // Reddcoin: PoS block signature
     std::vector<uint64_t> shorttxids;
     std::vector<PrefilledTransaction> prefilledtxn;
 
@@ -132,7 +133,7 @@ public:
         return base.GetShortID(txhash);
     }
 
-    SERIALIZE_METHODS(TestHeaderAndShortIDs, obj) { READWRITE(obj.header, obj.nonce, Using<VectorFormatter<CustomUintFormatter<CBlockHeaderAndShortTxIDs::SHORTTXIDS_LENGTH>>>(obj.shorttxids), obj.prefilledtxn); }
+    SERIALIZE_METHODS(TestHeaderAndShortIDs, obj) { READWRITE(obj.header, obj.nonce, obj.vchBlockSig, Using<VectorFormatter<CustomUintFormatter<CBlockHeaderAndShortTxIDs::SHORTTXIDS_LENGTH>>>(obj.shorttxids), obj.prefilledtxn); }
 };
 
 BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -500,7 +500,8 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
 BOOST_AUTO_TEST_CASE(ccoins_serialization)
 {
     // Good example
-    CDataStream ss1(ParseHex("97f23c835800816115944e077fe7c803cfa57f29b36bf87c1d35"), SER_DISK, CLIENT_VERSION);
+    // Reddcoin: Added "0000" suffix for fCoinStake flag (00) and nTime (00)
+    CDataStream ss1(ParseHex("97f23c835800816115944e077fe7c803cfa57f29b36bf87c1d350000"), SER_DISK, CLIENT_VERSION);
     Coin cc1;
     ss1 >> cc1;
     BOOST_CHECK_EQUAL(cc1.fCoinBase, false);
@@ -509,7 +510,8 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     BOOST_CHECK_EQUAL(HexStr(cc1.out.scriptPubKey), HexStr(GetScriptForDestination(PKHash(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))))));
 
     // Good example
-    CDataStream ss2(ParseHex("8ddf77bbd123008c988f1a4a4de2161e0f50aac7f17e7f9555caa4"), SER_DISK, CLIENT_VERSION);
+    // Reddcoin: Added "0000" suffix for fCoinStake flag (00) and nTime (00)
+    CDataStream ss2(ParseHex("8ddf77bbd123008c988f1a4a4de2161e0f50aac7f17e7f9555caa40000"), SER_DISK, CLIENT_VERSION);
     Coin cc2;
     ss2 >> cc2;
     BOOST_CHECK_EQUAL(cc2.fCoinBase, true);
@@ -518,7 +520,8 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     BOOST_CHECK_EQUAL(HexStr(cc2.out.scriptPubKey), HexStr(GetScriptForDestination(PKHash(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))))));
 
     // Smallest possible example
-    CDataStream ss3(ParseHex("000006"), SER_DISK, CLIENT_VERSION);
+    // Reddcoin: Added "0000" suffix for fCoinStake flag (00) and nTime (00)
+    CDataStream ss3(ParseHex("0000060000"), SER_DISK, CLIENT_VERSION);
     Coin cc3;
     ss3 >> cc3;
     BOOST_CHECK_EQUAL(cc3.fCoinBase, false);
@@ -527,7 +530,8 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     BOOST_CHECK_EQUAL(cc3.out.scriptPubKey.size(), 0U);
 
     // scriptPubKey that ends beyond the end of the stream
-    CDataStream ss4(ParseHex("000007"), SER_DISK, CLIENT_VERSION);
+    // Reddcoin: Added "0000" suffix for fCoinStake flag (00) and nTime (00)
+    CDataStream ss4(ParseHex("0000070000"), SER_DISK, CLIENT_VERSION);
     try {
         Coin cc4;
         ss4 >> cc4;
@@ -540,7 +544,8 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     uint64_t x = 3000000000ULL;
     tmp << VARINT(x);
     BOOST_CHECK_EQUAL(HexStr(tmp), "8a95c0bb00");
-    CDataStream ss5(ParseHex("00008a95c0bb00"), SER_DISK, CLIENT_VERSION);
+    // Reddcoin: Added "0000" suffix for fCoinStake flag (00) and nTime (00)
+    CDataStream ss5(ParseHex("00008a95c0bb000000"), SER_DISK, CLIENT_VERSION);
     try {
         Coin cc5;
         ss5 >> cc5;

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -144,7 +144,11 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
         BOOST_CHECK(node->fDisconnect == false);
     }
 
-    SetMockTime(GetTime() + 3 * chainparams.GetConsensus().nPowTargetSpacing + 1);
+    // Advance time past STALE_CHECK_INTERVAL (10 minutes) to trigger the next stale check
+    // For Reddcoin with 60s blocks, we need enough time for both:
+    // 1. The stale check interval to pass (600 seconds)
+    // 2. The tip to actually be stale (3 * 60 = 180 seconds)
+    SetMockTime(GetTime() + 3 * chainparams.GetConsensus().nPowTargetSpacing + 600 + 1);
 
     // Now tip should definitely be stale, and we should look for an extra
     // outbound peer


### PR DESCRIPTION
  ## Summary
  Updates test fixtures to account for Reddcoin's PoS-specific serialization fields (`fCoinStake`, `nTime`, `vchBlockSig`) and fixes timing assumptions for 60-second blocks.

  ---

  ## Changes

  ### Coin Serialization (`coins_tests.cpp`)
  - Updated 5 hex test vectors to include PoS fields (`fCoinStake` flag and `nTime` timestamp)
  - Example: `"97f23c8358...1d35"` → `"97f23c8358...1d350000"` (added `0000` suffix)

  ### Block Encoding (`blockencodings_tests.cpp`)
  - Added `vchBlockSig` field to `TestHeaderAndShortIDs` class to match Reddcoin's compact block format

  ### DoS Protection (`denialofservice_tests.cpp`)
  - Fixed `stale_tip_peer_management` timing for Reddcoin's 60-second blocks
  - Added 600 seconds to account for `STALE_CHECK_INTERVAL` (test was only accounting for 3 blocks = 180s)

  ---

  ## Testing
  ```bash
  ./src/test/test_reddcoin --run_test=coins_tests/ccoins_serialization
  ./src/test/test_reddcoin --run_test=blockencodings_tests
  ./src/test/test_reddcoin --run_test=denialofservice_tests/stale_tip_peer_management
```