### PR TITLE
miner: guard witness commitment erase in RegenerateCommitments

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -82,7 +82,9 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman)
 {
     CMutableTransaction tx{*block.vtx.at(0)};
-    tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
+    if (GetWitnessCommitmentIndex(block) != NO_WITNESS_COMMITMENT) {
+        tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
+    }
     block.vtx.at(0) = MakeTransactionRef(tx);
 
     CBlockIndex* prev_block = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block.hashPrevBlock));


### PR DESCRIPTION
  ## Summary
  
  `RegenerateCommitments()` could corrupt the heap and abort the process with
  `double free or corruption (out)` when regenerating the commitments of a block
  whose coinbase has **no** witness commitment (e.g. pre-SegWit regtest blocks).
  This is a one-line correctness fix that restores the guard present in upstream
  Bitcoin Core.
  
  ## Root cause
  
  In `src/miner.cpp`, `RegenerateCommitments()` erased the witness-commitment
  output unconditionally:
  
  ```cpp
  CMutableTransaction tx{*block.vtx.at(0)};
  tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
  
  GetWitnessCommitmentIndex(block) returns NO_WITNESS_COMMITMENT (-1) when the
  coinbase contains no commitment. In that case the expression becomes
  tx.vout.begin() + (-1) — an iterator before begin() — and erase() on it
  is undefined behaviour that corrupts the vector's heap allocation. The corruption
  surfaces as a double free or corruption (out) abort when the
  CMutableTransaction is destroyed at the end of the function.

  Fix

  Only erase when a commitment is actually present, matching upstream:

  CMutableTransaction tx{*block.vtx.at(0)};
  if (GetWitnessCommitmentIndex(block) != NO_WITNESS_COMMITMENT) {
      tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
  }
  block.vtx.at(0) = MakeTransactionRef(tx);

  Impact

  RegenerateCommitments() is exercised by TestChain100Setup::CreateAndProcessBlock(),
  which is used throughout the unit tests. Before this fix, the very first block of
  TestChain100Setup::mineBlocks() aborted, taking down test_reddcoin-qt
  (WalletTests) under make check and affecting any test that builds a chain
  with a non-SegWit coinbase. The crash is platform-independent (it was first
  observed in the ARM make check job and reproduced natively under gdb).