### PR TITLE
pos: fix coin selection and search interval in CreateCoinStake

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -167,7 +167,10 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
 
     // reddcoin: if coinstake available add coinstake tx
-    static int64_t nLastCoinStakeSearchTime = GetAdjustedTime();  // only initialized at startup
+    // Subtract 61s so the first call has a non-zero search interval.
+    // Without this, nSearchTime == nLastCoinStakeSearchTime on first call,
+    // causing CreateCoinStake to skip all coins (search loop count = 0).
+    static int64_t nLastCoinStakeSearchTime = GetAdjustedTime() - 61;
 
     // Create coinbase transaction.
     CMutableTransaction coinbaseTx;

--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -165,12 +165,9 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
     txNew.vout.push_back(CTxOut(0, scriptEmpty));
 
     // Choose coins to use
-    CAmount nBalance = pwallet->GetBalance().m_mine_trusted;
     CAmount nReserveBalance = 0;
     if (gArgs.IsArgSet("-reservebalance") && !ParseMoney(gArgs.GetArg("-reservebalance", ""), nReserveBalance))
         return error("CreateCoinStake : invalid reserve balance amount");
-    if (nBalance <= nReserveBalance)
-        return false;
     std::set<CInputCoin> setCoins;
     std::vector<CTransactionRef> vwtxPrev;
     CAmount nValueIn = 0;
@@ -178,7 +175,16 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
     CCoinControl temp;
     CoinSelectionParams coin_selection_params;
     pwallet->AvailableCoins(vAvailableCoins, &temp);
-    if (!pwallet->SelectCoins(vAvailableCoins, nBalance - nReserveBalance, setCoins, nValueIn, temp, coin_selection_params))
+    // For staking, use all available coins directly — SelectCoins applies
+    // confirmation filters that reject recently-received coins, but staking
+    // only needs any single UTXO with sufficient age to find a valid kernel.
+    CAmount nAvailable = 0;
+    for (const auto& coin : vAvailableCoins) {
+        setCoins.insert(coin.GetInputCoin());
+        nAvailable += coin.GetInputCoin().txout.nValue;
+    }
+    nValueIn = nAvailable;
+    if (nAvailable <= nReserveBalance)
         return false;
     if (setCoins.empty())
         return false;
@@ -257,7 +263,7 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
         if (fKernelFound)
             break; // if kernel is found stop searching
     }
-    if (nCredit == 0 || nCredit > nBalance - nReserveBalance)
+    if (nCredit == 0 || nCredit > nAvailable - nReserveBalance)
         return false;
     for (const auto& pcoin : setCoins)
     {
@@ -290,7 +296,7 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
             if (nCredit > nCombineThreshold)
                 break;
             // Stop adding inputs if reached reserve limit
-            if (nCredit + pcoin.txout.nValue > nBalance - nReserveBalance)
+            if (nCredit + pcoin.txout.nValue > nAvailable - nReserveBalance)
                 break;
             // Do not add additional significant input
             if (pcoin.txout.nValue > nCombineThreshold)


### PR DESCRIPTION
## Summary

PoS block creation could fail to stake under several conditions. This fixes three related issues in `CreateCoinStake` and the staker's search-interval initialisation.

### 1. Available balance vs wallet balance (`src/pos/stake.cpp`)
`CreateCoinStake` compared the target against `GetBalance().m_mine_trusted`, which counts locked UTXOs, while `AvailableCoins` excludes them. Any UTXO locked via `lockunspent` made the target exceed what was actually selectable, and staking aborted. The balance is now computed from the `AvailableCoins` result so the two are consistent.

### 2. Bypass SelectCoins for staking (`src/pos/stake.cpp`)
`SelectCoins` applies confirmation-based eligibility filters (e.g. 6 confirmations for received coins) that reject recently-received UTXOs. Staking only needs *any* single UTXO of sufficient age to find a valid kernel, and the min-age check in the kernel search loop already enforces that. The staking candidate set now uses all available coins directly; `nValueIn`/`nAvailable` track their total, and the subsequent credit/reserve checks use `nAvailable` instead of the wallet balance.

### 3. Zero search interval on first call (`src/miner.cpp`)
`CreateNewBlock` initialised the static `nLastCoinStakeSearchTime` to `GetAdjustedTime()`, so on the first call it equalled `nSearchTime`, producing a zero-length search window — the kernel search loop never executed. It's now initialised to `GetAdjustedTime() - 61` so the first call has a non-zero interval.

## Scope
- `src/miner.cpp` (+5/−1), `src/pos/stake.cpp` (+12/−6). No effect on PoW block production.