### PR TITLE
consensus: Add overflow check before summing transaction outputs

### DIFF
--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -26,6 +26,9 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-negative");
         if (txout.nValue > MAX_MONEY)
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-toolarge");
+        // Check for overflow before adding
+        if (nValueOut > MAX_MONEY - txout.nValue)
+            return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-txouttotal-toolarge");
         nValueOut += txout.nValue;
         if (!MoneyRange(nValueOut))
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-txouttotal-toolarge");


### PR DESCRIPTION
## Summary

Adds a defensive integer-overflow check in `CheckTransaction()` before
accumulating transaction output values, verifying that adding the next output
would not exceed `MAX_MONEY` before performing the addition. This gives earlier
detection of overflow conditions (related to CVE-2010-5139).

## Changes

`src/consensus/tx_check.cpp`: add a pre-addition bound check in the
output-summing loop, returning `bad-txns-txouttotal-toolarge` on failure.

```cpp
// Check for overflow before adding
if (nValueOut > MAX_MONEY - txout.nValue)
    return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-txouttotal-toolarge");
nValueOut += txout.nValue;
```

## Impact

Conservative and consensus-safe: each `txout.nValue` is already bounded to
`[0, MAX_MONEY]`, and the new guard only rejects transactions that would
already fail the existing `MoneyRange()` backstop. No change to which
transactions are valid, and no new error codes.