### PR TITLE
test: use stakeBlocks in findCommonAncestor test

### DIFF
--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -101,10 +101,10 @@ BOOST_AUTO_TEST_CASE(findCommonAncestor)
         m_node.chainman->ActiveChainstate().InvalidateBlock(state, active.Tip());
     }
     BOOST_CHECK_EQUAL(active.Height(), orig_tip->nHeight - 10);
-    coinbaseKey.MakeNewKey(true);
-    for (int i = 0; i < 20; ++i) {
-        CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-    }
+    // Advance time to ensure coins have sufficient age for staking
+    //SetMockTime(GetTime() + 60 * 60 * 24);  // Add 24 hours
+    // Use stakeBlocks since we're past PoW end (100 blocks)
+    stakeBlocks(20);
     BOOST_CHECK_EQUAL(active.Height(), orig_tip->nHeight + 10);
     uint256 fork_hash;
     int fork_height;


### PR DESCRIPTION
## Summary

  Fixes findCommonAncestor test to use PoS block creation after PoW end height in Reddcoin regtest.

  ---

  ### Changes

  **Switch to PoS Block Generation** (`src/test/interfaces_tests.cpp:107`)
  - Changed from `CreateAndProcessBlock()` loop to `stakeBlocks(20)`
  - After 100 blocks (TestChain100Setup), regtest is past PoW end height (89)
  - Test invalidates 10 blocks then creates 20 new blocks to test common ancestor finding
  - Uses staking functionality since PoW blocks cannot be created after height 89

  **Coin Age Handling** (`src/test/interfaces_tests.cpp:104-105`)
  - Commented out mock time advancement (24 hours)
  - `stakeBlocks()` utility handles coin age requirements internally
  - Ensures sufficient coin maturity for staking after chain invalidation

  ---

  ### Testing

  ```bash
  src/test/test_reddcoin --run_test=interfaces_tests/findCommonAncestor

  ✅ findCommonAncestor test passes with PoS block generation after chain reorganization
  ```