### PR TITLE
pos: deterministic, backward-compatible stake modifier fallback

### DIFF
--- a/src/pos/kernel.cpp
+++ b/src/pos/kernel.cpp
@@ -71,6 +71,17 @@ static bool GetLastStakeModifier(const CBlockIndex* pindex, uint64_t& nStakeModi
     while (pindex && pindex->pprev && !pindex->GeneratedStakeModifier())
         pindex = pindex->pprev;
     if (!pindex->GeneratedStakeModifier()) {
+        // Backward-compatible fix: when no generated modifier exists below
+        // pindex, return zero for both the modifier and its time.  Using
+        // pindex->nStakeModifier / GetBlockTime() here causes v4.22.10 to
+        // diverge from v4.22.9 after ~40 PoS blocks because the two
+        // versions then compute different stake modifiers from genesis.
+        // Returning zero matches v4.22.9's behavior (which has no such
+        // fallback) and preserves consensus compatibility while still
+        // producing deterministic reindex results.  See
+        // docs/feature_compat_pos_blocks.md for the divergence analysis.
+        nStakeModifier = 0;
+        nModifierTime = 0;
         return true;
     }
     nStakeModifier = pindex->nStakeModifier;


### PR DESCRIPTION
## Summary

Fixes PoS block validation failing on **reindex** due to a non-deterministic stake-modifier fallback.

## Root cause

`GetLastStakeModifier()` returned without setting `nStakeModifier`/`nModifierTime` when it walked back to genesis without finding a block with `GeneratedStakeModifier` set. The leftover `nModifierTime` made the timing check in `ComputeNextStakeModifier()` evaluate differently between initial chain creation and reindex:

- **Initial:** `nModifierTime = 0` → check fails → modifier computed at block 1
- **Reindex:** `nModifierTime = genesis_time` → check passes → no modifier at block 1

That one-block offset cascaded through the chain, so every subsequent stake modifier differed and PoS blocks failed validation on reindex.

## Fix

`src/pos/kernel.cpp`: set a deterministic fallback so the genesis-reached case yields the same `nModifierTime` on both initial sync and reindex. Backward-compatible (no change to modifiers on a normally-synced chain).