### PR TITLE
test: use CreateAndProcessPoSBlock in coinstatsindex test

### DIFF
--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -55,7 +55,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
 
     const CScript script_pub_key{CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG};
     std::vector<CMutableTransaction> noTxns;
-    CreateAndProcessBlock(noTxns, script_pub_key);
+    // Use PoS block since we're past PoW end (100 blocks)
+    CreateAndProcessPoSBlock(noTxns, script_pub_key, m_wallet.get());
 
     // Let the CoinStatsIndex to catch up again.
     BOOST_CHECK(coin_stats_index.BlockUntilSyncedToCurrentChain());


### PR DESCRIPTION
## Summary

  Fixes coinstatsindex test to use PoS block creation after PoW end height in Reddcoin regtest.

  ---

  ### Changes

  **Switch to PoS Block Creation** (`src/test/coinstatsindex_tests.cpp:59`)
  - Changed from `CreateAndProcessBlock()` to `CreateAndProcessPoSBlock()`
  - After 100 blocks (TestChain100Setup), regtest is past PoW end height (89)
  - Attempting PoW blocks after this point fails with "pow-ended" error
  - Uses `m_wallet` from TestChain100Setup for staking operations

  ---

  ### Testing

  ```bash
  src/test/test_reddcoin --run_test=coinstatsindex_tests

  ✅ coinstatsindex_initial_sync test passes with PoS block generation
  ```