### PR TITLE
qt: fix minting UI responsiveness during IBD and modernize code

### DIFF
--- a/src/pos/kernelrecord.h
+++ b/src/pos/kernelrecord.h
@@ -51,6 +51,7 @@ public:
     int64_t getCoinAgeWeight(int nTimeOffset = 0) const;
     double getProbToMintStake(double difficulty, int timeOffset = 0) const;
     double getProbToMintWithinNMinutes(double difficulty, int minutes);
+    void invalidateCache() { prevDifficulty = 0; }
 protected:
     int prevMinutes;
     double prevDifficulty;

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -11,6 +11,9 @@
 /* Milliseconds between model updates */
 static const int MODEL_UPDATE_DELAY = 250;
 
+/* Minting table update interval in milliseconds (age is in hours; 30s is plenty) */
+static const int MINTING_UPDATE_DELAY = 30 * 1000;
+
 /* Milliseconds between new update checks */
 static const int CHECK_UPDATE_DELAY = 86400000; // 24 hours
 

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -54,6 +54,25 @@ struct TxLessThan
     }
 };
 
+// Queue notification for batching during wallet rescans
+struct TransactionNotification2
+{
+    TransactionNotification2() {}
+    TransactionNotification2(uint256 _hash, ChangeType _status):
+        hash(_hash), status(_status) {}
+
+    void invoke(QObject *ttm) const
+    {
+        QString strHash = QString::fromStdString(hash.GetHex());
+        QMetaObject::invokeMethod(ttm, "updateTransaction", Qt::QueuedConnection,
+                                  Q_ARG(QString, strHash),
+                                  Q_ARG(int, status));
+    }
+private:
+    uint256 hash;
+    ChangeType status;
+};
+
 // Private implementation
 class MintingTablePriv
 {
@@ -74,6 +93,31 @@ public:
 
     /** True when initial wallet data has been loaded */
     bool m_loaded = false;
+
+    /** True while a rescan is in progress */
+    bool m_loading = false;
+
+    /** Queued notifications during load/rescan */
+    std::vector<TransactionNotification2> vQueueNotifications;
+
+    void NotifyTransactionChanged(const uint256& hash, ChangeType status)
+    {
+        TransactionNotification2 notification(hash, status);
+        if (!m_loaded || m_loading) {
+            vQueueNotifications.push_back(notification);
+            return;
+        }
+        notification.invoke(parent);
+    }
+
+    void DispatchNotifications()
+    {
+        if (!m_loaded || m_loading) return;
+        for (const auto& notification : vQueueNotifications) {
+            notification.invoke(parent);
+        }
+        vQueueNotifications.clear();
+    }
 
     /* Query entire wallet anew from core.
      */
@@ -98,6 +142,7 @@ public:
                 }
         }
         m_loaded = true;
+        vQueueNotifications.clear();
     }
 
     /* Update our model of the wallet incrementally, to synchronize our model of the wallet
@@ -248,44 +293,6 @@ public:
 
 };
 
-struct TransactionNotification2
-{
-public:
-    TransactionNotification2() {}
-    TransactionNotification2(uint256 _hash, ChangeType _status):
-        hash(_hash), status(_status) {}
-
-    void invoke(QObject *ttm)
-    {
-        QString strHash = QString::fromStdString(hash.GetHex());
-        QMetaObject::invokeMethod(ttm, "updateTransaction", Qt::QueuedConnection,
-                                  Q_ARG(QString, strHash),
-                                  Q_ARG(int, status));
-    }
-private:
-    uint256 hash;
-    ChangeType status;
-};
-
-static bool fQueueNotifications = false;
-static std::vector< TransactionNotification2 > vQueueNotifications;
-
-static void NotifyTransactionChanged(MintingTableModel *ttm, const uint256 &hash, ChangeType status)
-{
-    // Find transaction in wallet
-    // Determine whether to show transaction or not (determine this here so that no relocking is needed in GUI thread)
-   // bool showTransaction = TransactionRecord::showTransaction();
-
-    TransactionNotification2 notification(hash, status);
-
-    if (fQueueNotifications)
-    {
-        vQueueNotifications.push_back(notification);
-        return;
-    }
-    notification.invoke(ttm);
-}
-
 MintingTableModel::MintingTableModel(WalletModel *parent) :
         QAbstractTableModel(parent),
         walletModel(parent),
@@ -306,12 +313,20 @@ MintingTableModel::MintingTableModel(WalletModel *parent) :
     timer->start(MODEL_UPDATE_DELAY);
 
     connect(walletModel->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &MintingTableModel::updateDisplayUnit);
-    m_handler_transaction_changed = walletModel->wallet().handleTransactionChanged(std::bind(NotifyTransactionChanged, this, std::placeholders::_1, std::placeholders::_2));
+    m_handler_transaction_changed = walletModel->wallet().handleTransactionChanged(
+        std::bind(&MintingTablePriv::NotifyTransactionChanged, priv,
+                  std::placeholders::_1, std::placeholders::_2));
+    m_handler_show_progress = walletModel->wallet().handleShowProgress(
+        [this](const std::string&, int progress) {
+            priv->m_loading = progress < 100;
+            priv->DispatchNotifications();
+        });
 }
 
 MintingTableModel::~MintingTableModel()
 {
     m_handler_transaction_changed->disconnect();
+    m_handler_show_progress->disconnect();
     delete priv;
 }
 

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -273,6 +273,13 @@ public:
         }
     }
 
+    void invalidateCaches()
+    {
+        for (auto& rec : cachedWallet) {
+            rec.invalidateCache();
+        }
+    }
+
     int size()
     {
         return cachedWallet.size();
@@ -306,11 +313,12 @@ MintingTableModel::MintingTableModel(WalletModel *parent) :
     // The updateAge timer will trigger the load once IBD completes.
     if (!walletModel->node().isInitialBlockDownload()) {
         priv->refreshWallet();
+        m_cached_difficulty = walletModel->node().getDifficulty();
     }
 
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, &MintingTableModel::updateAge);
-    timer->start(MODEL_UPDATE_DELAY);
+    timer->start(MINTING_UPDATE_DELAY);
 
     connect(walletModel->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &MintingTableModel::updateDisplayUnit);
     m_handler_transaction_changed = walletModel->wallet().handleTransactionChanged(
@@ -357,9 +365,14 @@ void MintingTableModel::updateAge()
 
     if (priv->size() == 0) return;
 
-    Q_EMIT dataChanged(index(0, Age), index(priv->size()-1, Age));
-    Q_EMIT dataChanged(index(0, CoinDay), index(priv->size()-1, CoinDay));
-    Q_EMIT dataChanged(index(0, MintProbability), index(priv->size()-1, MintProbability));
+    // Cache difficulty once per update cycle instead of per-row in getDayToMint(),
+    // eliminating 2N LOCK(cs_main) acquisitions per tick.
+    m_cached_difficulty = walletModel->node().getDifficulty();
+
+    // Force probability recalculation with fresh difficulty
+    priv->invalidateCaches();
+
+    Q_EMIT dataChanged(index(0, Age), index(priv->size()-1, MintProbability));
 }
 
 void MintingTableModel::setMintingProxyModel(MintingFilterProxy *mintingProxy)
@@ -497,11 +510,8 @@ QString MintingTableModel::lookupAddress(const std::string &address, bool toolti
 
 double MintingTableModel::getDayToMint(KernelRecord *wtx) const
 {
-    // const CBlockIndex *p = GetLastBlockIndex(::ChainActive().Tip(), true);
-    double difficulty = walletModel->node().getDifficulty(); //p->GetBlockDifficulty();
     int nIntervalMins = mintingInterval / 60;
-
-    double prob = wtx->getProbToMintWithinNMinutes(difficulty, nIntervalMins);
+    double prob = wtx->getProbToMintWithinNMinutes(m_cached_difficulty, nIntervalMins);
     prob = prob * 100;
     return prob;
 }

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -70,6 +70,9 @@ public:
      */
     QList<KernelRecord> cachedWallet;
 
+    /** True when initial wallet data has been loaded */
+    bool m_loaded = false;
+
     /* Query entire wallet anew from core.
      */
     void refreshWallet()
@@ -92,6 +95,7 @@ public:
                     }
                 }
         }
+        m_loaded = true;
     }
 
     /* Update our model of the wallet incrementally, to synchronize our model of the wallet
@@ -303,7 +307,12 @@ MintingTableModel::MintingTableModel(WalletModel *parent) :
 {
     columns << tr("Transaction") <<  tr("Address") << tr("Age") << tr("Balance") << tr("Coin Day") << tr("Stake Probability");
 
-    priv->refreshWallet();
+    // Defer initial wallet load if we're in IBD — refreshWallet() acquires
+    // LOCK(cs_wallet) which would block the GUI thread during sync.
+    // The updateAge timer will trigger the load once IBD completes.
+    if (!walletModel->node().isInitialBlockDownload()) {
+        priv->refreshWallet();
+    }
 
     QTimer *timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this, &MintingTableModel::updateAge);
@@ -321,6 +330,12 @@ MintingTableModel::~MintingTableModel()
 
 void MintingTableModel::updateTransaction(const QString &hash, int status)
 {
+    // Skip per-transaction minting updates during IBD. Staking data is not
+    // meaningful until fully synced, and the hard LOCK(cs_wallet) calls in
+    // updateWallet() would block the GUI thread while blockConnected()
+    // holds the lock on the scheduler thread.
+    if (walletModel->node().isInitialBlockDownload()) return;
+
     uint256 updated;
     updated.SetHex(hash.toStdString());
 
@@ -333,6 +348,13 @@ void MintingTableModel::updateTransaction(const QString &hash, int status)
 
 void MintingTableModel::updateAge()
 {
+    // If initial load was deferred during IBD, trigger it once IBD completes
+    if (!priv->m_loaded && !walletModel->node().isInitialBlockDownload()) {
+        priv->refreshWallet();
+    }
+
+    if (priv->size() == 0) return;
+
     Q_EMIT dataChanged(index(0, Age), index(priv->size()-1, Age));
     Q_EMIT dataChanged(index(0, CoinDay), index(priv->size()-1, CoinDay));
     Q_EMIT dataChanged(index(0, MintProbability), index(priv->size()-1, MintProbability));

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -111,7 +111,7 @@ public:
         {
             // Find transaction in wallet
             auto wtx = walletModel->wallet().getWalletTx(hash);
-            bool inWallet = wtx.tx ? true : false;
+            bool inWallet = wtx.tx != nullptr;
 
             // Find bounds of this transaction in model
             QList<KernelRecord>::iterator lower = std::lower_bound(
@@ -214,12 +214,6 @@ public:
                                    && (rec.nValue == cachedRec.nValue)
                                    && (rec.idx == cachedRec.idx))
                                 {
-                                    if(i>=cachedWallet.size())
-                                    {
-                                	qWarning() << "MintingTablePriv::updateWallet: Warning: cachedWallet is smaller than expected, remove item " + QString::number(i) +
-                                	    " not in size " + QString::number(cachedWallet.size());
-                                        break;
-                                    }
                                     parent->beginRemoveRows(QModelIndex(), i, i);
                                     cachedWallet.removeAt(i);
                                     parent->endRemoveRows();
@@ -248,16 +242,8 @@ public:
         }
         else
         {
-            return 0;
+            return nullptr;
         }
-    }
-
-    QString describe(TransactionRecord *rec)
-    {
-        {
-            return TransactionDesc::toHTML(walletModel->node(), walletModel->wallet(), rec, BitcoinUnits::BTC);  
-        }
-        return QString("");
     }
 
 };
@@ -304,8 +290,7 @@ MintingTableModel::MintingTableModel(WalletModel *parent) :
         QAbstractTableModel(parent),
         walletModel(parent),
         mintingInterval(60),
-        priv(new MintingTablePriv(walletModel, this)),
-        cachedNumBlocks(0)
+        priv(new MintingTablePriv(walletModel, this))
 {
     columns << tr("Transaction") <<  tr("Address") << tr("Age") << tr("Balance") << tr("Coin Day") << tr("Stake Probability");
 

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -25,6 +25,8 @@
 #include <QDebug>
 #include <QTimer>
 
+#include <algorithm>
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter,
@@ -112,9 +114,9 @@ public:
             bool inWallet = wtx.tx ? true : false;
 
             // Find bounds of this transaction in model
-            QList<KernelRecord>::iterator lower = qLowerBound(
+            QList<KernelRecord>::iterator lower = std::lower_bound(
                 cachedWallet.begin(), cachedWallet.end(), hash, TxLessThan());
-            QList<KernelRecord>::iterator upper = qUpperBound(
+            QList<KernelRecord>::iterator upper = std::upper_bound(
                 cachedWallet.begin(), cachedWallet.end(), hash, TxLessThan());
             int lowerIndex = (lower - cachedWallet.begin());
             int upperIndex = (upper - cachedWallet.begin());

--- a/src/qt/mintingtablemodel.h
+++ b/src/qt/mintingtablemodel.h
@@ -53,6 +53,7 @@ private:
     int mintingInterval;
     MintingTablePriv *priv;
     MintingFilterProxy *mintingProxyModel{nullptr};
+    double m_cached_difficulty{0};
 
     QString lookupAddress(const std::string &address, bool tooltip) const;
 

--- a/src/qt/mintingtablemodel.h
+++ b/src/qt/mintingtablemodel.h
@@ -52,8 +52,7 @@ private:
     QStringList columns;
     int mintingInterval;
     MintingTablePriv *priv;
-    MintingFilterProxy *mintingProxyModel;
-    int cachedNumBlocks;
+    MintingFilterProxy *mintingProxyModel{nullptr};
 
     QString lookupAddress(const std::string &address, bool tooltip) const;
 

--- a/src/qt/mintingview.cpp
+++ b/src/qt/mintingview.cpp
@@ -92,11 +92,7 @@ MintingView::MintingView(const PlatformStyle* platformStyle, QWidget* parent)
     vlayout->setSpacing(0);
     int width = view->verticalScrollBar()->sizeHint().width();
     // Cover scroll bar width with spacing
-#ifdef Q_WS_MAC
-    hlayout->addSpacing(width+2);
-#else
     hlayout->addSpacing(width);
-#endif
     // Always show scroll bar
     view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
     view->setTabKeyNavigation(false);
@@ -139,21 +135,12 @@ void MintingView::setModel(WalletModel *model)
 
         mintingView->horizontalHeader()->resizeSection(
                 MintingTableModel::Address, 300);
-#if QT_VERSION < 0x050000
-        mintingView->horizontalHeader()->setResizeMode(
-                MintingTableModel::TxHash, QHeaderView::Stretch);
-        mintingView->horizontalHeader()->resizeSection(
-                MintingTableModel::Age, QHeaderView::ResizeToContents);
-        mintingView->horizontalHeader()->resizeSection(
-                MintingTableModel::Balance, ResizeToContents);
-#else
         mintingView->horizontalHeader()->setSectionResizeMode(
                 MintingTableModel::TxHash, QHeaderView::Stretch);
         mintingView->horizontalHeader()->setSectionResizeMode(
                 MintingTableModel::Age, QHeaderView::ResizeToContents);
         mintingView->horizontalHeader()->setSectionResizeMode(
                 MintingTableModel::Balance, QHeaderView::ResizeToContents);
-#endif
         mintingView->horizontalHeader()->resizeSection(
                 MintingTableModel::CoinDay,100);
         mintingView->horizontalHeader()->resizeSection(
@@ -186,15 +173,6 @@ void MintingView::chooseMintingInterval(int idx)
     }
     model->getMintingTableModel()->setMintingInterval(interval);
     mintingProxyModel->invalidate();
-}
-
-void MintingView::changeEvent(QEvent* e)
-{
-    if (e->type() == QEvent::PaletteChange) {
-
-    }
-
-    QWidget::changeEvent(e);
 }
 
 void MintingView::exportClicked()

--- a/src/qt/mintingview.h
+++ b/src/qt/mintingview.h
@@ -40,8 +40,8 @@ private:
     WalletModel *model{nullptr};
     MintingFilterProxy *mintingProxyModel{nullptr};
     QTableView *mintingView{nullptr};
-    QComboBox *mintingCombo;
-    QMenu *contextMenu;
+    QComboBox *mintingCombo{nullptr};
+    QMenu *contextMenu{nullptr};
 
     const PlatformStyle* m_platform_style;
 

--- a/src/qt/mintingview.h
+++ b/src/qt/mintingview.h
@@ -36,9 +36,6 @@ public:
         Minting90days
     };
 
-protected:
-    void changeEvent(QEvent* e) override;
-
 private:
     WalletModel *model{nullptr};
     MintingFilterProxy *mintingProxyModel{nullptr};


### PR DESCRIPTION
  - Defer MintingTableModel wallet access during IBD to prevent GUI thread blocking on cs_wallet lock contention with the scheduler thread
  - Reduce minting table timer from 250ms to 30s and cache difficulty per update cycle, eliminating 2N LOCK(cs_main) acquisitions per tick
  - Wire up a proper notification queue in MintingTablePriv for transaction changes during wallet rescans
  - Remove Qt4 compatibility code, deprecated Qt API usage, and dead code from the minting UI
