### PR TITLE
index: don't rewind to a null tip on a stale genesis BlockConnected

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -247,7 +247,13 @@ void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const
         // m_synced. Consider the case where there is a reorg and the blocks on the stale branch are
         // in the ValidationInterface queue backlog even after the sync thread has caught up to the
         // new chain tip. In this unlikely event, log a warning and let the queue clear.
-        if (best_block_index->GetAncestor(pindex->nHeight - 1) != pindex->pprev) {
+        //
+        // pindex->pprev is null only for the genesis block. When the index already has a best
+        // block, a (stale, queue-backlog) genesis BlockConnected cannot connect to it and must not
+        // reach Rewind(), which dereferences new_tip (== pprev). Treat it like any other
+        // non-connecting block.
+        if (pindex->pprev == nullptr ||
+            best_block_index->GetAncestor(pindex->nHeight - 1) != pindex->pprev) {
             LogPrintf("%s: WARNING: Block %s does not connect to an ancestor of " /* Continued */
                       "known best chain (tip=%s); not updating index\n",
                       __func__, pindex->GetBlockHash().ToString(),


### PR DESCRIPTION
## Summary

`BaseIndex::BlockConnected` could call `Rewind(best_block_index, pindex->pprev)`
with `pprev == nullptr` for the genesis block, and `Rewind` dereferences
`new_tip`, crashing the index thread with SIGSEGV. One-line guard so `Rewind`
never receives a null tip.

## Root cause

`BaseIndex` runs a background sync thread that advances `m_best_block_index`
while `BlockConnected` notifications arrive from the `ValidationInterface` queue.
These race: a **stale `BlockConnected` for genesis** (height 0, `pprev == nullptr`)
can be delivered *after* the index already has a best block.

The existing "does not connect to an ancestor of known best chain" guard misses
it — for genesis, `best_block_index->GetAncestor(pindex->nHeight - 1)` is
`GetAncestor(-1)` (null) and `pindex->pprev` is also null, so they compare equal
and the guard passes. Execution then reaches `Rewind(best_block_index, nullptr)`,
whose `assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip)` dereferences
the null `new_tip` → SIGSEGV.

## Fix

Genesis can never connect on top of an existing best block, so treat a null
`pprev` as a non-connecting block (log and return) — which also guarantees
`Rewind` never sees a null `new_tip`.

## How it was found / verified

Surfaced as an intermittent `test_reddcoin-qt` `AddressBookTests` crash that only
reproduced on fast aarch64 CI runners — the txindex that `TestChain100Setup`
starts exercises this path, and the weakly-ordered core exposed the race (gdb,
x86, and slower cores all hid it). Captured a core on real aarch64 hardware; the
backtrace pinned `BaseIndex::Rewind(new_tip=nullptr)`. With the fix, the same
binary ran **200/200 crash-free** on aarch64 (vs. crashing by ~iteration 43
unpatched).

```
#7  BaseIndex::Rewind (new_tip=0x0)                index/base.cpp
#8  BaseIndex::BlockConnected                      index/base.cpp
#9  CMainSignals::BlockConnected                   validationinterface.cpp
#17 SingleThreadedSchedulerClient::ProcessQueue    scheduler.cpp
```