### PR TITLE
policy: Fix integer overflow in CFeeRate calculation

### DIFF
--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -15,9 +15,20 @@ CFeeRate::CFeeRate(const CAmount& nFeePaid, uint32_t num_bytes)
 {
     const int64_t nSize{num_bytes};
 
-    if (nFeePaid >= MAX_MONEY && nSize > 0) {
+    // Check if nFeePaid * 1000 would overflow int64_t before performing the multiplication.
+    // Previously used MAX_MONEY as threshold, but that's a consensus rule about money supply,
+    // not a mathematical overflow limit. The correct threshold is INT64_MAX / 1000.
+    // INT64_MAX = 9,223,372,036,854,775,807, so INT64_MAX / 1000 = 9,223,372,036,854,775.
+    // If nFeePaid exceeds this, use arbitrary precision arithmetic to prevent overflow.
+    if (nFeePaid > INT64_MAX / 1000 && nSize > 0) {
         arith_uint256 nSatsPerK = arith_uint256(nFeePaid) * 1000 / arith_uint256(nSize);
-        nSatoshisPerK = nSatsPerK.GetLow64();
+        // Clamp to INT64_MAX to prevent downstream issues with double conversion
+        // Check if the result fits in 63 bits (signed int64_t range)
+        if (nSatsPerK.bits() > 63) {
+            nSatoshisPerK = INT64_MAX;
+        } else {
+            nSatoshisPerK = nSatsPerK.GetLow64();
+        }
     } else if (nSize > 0) {
         nSatoshisPerK = nFeePaid * 1000 / nSize;
     } else {
@@ -31,7 +42,21 @@ CAmount CFeeRate::GetFee(uint32_t num_bytes) const
 
     // Be explicit that we're converting from a double to int64_t (CAmount) here.
     // We've previously had issues with the silent double->int64_t conversion.
-    CAmount nFee{static_cast<CAmount>(std::ceil(nSatoshisPerK * nSize / 1000.0))};
+    // Guard against overflow in the multiplication by using double throughout
+    double dFee = std::ceil(static_cast<double>(nSatoshisPerK) * static_cast<double>(nSize) / 1000.0);
+
+    // Clamp to valid CAmount range to prevent undefined behavior.
+    // static_cast<double>(INT64_MAX) rounds up to 2^63, which is NOT representable
+    // as int64_t, so a dFee of exactly 2^63 must be caught here (>=); otherwise the
+    // static_cast<CAmount>(dFee) below would be undefined. INT64_MIN == -2^63 is
+    // exactly representable, so the lower bound stays a strict "<".
+    if (dFee >= static_cast<double>(INT64_MAX)) {
+        return INT64_MAX;
+    } else if (dFee < static_cast<double>(INT64_MIN)) {
+        return INT64_MIN;
+    }
+
+    CAmount nFee{static_cast<CAmount>(dFee)};
 
     if (nFee == 0 && nSize != 0) {
         if (nSatoshisPerK > 0) nFee = CAmount(1);

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -88,6 +88,36 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
 }
 
+BOOST_AUTO_TEST_CASE(GetFeeOverflowTest)
+{
+    // Regression test for the out-of-range double->int64 conversion in
+    // CFeeRate::GetFee(). The constructor clamps an overflowing rate to INT64_MAX,
+    // after which GetFee()'s double math can land exactly on 2^63. Because
+    // static_cast<double>(INT64_MAX) rounds up to 2^63, a strict ">" bound let that
+    // value fall through to an undefined static_cast<CAmount>(2^63); GetFee() must
+    // clamp with ">=" and return INT64_MAX instead.
+    constexpr CAmount int64_max{std::numeric_limits<int64_t>::max()};
+    constexpr CAmount int64_min{std::numeric_limits<int64_t>::min()};
+    constexpr uint32_t u32_max{std::numeric_limits<uint32_t>::max()};
+
+    const CFeeRate maxRate{int64_max};
+    // size 1000 -> dFee == 2^63 exactly: must clamp, not trap.
+    BOOST_CHECK_EQUAL(maxRate.GetFee(1000), int64_max);
+    // larger sizes overflow further; still clamped.
+    BOOST_CHECK_EQUAL(maxRate.GetFee(2000), int64_max);
+    BOOST_CHECK_EQUAL(maxRate.GetFee(u32_max), int64_max);
+
+    const CFeeRate minRate{int64_min};
+    // negative side: -2^63 is exactly representable, so the boundary is well-defined.
+    BOOST_CHECK_EQUAL(minRate.GetFee(1000), int64_min);
+    BOOST_CHECK_EQUAL(minRate.GetFee(2000), int64_min);
+    BOOST_CHECK_EQUAL(minRate.GetFee(u32_max), int64_min);
+
+    // full constructor must clamp an overflowing rate (bits() > 63 path) to
+    // INT64_MAX rather than wrapping, and GetFee() must stay clamped afterwards.
+    BOOST_CHECK_EQUAL(CFeeRate(int64_max, 1).GetFee(1000), int64_max);
+}
+
 BOOST_AUTO_TEST_CASE(SizeLimitTest)
 {
     // Maximum size in bytes, should not crash


### PR DESCRIPTION
## Summary

Fixes a crash (SIGABRT) when processing transactions with extremely high fees,
caused by signed-integer overflow and an out-of-range `double`→`int64_t`
conversion in `CFeeRate`.

## Root cause

`CFeeRate` computes `nFeePaid * 1000` and converts fee rates through `double`
without proper overflow handling:

- The constructor's overflow check used `MAX_MONEY` as the threshold, but
  `MAX_MONEY` is a money-supply consensus constant (92,233,720,368 COIN) — **not**
  the mathematical overflow limit. Fees between `INT64_MAX / 1000` and `MAX_MONEY`
  still overflowed `nFeePaid * 1000`.
- `GetFee()`'s `double` math can land exactly on `2^63`. Since
  `static_cast<double>(INT64_MAX)` rounds up to `2^63`, a strict `>` bound let
  that value fall through to an undefined `static_cast<CAmount>(2^63)`.

## Changes — `src/policy/feerate.cpp`

- Overflow threshold changed from `MAX_MONEY` to `INT64_MAX / 1000`.
- Result clamping via `arith_uint256::bits()`.
- `GetFee()` hardened with bounds checking for the `double` conversion, clamping
  with `>=` (not `>`) so the exact `2^63` boundary returns `INT64_MAX` instead of
  an undefined conversion.
- Comments documenting the mathematical limits.

## Tests — `src/test/amount_tests.cpp`

Adds `GetFeeOverflowTest` covering the `INT64_MAX` / `INT64_MIN` `GetFee()`
boundaries (sizes 1000, 2000, `UINT32_MAX`) and the overflowing full-constructor
clamp path.

## Impact

Prevents node crashes from transactions with extremely high fees — a potential
DoS vector if fee checks are bypassed. No change to fee-rate results in the
normal operating range.