### PR TITLE
fix: update regtest assumeutxo hash for PoS blocks at height 110

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -711,14 +711,17 @@ public:
             }
         };
 
+        // Reddcoin: Updated for PoS blocks (blocks 90-110 include coinstake transactions)
+        // nChainTx = 132 (includes genesis + 89 PoW blocks + 21 PoS blocks with 2 tx each)
+        // UTXO set hash computed with HASH_SERIALIZED (not block hash)
         m_assumeutxo_data = MapAssumeutxo{
             {
                 110,
-                {AssumeutxoHash{uint256S("0x1ebbf5850204c0bdb15bf030f47c7fe91d45c44c712697e4509ba67adb01c618")}, 110},
+                {AssumeutxoHash{uint256S("17456f9ccafe445335f3688b426df85e5a0ea7c8a8bbf5fb724fa1cc8da4efc3")}, 132},
             },
             {
                 200,
-                {AssumeutxoHash{uint256S("0x51c8d11d8b5c1de51543c579736e786aa2736206d1e11e627568029ce092cf62")}, 200},
+                {AssumeutxoHash{uint256S("51c8d11d8b5c1de51543c579736e786aa2736206d1e11e627568029ce092cf62")}, 200},
             },
         };
 


### PR DESCRIPTION
## Summary

  Fixes regtest assumeutxo data at height 110 to use correct UTXO set hash (HASH_SERIALIZED) instead of block hash, accounting for PoS blocks with coinstake transactions.

  ---

  ### Changes

  **Update Assumeutxo Hash at Height 110** (`src/chainparams.cpp:720`)
  - Changed from block hash `0x1ebbf5850204c0bdb15bf030f47c7fe91d45c44c712697e4509ba67adb01c618`
  - To UTXO set hash `17456f9ccafe445335f3688b426df85e5a0ea7c8a8bbf5fb724fa1cc8da4efc3`
  - Assumeutxo validation requires UTXO set hash (HASH_SERIALIZED), not block hash

  **Update Transaction Count** (`src/chainparams.cpp:720`)
  - Changed `nChainTx` from 110 to 132
  - Calculation: 1 (genesis) + 89 (PoW blocks) + 21 (PoS blocks) × 2 (tx per PoS block)
  - Each PoS block contains 2 transactions: coinbase + coinstake

  **Transaction Count Breakdown:**
  Genesis block:        1 tx   (height 0)
  PoW blocks (1-89):   89 tx   (1 tx per block)
  PoS blocks (90-110): 42 tx   (21 blocks × 2 tx each)
  Total:              132 tx

  **Remove Leading 0x Prefix** (`src/chainparams.cpp:723`)
  - Cleaned up height 200 hash format for consistency (removed `0x` prefix)

  **Add Explanatory Comments** (`src/chainparams.cpp:714-716`)
  - Documents PoS block structure with coinstake transactions
  - Clarifies nChainTx calculation
  - Notes that hash is UTXO set hash, not block hash

  ---

  ### Testing

  ```bash
  src/test/test_reddcoin --run_test=validation_tests/test_assumeutxo

  ✅ test_assumeutxo - validates correct UTXO set hash and transaction count for PoS blocks
  ```