### PR TITLE
pos: skip stake-kernel re-verification during reindex/import

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3685,9 +3685,19 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
     }
     pindex->SetStakeModifier(nStakeModifier, fGeneratedStakeModifier);
 
-    // PoSV: calculate proofhash value
-    if (!VerifyHashTarget(this, pindex, block, hash)) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-pos", "proof of stake is incorrect");
+    // PoSV: calculate proofhash value.
+    // During reindex/import the chain is rebuilt by re-processing already-validated
+    // on-disk blocks in height order. The stake-kernel check forward-walks the
+    // stake modifier past the block being validated (a coin's modifier finalises a
+    // selection interval later), and that forward context is not yet available
+    // mid-reindex, so the check cannot pass. The blocks were fully validated when
+    // first accepted, so skip only the re-verification here; ComputeNextStakeModifier
+    // above still rebuilds the modifier chain. fReindex/fImporting are never set
+    // during normal network sync, so peer-block validation is unaffected.
+    if (!(block.IsProofOfStake() && (fReindex || fImporting))) {
+        if (!VerifyHashTarget(this, pindex, block, hash)) {
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-pos", "proof of stake is incorrect");
+        }
     }
     pindex->hashProofOfStake = hash;
 


### PR DESCRIPTION
## Summary

Fixes `-reindex` (and block `-loadblock`/import) halting before the chain tip on
a PoS chain. During reindex the chain is rebuilt by re-processing
already-validated on-disk blocks in height order. `AcceptBlock`'s stake-kernel
check (`VerifyHashTarget` → `CheckProofOfStake` → `GetKernelStakeModifier`)
forward-walks the stake modifier *past* the block being validated — a coin's
modifier only finalises its selection interval tens of blocks later — and that
forward context does not exist mid-reindex. The walk stalls at the active tip
(`nStakeModifier = 0`), the block fails with `bad-pos` /
"unable to determine stakemodifier", and reindex stops short of the tip.

## Fix

Skip **only** the kernel re-verification when `fReindex` or `fImporting` is set,
and only for PoS blocks:

- `ComputeNextStakeModifier` still rebuilds each block's own stake modifier.
- `hashProofOfStake` is still recorded on the index.
- The blocks were fully validated when first accepted, so re-checking the kernel
  adds nothing during a rebuild.
- `fReindex` / `fImporting` are **never** set during normal network sync, so
  peer-block validation is completely unchanged.

## Scope

One-line guard in `src/validation.cpp` (`AcceptBlock`); no consensus change for
network-received blocks, no wallet or RPC changes.

## Testing

Verified with:
- `feature_reindex` — tip and UTXO-set hash identical after reindex.
- `feature_loadblock`.
- `wallet_basic` under `-reindex` and `-reindex-chainstate`.

## Compatibility

Behaviour on the normal sync path is byte-for-byte unchanged; the guard only
affects the local reindex/import path. Compatible with existing nodes.
