### PR TITLE
wallet: make nWalletVersion atomic for lock-free reads

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -481,14 +481,14 @@ void CWallet::chainStateFlushed(const CBlockLocator& loc)
 void CWallet::SetMinVersion(enum WalletFeature nVersion, WalletBatch* batch_in)
 {
     LOCK(cs_wallet);
-    if (nWalletVersion >= nVersion)
+    if (nWalletVersion.load(std::memory_order_acquire) >= nVersion)
         return;
-    nWalletVersion = nVersion;
+    nWalletVersion.store(nVersion, std::memory_order_release);
 
     {
         WalletBatch* batch = batch_in ? batch_in : new WalletBatch(GetDatabase());
-        if (nWalletVersion > 40000)
-            batch->WriteMinVersion(nWalletVersion);
+        if (nVersion > 40000)
+            batch->WriteMinVersion(nVersion);
         if (!batch_in)
             delete batch;
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -247,7 +247,9 @@ private:
     friend class WalletRescanReserver;
 
     //! the current wallet version: clients below this version are not able to load the wallet
-    int nWalletVersion GUARDED_BY(cs_wallet){FEATURE_BASE};
+    //! Atomic because it is read from ScriptPubKeyMan without cs_wallet (via WalletStorage interface).
+    //! Only written during wallet init/upgrade under cs_wallet, effectively read-only afterwards.
+    std::atomic<int> nWalletVersion{FEATURE_BASE};
 
     /** The next scheduled rebroadcast of wallet transactions. */
     int64_t nNextResend = 0;
@@ -446,7 +448,7 @@ public:
     bool IsTrusted(const CWalletTx& wtx, std::set<uint256>& trusted_parents) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! check whether we support the named feature
-    bool CanSupportFeature(enum WalletFeature wf) const override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); return IsFeatureSupported(nWalletVersion, wf); }
+    bool CanSupportFeature(enum WalletFeature wf) const override { return IsFeatureSupported(nWalletVersion, wf); }
 
     /**
      * populate vCoins with vector of available COutputs.
@@ -509,7 +511,7 @@ public:
     //! Upgrade DescriptorCaches
     void UpgradeDescriptorCache() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; return true; }
+    bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion.store(nVersion, std::memory_order_release); return true; }
 
     //! Adds a destination data tuple to the store, without saving it to disk
     void LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -740,7 +742,7 @@ public:
     void SetMinVersion(enum WalletFeature, WalletBatch* batch_in = nullptr) override;
 
     //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
-    int GetVersion() const { LOCK(cs_wallet); return nWalletVersion; }
+    int GetVersion() const { return nWalletVersion.load(std::memory_order_acquire); }
 
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
## Summary

`nWalletVersion` is read from `ScriptPubKeyMan` via the `WalletStorage` interface without holding `cs_wallet`, but was declared `GUARDED_BY(cs_wallet)` and mutated under that lock during init/upgrade. That's a TSAN-detectable data race, even though the value is effectively read-only after wallet load.

## Changes (`src/wallet/wallet.{cpp,h}`)
- Make `nWalletVersion` a `std::atomic<int>` and use acquire/release semantics on reads/writes.
- Drop `EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)` from `CanSupportFeature()` and remove the `LOCK(cs_wallet)` from `GetVersion()` — the atomic load is now sufficient.
- `LoadMinVersion()` / `SetMinVersion()` use atomic store; in `SetMinVersion()`, capture `nVersion` locally before passing to `WriteMinVersion` to avoid a redundant second atomic load.

## Scope
- `src/wallet/wallet.cpp` (+4/−4), `src/wallet/wallet.h` (+6/−4). Thread-safety fix; no behavioural change to wallet versioning.