### PR TITLE
wallet: fix build — declare DescriptorScriptPubKeyMan::GetKey(CScript) overload in header

### DIFF
--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -624,6 +624,9 @@ public:
 
     uint256 GetID() const override;
 
+    //! Reddcoin: fetch the private key for keyid within the given script's descriptor
+    bool GetKey(const CScript& script, const CKeyID& keyid, CKey& key) const;
+
     void SetCache(const DescriptorCache& cache);
 
     bool AddKey(const CKeyID& key_id, const CKey& key);


### PR DESCRIPTION
## Summary

Fixes a build regression on `develop`. The createwallet BIP39/BIP44 work (#393) added a definition of

```cpp
bool DescriptorScriptPubKeyMan::GetKey(const CScript& script, const CKeyID& keyid, CKey& key) const
```

in `src/wallet/scriptpubkeyman.cpp` (line 2230), but the matching declaration was never added to `src/wallet/scriptpubkeyman.h` — the feature branch's diff touched the `.cpp` but not the header. Wallet-enabled builds therefore fail:

```
scriptpubkeyman.cpp:2230:6: error: no declaration matches
  'bool DescriptorScriptPubKeyMan::GetKey(const CScript&, const CKeyID&, CKey&) const'
```

## Change

Add the declaration to the `DescriptorScriptPubKeyMan` class:

```cpp
//! Reddcoin: fetch the private key for keyid within the given script's descriptor
bool GetKey(const CScript& script, const CKeyID& keyid, CKey& key) const;
```

Non-`override` (there is no base-class virtual of this signature) and `const`, matching the existing definition. The overload delegates to `GetSigningProvider(script, true)` and then the provider's `GetKey(keyid, key)`.

## Scope
1 file, +3 lines (`src/wallet/scriptpubkeyman.h`). Restores compilation; no behavioural change.
