### PR TITLE
fix: add negative and overflow checks to CheckProofOfWork

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -137,11 +137,14 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
 bool CheckProofOfWork(arith_uint256 hash, unsigned int nBits, const Consensus::Params& params)
 {
+    bool fNegative;
+    bool fOverflow;
     arith_uint256 bnTarget;
-    bnTarget.SetCompact(nBits);
+
+    bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
 
     // Check range
-    if (bnTarget <= 0 || bnTarget > UintToArith256(params.powLimit))
+    if (fNegative || bnTarget == 0 || fOverflow || bnTarget > UintToArith256(params.powLimit))
         return error("CheckProofOfWork() : nBits below minimum work");
 
     // Check proof of work matches claimed amount


### PR DESCRIPTION
## Summary

  Fixes CheckProofOfWork validation to properly handle negative and overflow nBits values, matching Bitcoin Core implementation.

  ---

  ### Changes

  **Add Compact Representation Validation** (`src/pow.cpp:140-148`)
  - Capture `fNegative` and `fOverflow` flags from `SetCompact()` call
  - Added explicit checks for negative and overflow conditions
  - Changed `bnTarget <= 0` to `bnTarget == 0` (negative handled by separate flag)
  - Prevents acceptance of invalid compact nBits representations

  **Validation Logic** (`src/pow.cpp:147`)
  ```cpp
  if (fNegative || bnTarget == 0 || fOverflow || bnTarget > UintToArith256(params.powLimit))
      return error("CheckProofOfWork() : nBits below minimum work");

  ---
  Testing

  src/test/test_reddcoin --run_test=pow_tests/CheckProofOfWork_test_negative_target

  ✅ CheckProofOfWork_test_negative_target test now passes with proper negative value rejection
  ```