### PR TITLE
fix: Skip coinstake in getblockstats fee calculations

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2127,7 +2127,7 @@ static RPCHelpMan getblockstats()
             }
         }
 
-        if (tx->IsCoinBase()) {
+        if (tx->IsCoinBase() || tx->IsCoinStake()) {
             continue;
         }
 


### PR DESCRIPTION
## Summary

Coinstake transactions have a negative "fee" (outputs exceed inputs because of the staking reward), which trips a `MoneyRange` assertion failure in `getblockstats` when it accumulates per-transaction fees.

## Change (`src/rpc/blockchain.cpp`)
- Skip coinstake transactions in the `getblockstats` fee loop, the same way coinbase is already skipped: `if (tx->IsCoinBase() || tx->IsCoinStake()) continue;`. Both are block-creation infrastructure rather than user transactions, so neither belongs in fee statistics.

## Scope
- Single file, `src/rpc/blockchain.cpp` (+1/−1).