### PR TITLE
pow: honor fPowNoRetargeting in GetNextWorkRequired on regtest

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -113,6 +113,12 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 {
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
 
+    // Reddcoin: regtest keeps difficulty fixed so PoW/PoS blocks remain trivially
+    // mineable at any chain height (KimotoGravityWell would otherwise ratchet
+    // difficulty up as blocks are mined faster than the target spacing).
+    if (params.fPowNoRetargeting)
+        return pindexLast->nBits;
+
     if (params.fPowAllowMinDifficultyBlocks && pindexLast->nHeight < params.nLastPowHeight)
         return bnPowLimit.GetCompact();
 


### PR DESCRIPTION
## Summary

`GetNextWorkRequired` ignored the `fPowNoRetargeting` consensus flag, so its only min-difficulty escape was gated on chain height (`height < nLastPowHeight`). On regtest `nLastPowHeight` is 89, so once a generated PoW chain passed that height every block fell through to KimotoGravityWell, which retargets on real block spacing.

Because functional tests mine blocks far faster than the 60s target spacing, difficulty ratcheted upward over hundreds of blocks, making scrypt proof-of-work progressively expensive — until a single `generatetoaddress` RPC exceeded its 30s timeout (e.g. `feature_block.py`'s 1088-block large reorg).

## Change (`src/pow.cpp`)

Return the previous block's `nBits` when `fPowNoRetargeting` is set, keeping regtest difficulty pinned at the genesis `powLimit` target regardless of height:

```cpp
if (params.fPowNoRetargeting)
    return pindexLast->nBits;
```

Only regtest sets `fPowNoRetargeting`, so mainnet, testnet and signet retargeting are unaffected. This also matches upstream Bitcoin's handling of the flag in `GetNextWorkRequired`.

## Scope
1 file, +6 lines (`src/pow.cpp`). Regtest-only behaviour change; no effect on the other networks.