### PR TITLE
fix: Add coinstake sigops entries to block template for PoS blocks

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -204,6 +204,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
                     coinbaseTx.vout[0].SetEmpty();
                     coinbaseTx.nTime = txCoinStake.nTime;
                     pblock->vtx.push_back(MakeTransactionRef(CTransaction(txCoinStake)));
+                    // Add placeholder entries for coinstake fee and sigops (updated later)
+                    pblocktemplate->vTxFees.push_back(0);
+                    pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
                     *pfPoSCancel = false;
                 }
             }
@@ -256,6 +259,11 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         UpdateTime(pblock, Params().GetConsensus(), pindexPrev);
     pblock->nNonce         = 0;
     pblocktemplate->vTxSigOpsCost[0] = WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*pblock->vtx[0]);
+
+    // For PoS blocks, also update coinstake sigops
+    if (pblock->IsProofOfStake()) {
+        pblocktemplate->vTxSigOpsCost[1] = WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*pblock->vtx[1]);
+    }
 
     BlockValidationState state;
     // Validate all blocks (PoW and PoS) - signature check skipped for unsigned PoS blocks


### PR DESCRIPTION
## Summary

When creating PoS blocks, the coinstake transaction was appended to the block but no corresponding entries were added to the `vTxFees` and `vTxSigOpsCost` vectors. As a result those vectors were shorter than `vtx`, and `getblocktemplate` tripped the `nTxSigOps % WITNESS_SCALE_FACTOR == 0` assertion in `rpc/mining.cpp` when it indexed the coinstake's sigops slot.

## Changes (`src/miner.cpp`)
- When the coinstake is added, push placeholder entries onto `vTxFees` (`0`) and `vTxSigOpsCost` (`-1`, updated later) so the per-tx vectors stay aligned with `vtx`.
- After the header is filled in, set the coinstake's real sigops cost for PoS blocks: `vTxSigOpsCost[1] = WITNESS_SCALE_FACTOR * GetLegacySigOpCount(vtx[1])`, matching how slot `0` (coinbase) is handled.

This keeps the template vectors consistent (`vTxFees.size() == vTxSigOpsCost.size() == vtx.size()`) for PoS blocks and resolves the `getblocktemplate` assertion failure.

## Scope
- Single file, +8 lines, no behavioural change for PoW blocks.
- Part of the `pr/core-fixes` split — group B (PoS block production), tracked in RED-29.