### PR TITLE
test: update assumeutxo test for PoS regtest values

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -135,8 +135,9 @@ BOOST_AUTO_TEST_CASE(test_assumeutxo)
     }
 
     const auto out110 = *ExpectedAssumeutxo(110, *params);
-    BOOST_CHECK_EQUAL(out110.hash_serialized.ToString(), "1ebbf5850204c0bdb15bf030f47c7fe91d45c44c712697e4509ba67adb01c618");
-    BOOST_CHECK_EQUAL(out110.nChainTx, 110U);
+    // Reddcoin: Updated for PoS - UTXO set hash and nChainTx include PoS blocks
+    BOOST_CHECK_EQUAL(out110.hash_serialized.ToString(), "17456f9ccafe445335f3688b426df85e5a0ea7c8a8bbf5fb724fa1cc8da4efc3");
+    BOOST_CHECK_EQUAL(out110.nChainTx, 132U);  // genesis + 89 PoW + 21 PoS (2 tx each)
 
     const auto out210 = *ExpectedAssumeutxo(200, *params);
     BOOST_CHECK_EQUAL(out210.hash_serialized.ToString(), "51c8d11d8b5c1de51543c579736e786aa2736206d1e11e627568029ce092cf62");


### PR DESCRIPTION
## Summary

  Updates validation_tests assumeutxo expectations for Reddcoin's PoS blocks at height 110, using correct UTXO set hash and transaction count.

  ---

  ### Changes

  **Update Height 110 Assumeutxo Hash** (`src/test/validation_tests.cpp:139`)
  ```cpp
  // Before: Block hash
  "1ebbf5850204c0bdb15bf030f47c7fe91d45c44c712697e4509ba67adb01c618"

  // After: UTXO set hash (HASH_SERIALIZED)
  "17456f9ccafe445335f3688b426df85e5a0ea7c8a8bbf5fb724fa1cc8da4efc3"
  - Assumeutxo validation requires UTXO set hash computed with HASH_SERIALIZED
  - Not the block hash itself

  Update Height 110 Transaction Count (src/test/validation_tests.cpp:140)
  // Before: 110 transactions (one per block)
  BOOST_CHECK_EQUAL(out110.nChainTx, 110U);

  // After: 132 transactions (accounting for PoS coinstakes)
  BOOST_CHECK_EQUAL(out110.nChainTx, 132U);  // genesis + 89 PoW + 21 PoS (2 tx each)

  Transaction Count Breakdown:
  Genesis block (0):    1 tx   (coinbase only)
  PoW blocks (1-89):   89 tx   (coinbase only, 1 tx per block)
  PoS blocks (90-110): 42 tx   (coinbase + coinstake, 2 tx per block × 21 blocks)
  Total at height 110: 132 tx

  Add Explanatory Comment (src/test/validation_tests.cpp:138)
  - Documents that values are updated for PoS blocks
  - Clarifies UTXO set hash usage and nChainTx calculation
```
  ---
  Testing
```bash
  src/test/test_reddcoin --run_test=validation_tests/test_assumeutxo

  ✅ test_assumeutxo - validates correct UTXO set hash 17456f9c... at height 110
  ✅ test_assumeutxo - validates nChainTx count of 132 for PoS blocks
  ```