### PR TITLE
init: Advertise NODE_WITNESS only when SegWit activation is scheduled

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1608,9 +1608,18 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
     }
 
-    if (DeploymentEnabled(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) {
-        // Advertise witness capabilities.
-        // The option to not set NODE_WITNESS is only used in the tests and should be removed.
+    if (chainparams.GetConsensus().vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout != 0) {
+        // Only advertise witness capabilities if segwit has a defined activation window.
+        // This allows deploying segwit code before scheduling activation by setting nTimeout=0.
+        // Once activation is scheduled (nTimeout != 0), nodes will advertise NODE_WITNESS.
+        //
+        // Note: setting NODE_WITNESS is never strictly required. The only downside from not
+        // doing so is that after activation, upgraded nodes won't fetch witness blocks from you.
+        //
+        // ReddCoin: Using nTimeout check (pre-buried style) instead of DeploymentEnabled()
+        // because segwit is not yet activated on mainnet. DeploymentEnabled() returns true
+        // for any nStartTime != NEVER_ACTIVE, which would incorrectly advertise NODE_WITNESS
+        // before segwit activation is scheduled.
         nLocalServices = ServiceFlags(nLocalServices | NODE_WITNESS);
     }
 


### PR DESCRIPTION
## Summary

Gates `NODE_WITNESS` advertising on whether SegWit has a defined activation window, rather than on `DeploymentEnabled()`.

`DeploymentEnabled()` returns true for any deployment with `nStartTime != NEVER_ACTIVE`, so it would advertise `NODE_WITNESS` even when SegWit activation is not yet scheduled. On Reddcoin SegWit is not yet activated on mainnet, so the node should not signal witness capabilities prematurely.

## Change (`src/init.cpp`)
- Advertise `NODE_WITNESS` only when `vDeployments[DEPLOYMENT_SEGWIT].nTimeout != 0` (pre-buried style check).
- Setting `nTimeout = 0` lets the SegWit code ship without scheduling activation; once a real activation window is configured (`nTimeout != 0`), nodes advertise `NODE_WITNESS`.

As the inline comment notes, setting `NODE_WITNESS` is never strictly required — the only downside of not setting it is that, after activation, upgraded peers won't fetch witness blocks from this node. That trade-off is acceptable pre-activation.

## Scope
- Single file, +12/−3, no behavioural change once SegWit activation is scheduled.
- Part of the `pr/core-fixes` split — group B (PoS block production / pre-activation plumbing), tracked in RED-29. Independent of #386 and #387.