### PR TITLE
test: fix unused-variable errors and adapt unit tests for PoS/v3

### DIFF
--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -134,11 +134,13 @@ void BumpFee(TransactionView& view, const uint256& txid, bool expectDisabled, st
 //     QT_QPA_PLATFORM=cocoa   src/qt/test/test_bitcoin-qt  # macOS
 void TestGUI(interfaces::Node& node)
 {
-    // Set up wallet and chain with 15 blocks (10 from TestChain100Setup + 5 more for spending).
+    // Set up wallet and chain. TestChain100Setup builds a height-100 chain
+    // (89 PoW blocks then 11 PoS blocks), all rewards paying to coinbaseKey.
+    // With nCoinbaseMaturity=60 the early PoW coinbases are already mature and
+    // spendable, so no extra blocks are needed. (Upstream mined 5 more PoW
+    // blocks here for maturity, but Reddcoin rejects PoW past nLastPowHeight=89
+    // with "pow-ended".)
     TestChain100Setup test;
-    for (int i = 0; i < 5; ++i) {
-        test.CreateAndProcessBlock({}, GetScriptForRawPubKey(test.coinbaseKey.GetPubKey()));
-    }
     node.setContext(&test.m_node);
     std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
     wallet->LoadWallet();
@@ -147,7 +149,7 @@ void TestGUI(interfaces::Node& node)
         LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
         wallet->SetAddressBook(GetDestinationForKey(test.coinbaseKey.GetPubKey(), wallet->m_default_address_type), "", "receive");
         spk_man->AddKeyPubKey(test.coinbaseKey, test.coinbaseKey.GetPubKey());
-        wallet->SetLastBlockProcessed(15, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+        wallet->SetLastBlockProcessed(node.context()->chainman->ActiveChain().Height(), node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
     }
     {
         WalletRescanReserver reserver(*wallet);
@@ -182,11 +184,14 @@ void TestGUI(interfaces::Node& node)
     }
 
     // Send two transactions, and verify they are added to transaction list.
+    // The number of pre-existing wallet transactions depends on the height-100
+    // TestChain100Setup, so assert relative to the initial count rather than a
+    // hardcoded total.
     TransactionTableModel* transactionTableModel = walletModel.getTransactionTableModel();
-    QCOMPARE(transactionTableModel->rowCount({}), 15);
+    const int initial_tx_rows = transactionTableModel->rowCount({});
     uint256 txid1 = SendCoins(*wallet.get(), sendCoinsDialog, PKHash(), 5 * COIN, false /* rbf */);
     uint256 txid2 = SendCoins(*wallet.get(), sendCoinsDialog, PKHash(), 10 * COIN, true /* rbf */);
-    QCOMPARE(transactionTableModel->rowCount({}), 17);
+    QCOMPARE(transactionTableModel->rowCount({}), initial_tx_rows + 2);
     QVERIFY(FindTx(*transactionTableModel, txid1).isValid());
     QVERIFY(FindTx(*transactionTableModel, txid2).isValid());
 

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -105,7 +105,6 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_accept_v1_zero_time, TestChain100Setup)
 
     LOCK(cs_main);
 
-    unsigned int initialPoolSize = m_node.mempool->size();
     const MempoolAcceptResult result = AcceptToMemoryPool(m_node.chainman->ActiveChainstate(),
                                                          *m_node.mempool,
                                                          MakeTransactionRef(tx),

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -347,7 +347,11 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
     // TEST CHECKSEQUENCEVERIFY
     {
         CMutableTransaction invalid_with_csv_tx;
-        invalid_with_csv_tx.nVersion = 2;
+        // Reddcoin enforces BIP68/BIP112 sequence locks only for tx nVersion >= 3
+        // (v2 is the PoS-aware tx, which does not trigger BIP68); see
+        // tx_verify.cpp and CheckSequence() in interpreter.cpp. Bitcoin uses
+        // nVersion = 2 here, so bump to 3 for CSV to actually be enforced.
+        invalid_with_csv_tx.nVersion = 3;
         invalid_with_csv_tx.vin.resize(1);
         invalid_with_csv_tx.vin[0].prevout.hash = spend_tx.GetHash();
         invalid_with_csv_tx.vin[0].prevout.n = 3;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -219,8 +219,6 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
 TestChain100Setup::TestChain100Setup()
     : TestingSetup(CBaseChainParams::REGTEST, {"-txindex=1"})
 {
-    const Consensus::Params& params = Params().GetConsensus();
-
     // Set mock time to be after genesis block time
     SetMockTime(Params().GenesisBlock().nTime + 1);
     constexpr std::array<unsigned char, 32> vchKey = {
@@ -408,7 +406,6 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
 CBlock TestChain100Setup::CreateAndProcessPoSBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey, CWallet* pwallet)
 {
     const CChainParams& chainparams = Params();
-    const Consensus::Params& consensusParams = chainparams.GetConsensus();
 
     // Get pindexPrev BEFORE CreateNewBlock, without lock (matching miner.cpp line 650)
     CBlockIndex* pindexPrev = m_node.chainman->ActiveChain().Tip();

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
                         }
                     }
 
-                    bool processed = Assert(m_node.chainman)->ProcessNewBlock(Params(), block, true, &ignored);
+                    Assert(m_node.chainman)->ProcessNewBlock(Params(), block, true, &ignored);
 
                     // Reddcoin: Check if block was accepted even if not connected to active chain
                     // In a tree with forks, not all valid blocks will be on the active chain


### PR DESCRIPTION
## Summary

A set of small unit-test fixes surfaced while building and running the test
suite against the regtest PoS chain. Two classes of issue:

1. **GCC 12 `-Werror=unused-variable`** — several tests declared variables that
   were never read, which newer compilers reject as errors.
2. **Reddcoin-specific test assumptions** — a couple of tests still assumed
   Bitcoin's chain shape / transaction-version semantics instead of Reddcoin's
   PoS model.

No production code changes; test-only.

## Changes

### Unused-variable cleanups (GCC 12 `-Werror=unused-variable`)

- **`txvalidation_tests`** — remove the unused `initialPoolSize` in the
  version-1 `nTime=0` case (the other cases use it via `BOOST_CHECK_EQUAL`).
- **`validation_block_tests`** — drop the unused `processed` result of
  `ProcessNewBlock` (the test verifies acceptance via `LookupBlockIndex`); the
  call is kept for its side effect.
- **`setup_common`** — remove two unread `Consensus::Params` references in
  `TestChain100Setup`'s constructor and `CreateAndProcessPoSBlock` (the
  `CChainParams` they were derived from is still used).

### PoS / v3 test adaptations

- **`qt/test: wallettests`** — adapt `TestGUI` to the height-100
  `TestChain100Setup` (89 PoW + 11 PoS). It previously mined 5 extra **PoW**
  blocks for maturity, which Reddcoin rejects past `nLastPowHeight=89`
  (`pow-ended`). Those blocks are unnecessary (with `nCoinbaseMaturity=60` the
  early coinbases are already mature); the processed height is now derived from
  the active chain, and the transaction-row assertions are relative to the
  initial count rather than hardcoded totals.
- **`txvalidationcache_tests`** — use `nVersion=3` for the CSV check.
  Reddcoin enforces BIP68/BIP112 only for `nVersion >= 3` (v2 is the PoS-aware
  tx), whereas Bitcoin uses `>= 2`; with v2, `CheckSequence()` short-circuits and
  the supposed-valid case failed `CheckInputScripts`.

## Testing

- `src/test/test_reddcoin` — full suite passes.
- `src/qt/test/test_reddcoin-qt` — full suite passes.