### PR TITLE
chainparams, test: real regtest assumeutxo UTXO hashes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -720,8 +720,10 @@ public:
             }
         };
 
-        // Reddcoin: assumeutxo data for 100-block test chain (89 PoW + 11 PoS blocks)
-        // TODO: Recompute these hashes after RegenerateCommitments fix
+        // Reddcoin: assumeutxo data for the regtest PoS test chain (genesis +
+        // 89 PoW + PoS blocks). hash_serialized is the HASH_SERIALIZED UTXO-set
+        // hash from gettxoutsetinfo at the given height; nChainTx counts genesis
+        // + 1 tx per PoW block + 2 tx (coinbase + coinstake) per PoS block.
         m_assumeutxo_data = MapAssumeutxo{
             {
                 110,
@@ -729,7 +731,7 @@ public:
             },
             {
                 200,
-                {AssumeutxoHash{uint256S("0000000000000000000000000000000000000000000000000000000000000000")}, 200},
+                {AssumeutxoHash{uint256S("8938769375b98ee91f968cbe547cd364d7977317cc3d5241c4dca8fc92912569")}, 312},
             },
         };
 

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -183,13 +183,15 @@ BOOST_AUTO_TEST_CASE(test_assumeutxo)
     }
 
     const auto out110 = *ExpectedAssumeutxo(110, *params);
-    // Reddcoin: Updated for PoS - UTXO set hash and nChainTx include PoS blocks
-    BOOST_CHECK_EQUAL(out110.hash_serialized.ToString(), "17456f9ccafe445335f3688b426df85e5a0ea7c8a8bbf5fb724fa1cc8da4efc3");
+    // Reddcoin: UTXO set hash and nChainTx for the regtest PoS test chain,
+    // computed via gettxoutsetinfo (HASH_SERIALIZED) on the chain built by the
+    // C++ staking helpers (genesis + 89 PoW + PoS blocks).
+    BOOST_CHECK_EQUAL(out110.hash_serialized.ToString(), "106f9f9bd6c57cea84444957b5630e4a1679a658c73455a0e0362ff0174ee181");
     BOOST_CHECK_EQUAL(out110.nChainTx, 132U);  // genesis + 89 PoW + 21 PoS (2 tx each)
 
     const auto out210 = *ExpectedAssumeutxo(200, *params);
-    BOOST_CHECK_EQUAL(out210.hash_serialized.ToString(), "51c8d11d8b5c1de51543c579736e786aa2736206d1e11e627568029ce092cf62");
-    BOOST_CHECK_EQUAL(out210.nChainTx, 200U);
+    BOOST_CHECK_EQUAL(out210.hash_serialized.ToString(), "8938769375b98ee91f968cbe547cd364d7977317cc3d5241c4dca8fc92912569");
+    BOOST_CHECK_EQUAL(out210.nChainTx, 312U);  // genesis + 89 PoW + 111 PoS (2 tx each)
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Finalizes the regtest `m_assumeutxo_data` that #375 left as a placeholder. Now that
#378 (the `RegenerateCommitments` heap-corruption fix) lets the regtest PoS test
chain build correctly, the real `HASH_SERIALIZED` UTXO-set hashes were computed and
are written into both `chainparams.cpp` and the `test_assumeutxo` unit test.

## Background

#375 added regtest assumeutxo data for the PoS test chain but left the height-200
entry as a zero-hash placeholder ("the height-200 hash is a placeholder pending the
RegenerateCommitments fix"), and `test_assumeutxo` carried expected hashes that never
matched chainparams. The placeholder could not be filled in earlier because building
the PoS chain past the PoW cutoff relies on `TestChain100Setup`'s staking helpers,
which aborted via the `RegenerateCommitments` heap bug fixed in #378.

## How the values were computed

With #378 in place, the chain was built with the C++ staking helpers
(`mineBlocks` + `stakeBlocks`) and the UTXO-set hash read the same way
`gettxoutsetinfo` does (`CoinStatsHashType::HASH_SERIALIZED`):

| height | hash_serialized | nChainTx |
|--------|-----------------|----------|
| 110 | `106f9f9bd6c57cea84444957b5630e4a1679a658c73455a0e0362ff0174ee181` | 132 (genesis + 89 PoW + 21 PoS) |
| 200 | `8938769375b98ee91f968cbe547cd364d7977317cc3d5241c4dca8fc92912569` | 312 (genesis + 89 PoW + 111 PoS) |

## Changes

- `src/chainparams.cpp`: replace the height-200 placeholder (zero hash, `nChainTx`
  200) with the real hash and `nChainTx` 312. Height 110 was already correct and is
  unchanged.
- `src/test/validation_tests.cpp`: align `test_assumeutxo`'s expected hashes with the
  real values (the previous expectations — `17456f9c…` at 110, `51c8d11d…` at 200 —
  were stale and never matched chainparams).

## Notes

- Depends on #378. `nChainTx` counts genesis + 1 tx per PoW block + 2 tx
  (coinbase + coinstake) per PoS block.

## Testing

- `src/test/test_reddcoin --run_test=validation_tests/test_assumeutxo` passes.
- Full `src/test/test_reddcoin` suite passes.