### PR TITLE
validation: prevent early break in ActivateBestChainStep for small reorgs

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2691,7 +2691,13 @@ bool CChainState::ActivateBestChainStep(BlockValidationState& state, CBlockIndex
                 }
             } else {
                 PruneBlockIndexCandidates();
-                if (!pindexOldTip || m_chain.Tip()->nChainWork > pindexOldTip->nChainWork) {
+                // Don't break early for small connections (typical reorgs).
+                // This ensures all blocks are connected in a single batch,
+                // producing correct block announcement behavior (headers for
+                // ≤MAX_BLOCKS_TO_ANNOUNCE, inv for larger reorgs). For large
+                // connections (IBD), break early to release cs_main.
+                if (pindexMostWork->nHeight - m_chain.Tip()->nHeight > 16 &&
+                    (!pindexOldTip || m_chain.Tip()->nChainWork > pindexOldTip->nChainWork)) {
                     // We're in a better position than we were. Return temporarily to release the lock.
                     fContinue = false;
                     break;


### PR DESCRIPTION
## Summary

Restores batched block-connection (and the single batched headers announcement) during small reorgs.

## Root cause

`ActivateBestChainStep` breaks early (to release `cs_main`) once the connected block exceeds `pindexOldTip`. With no threshold, **every** block connected during a reorg triggered that early break, so blocks were connected one-at-a-time instead of in a single batch — turning a reorg that should produce one batched headers announcement into individual per-block announcements.

## Fix

`src/validation.cpp`: only break early when **more than 16 blocks** remain to connect, so small reorgs connect in a single batch.