### PR TITLE
validation: pass coins view to GetCoinAge for VerifyDB level 4 reconnection

### DIFF
--- a/src/pos/kernel.cpp
+++ b/src/pos/kernel.cpp
@@ -465,7 +465,7 @@ bool CheckCoinStakeTimestamp(int64_t nTimeBlock, int64_t nTimeTx)
 // guaranteed to be in main chain by sync-checkpoint. This rule is
 // introduced to help nodes establish a consistent view of the coin
 // age (trust score) of competing branches.
-uint64_t GetCoinAge(CChainState* active_chainstate, const CTransaction& tx, const Consensus::Params& params)
+uint64_t GetCoinAge(CChainState* active_chainstate, const CTransaction& tx, const Consensus::Params& params, CCoinsViewCache* coins_view)
 {
     arith_uint256 bnCentSecond = 0; // coin age in the unit of cent-seconds
     uint64_t nCoinAge = 0;
@@ -475,9 +475,14 @@ uint64_t GetCoinAge(CChainState* active_chainstate, const CTransaction& tx, cons
 
     LOCK(cs_main);
 
+    // Use provided coins view if available, otherwise fall back to CoinsTip().
+    // During VerifyDB level 4 reconnection, CoinsTip() still reflects the
+    // original chain state, while the provided view has the disconnected state.
+    CCoinsViewCache& coins_ref = coins_view ? *coins_view : active_chainstate->CoinsTip();
+
     for (const CTxIn& txin : tx.vin) {
         // Get coin from UTXO set (faster and works during reindex)
-        const Coin& coin = active_chainstate->CoinsTip().AccessCoin(txin.prevout);
+        const Coin& coin = coins_ref.AccessCoin(txin.prevout);
         if (coin.IsSpent()) {
             continue; // coin already spent or not in UTXO set
         }

--- a/src/pos/kernel.h
+++ b/src/pos/kernel.h
@@ -14,6 +14,7 @@ class CBlock;
 class CBlockHeader;
 class CBlockIndex;
 class CChainState;
+class CCoinsViewCache;
 
 // MODIFIER_INTERVAL_RATIO:
 // ratio of group interval length between the last group and the first group
@@ -37,8 +38,11 @@ bool CheckProofOfStake(CChainState* active_chainstate, CBlockIndex* pindexPrev, 
 // Check whether the coinstake timestamp meets protocol
 bool CheckCoinStakeTimestamp(int64_t nTimeBlock, int64_t nTimeTx);
 
-// Function to retrieve the coin age of a given transaction
-uint64_t GetCoinAge(CChainState* active_chainstate, const CTransaction& tx, const Consensus::Params& consensusParams);
+// Function to retrieve the coin age of a given transaction.
+// If coins_view is provided, it is used instead of CoinsTip() to look up
+// UTXOs. This is needed during VerifyDB level 4 where ConnectBlock operates
+// on a local CCoinsViewCache that differs from the live CoinsTip().
+uint64_t GetCoinAge(CChainState* active_chainstate, const CTransaction& tx, const Consensus::Params& consensusParams, CCoinsViewCache* coins_view = nullptr);
 
 // Function to calculate the coin age weight
 int64_t GetCoinAgeWeight(int64_t nIntervalBeginning, int64_t nIntervalEnd, const Consensus::Params& consensusParams);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1946,6 +1946,15 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
 
     CBlockUndo blockundo;
 
+    // PoSV: Compute coinstake coin age BEFORE the transaction processing loop,
+    // because UpdateCoins() will spend the coinstake inputs in the view.
+    // GetCoinAge reads from the view to find unspent coins, so it must run
+    // while the inputs are still unspent.
+    uint64_t nCoinAge = 0;
+    if (block.IsProofOfStake()) {
+        nCoinAge = GetCoinAge(this, *block.vtx[1], m_params.GetConsensus(), &view);
+    }
+
     // Precomputed transaction data pointers must not be invalidated
     // until after `control` has run the script checks (potentially
     // in multiple threads). Preallocate the vector size so a new allocation
@@ -2055,8 +2064,9 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     }
     else if (block.IsProofOfStake())
     {
-        // PoSV: coinstake tx earns reward instead of paying fee
-        uint64_t nCoinAge = GetCoinAge(this, *block.vtx[1], m_params.GetConsensus());
+        // PoSV: coinstake tx earns reward instead of paying fee.
+        // nCoinAge was computed before the transaction processing loop (above)
+        // while the coinstake inputs were still unspent in the view.
         if (!nCoinAge)
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-posv-coinage");
 


### PR DESCRIPTION
## Summary

Fixes `bad-posv-coinage` failures on PoS blocks during `VerifyDB` level 4.

## Root cause

`GetCoinAge` read coinstake inputs directly from `CoinsTip()`. During `VerifyDB` level 4, `ConnectBlock` operates on a **local `CCoinsViewCache`** that differs from the live `CoinsTip()`, so coin-age computation failed with `bad-posv-coinage` on PoS blocks.

## Fix

`src/pos/kernel.{cpp,h}`, `src/validation.cpp`:
- Add an optional `CCoinsViewCache*` parameter to `GetCoinAge` so it reads from the view in use.
- Move the `GetCoinAge` call to **before** the transaction-processing loop in `ConnectBlock`, while the coinstake inputs are still unspent in the view.