### PR TITLE
fix: Initialize WalletOptions struct to prevent undefined behavior

### DIFF
--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -219,9 +219,9 @@ enum walletType {
 };
 
 struct WalletOptions {
-    int walletType;
-    int bits;
-    bool importing;
+    int walletType = 0;  // bip32Wallet
+    int bits = 256;
+    bool importing = false;
     SecureString ssMnemonic;
     SecureString ssMnemonicPassphrase;
     SecureString ssMasterKey;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -625,7 +625,10 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     if (IsCrypted())
         return false;
 
-    WalletOptions walletoptions;
+    WalletOptions walletoptions{};
+    walletoptions.walletType = walletType::bip32Wallet;
+    walletoptions.bits = 256;
+    walletoptions.importing = false;
 
     CKeyingMaterial _vMasterKey;
 


### PR DESCRIPTION
## Summary

The `WalletOptions` struct members (`walletType`, `bits`, `importing`) were uninitialized. When `EncryptWallet` created a local `WalletOptions` and passed it to `SetupGeneration`, the garbage values led to unpredictable behaviour.

## Changes
- **`src/wallet/db.h`**: add default member initializers — `walletType = 0` (bip32Wallet), `bits = 256`, `importing = false` — so every `WalletOptions` is well-defined at construction.
- **`src/wallet/wallet.cpp`**: in `EncryptWallet`, value-initialize the local (`WalletOptions walletoptions{};`) and set the members explicitly (`bip32Wallet`, 256 bits, not importing).

## Scope
- `src/wallet/db.h` (+3/−3), `src/wallet/wallet.cpp` (+4/−1). Removes undefined behaviour; no functional change once members hold their intended defaults.
- Part of the `pr/core-fixes` split — group D (wallet robustness), tracked in RED-30.

> Note: touches `src/wallet/wallet.cpp` alongside the `nWalletVersion` atomic change (group D); whichever merges second needs a trivial rebase.