### PR TITLE
pos: source coinstake age gates from the UTXO coin

### DIFF
--- a/src/pos/kernel.cpp
+++ b/src/pos/kernel.cpp
@@ -476,6 +476,25 @@ bool CheckCoinStakeTimestamp(int64_t nTimeBlock, int64_t nTimeTx)
 // guaranteed to be in main chain by sync-checkpoint. This rule is
 // introduced to help nodes establish a consistent view of the coin
 // age (trust score) of competing branches.
+bool GetCoinAgeTimes(CChainState* active_chainstate, CCoinsViewCache& view, const COutPoint& outpoint, uint32_t& nTimeBlockFrom, uint32_t& nTimeTxPrev)
+{
+    AssertLockHeld(cs_main);
+    // Mirror GetCoinAge's per-coin UTXO lookup (see below): the Coin already
+    // carries both the creating tx's nTime and its height, so the age gates no
+    // longer need a separate disk read. Values are identical to the former disk
+    // source: m_chain[coin.nHeight]->GetBlockTime() == the block header nTime,
+    // and coin.nTime == the prev tx's nTime.
+    const Coin& coin = view.AccessCoin(outpoint);
+    if (coin.IsSpent())
+        return false;
+    const CBlockIndex* pindex = active_chainstate->m_chain[coin.nHeight];
+    if (!pindex)
+        return false;
+    nTimeBlockFrom = pindex->GetBlockTime();
+    nTimeTxPrev = coin.nTime;
+    return true;
+}
+
 uint64_t GetCoinAge(CChainState* active_chainstate, const CTransaction& tx, const Consensus::Params& params, CCoinsViewCache* coins_view)
 {
     arith_uint256 bnCentSecond = 0; // coin age in the unit of cent-seconds

--- a/src/pos/kernel.h
+++ b/src/pos/kernel.h
@@ -44,6 +44,15 @@ bool CheckCoinStakeTimestamp(int64_t nTimeBlock, int64_t nTimeTx);
 // on a local CCoinsViewCache that differs from the live CoinsTip().
 uint64_t GetCoinAge(CChainState* active_chainstate, const CTransaction& tx, const Consensus::Params& consensusParams, CCoinsViewCache* coins_view = nullptr);
 
+// Resolve a prevout's containing-block time and prev-tx time from the UTXO set.
+// This is the single source of truth (UTXO Coin) for the PoS age gates in
+// CreateCoinStake, matching the source GetCoinAge already uses. nTimeTxPrev is
+// the raw Coin.nTime (no zero fixup) so callers reproduce the exact value the
+// former disk read (tx->nTime) provided. Returns false if the coin is absent or
+// spent in the view, or its creating block is not on the active chain.
+// Requires cs_main.
+bool GetCoinAgeTimes(CChainState* active_chainstate, CCoinsViewCache& view, const COutPoint& outpoint, uint32_t& nTimeBlockFrom, uint32_t& nTimeTxPrev);
+
 // Function to calculate the coin age weight
 int64_t GetCoinAgeWeight(int64_t nIntervalBeginning, int64_t nIntervalEnd, const Consensus::Params& consensusParams);
 

--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -347,7 +347,13 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
                 nCredit += pcoin.txout.nValue;
                 vwtxPrev.push_back(tx);
                 txNew.vout.push_back(CTxOut(0, scriptPubKeyOut));
-                if (GetCoinAgeWeight(header.GetBlockTime(), (int64_t)txNew.nTime, consensusParams) < nStakeSplitAge && nCredit >= nCombineThreshold)
+                // Age the kernel from the UTXO Coin (single source of truth,
+                // same source GetCoinAge/ConnectBlock use). Value is identical
+                // to the disk header.GetBlockTime(); fall back to it defensively.
+                uint32_t nKernelBlockTime = header.GetBlockTime();
+                uint32_t nKernelTxPrevTime;
+                GetCoinAgeTimes(chainstate, chainstate->CoinsTip(), pcoin.outpoint, nKernelBlockTime, nKernelTxPrevTime);
+                if (GetCoinAgeWeight(nKernelBlockTime, (int64_t)txNew.nTime, consensusParams) < nStakeSplitAge && nCredit >= nCombineThreshold)
                     txNew.vout.push_back(CTxOut(0, scriptPubKeyOut)); // Split stake
                 LogPrintf("CreateCoinStake : added kernel type=%s\n", GetTxnOutputType(whichType));
                 fKernelFound = true;
@@ -395,8 +401,12 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
             // Do not add additional significant input
             if (pcoin.txout.nValue > nCombineThreshold)
                 continue;
-            // Do not add input that is still too young
-            if (tx->nTime + consensusParams.nStakeMaxAge > txNew.nTime)
+            // Do not add input that is still too young. Age from the UTXO Coin
+            // (single source of truth); raw coin.nTime is identical to the disk
+            // tx->nTime, so behaviour is unchanged. Fall back defensively.
+            uint32_t nCombineBlockTime, nCombineTxPrevTime = tx->nTime;
+            GetCoinAgeTimes(chainstate, chainstate->CoinsTip(), pcoin.outpoint, nCombineBlockTime, nCombineTxPrevTime);
+            if (nCombineTxPrevTime + consensusParams.nStakeMaxAge > txNew.nTime)
                 continue;
             txNew.vin.push_back(CTxIn(pcoin.outpoint.hash, pcoin.outpoint.n));
             nCredit += pcoin.txout.nValue;

--- a/test/functional/feature_pos_coinage_source.py
+++ b/test/functional/feature_pos_coinage_source.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test coin-age source symmetry between coinstake creation and validation.
+
+CreateCoinStake's stake-split and input-combine gates (src/pos/stake.cpp) read
+the prev-coin timestamp from the same UTXO Coin source (via GetCoinAgeTimes)
+that GetCoinAge / ConnectBlock use, rather than a separate disk read. This test
+exercises the combine gate — which only folds in inputs older than nStakeMaxAge
+(45 days) — by advancing mocktime past that age.
+
+Stress points exercised:
+  * every folded-in coinstake input is genuinely matured
+    (prev.nTime + nStakeMaxAge <= coinstake.nTime), catching the historical bug
+    where a young coin was combined because the timestamp source disagreed with
+    the validator's,
+  * a second node validates every staked block (a rejection would mean the
+    staker's coin-age gates disagreed with the consensus coin-age source),
+  * the staker is restarted mid-run, proving coin age is read correctly from the
+    reloaded UTXO set (not cached / disk-order dependent).
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    advance_time_for_pos,
+    set_node_times,
+)
+
+STAKE_MAX_AGE = 45 * 24 * 60 * 60  # regtest consensus.nStakeMaxAge
+
+
+class PosCoinageSourceTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = False  # use the 199-block PoS cache
+        self.extra_args = [["-staking=0"], ["-staking=0"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def import_deterministic_coinbase_privkeys(self):
+        self.init_wallet(0)
+        self.init_wallet(1)
+
+    def setup_network(self):
+        # Start disconnected: node0 stakes in isolation, node1 validates after.
+        self.setup_nodes()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _inspect_coinstake(self, node, blockhash):
+        """Return (n_inputs, n_outputs, combined_ok) for a block's coinstake.
+
+        combined_ok asserts that every folded-in input (vin[1:], i.e. every
+        input other than the kernel vin[0]) is older than nStakeMaxAge relative
+        to the coinstake timestamp — the exact decision the combine gate makes
+        from the UTXO Coin.nTime.
+        """
+        block = node.getblock(blockhash, 2)
+        cs = block["tx"][1]
+        cs_ntime = cs.get("time", block["time"])  # coinstake nTime == block time
+        for vin in cs["vin"][1:]:
+            prev = node.getrawtransaction(vin["txid"], True)
+            prev_ntime = prev.get("time", 0)  # 0 for legacy PoW-era coins
+            assert prev_ntime + STAKE_MAX_AGE <= cs_ntime, (
+                f"combine gate folded a too-young input: prev.nTime={prev_ntime} "
+                f"+ {STAKE_MAX_AGE} > coinstake.nTime={cs_ntime}")
+        return len(cs["vin"]), len(cs["vout"])
+
+    def run_test(self):
+        staker, validator = self.nodes[0], self.nodes[1]
+        start_height = staker.getblockcount()
+        assert start_height >= 199
+
+        # Age every coin past nStakeMaxAge so the combine gate folds matured
+        # same-address inputs into the coinstake.
+        aged_time = max(staker.mocktime, validator.mocktime) + STAKE_MAX_AGE + 24 * 60 * 60
+        set_node_times(self.nodes, aged_time)
+
+        n_blocks = 16
+        restart_at = n_blocks // 2
+        combined = split = 0
+        self.log.info(f"Staking {n_blocks} PoS blocks on node0 with aged coins "
+                      f"(restarting the staker at block {restart_at})")
+        for i in range(n_blocks):
+            advance_time_for_pos(staker, seconds=60)
+            blockhash = staker.generate(1)[0]
+            n_in, n_out = self._inspect_coinstake(staker, blockhash)
+            if n_in > 1:
+                combined += 1
+            if n_out >= 4:
+                split += 1
+
+            if i == restart_at:
+                # Restart the staker; coin age must be read from the reloaded
+                # UTXO set (mocktime is an RPC state, restore it after restart).
+                saved = staker.mocktime
+                self.log.info("Restarting staker mid-run to test UTXO-source persistence")
+                self.restart_node(0)
+                staker = self.nodes[0]
+                set_node_times([staker], saved)
+
+        assert_equal(staker.getblockcount(), start_height + n_blocks)
+        self.log.info(f"combine-exercised blocks={combined} split-exercised blocks={split}")
+        assert combined > 0, (
+            "combine gate (stake.cpp:399) was not exercised; the aged cache did "
+            "not yield multi-input coinstakes")
+
+        # Cross-node validation: node1 must accept every block node0 staked.
+        set_node_times(self.nodes, staker.mocktime)
+        self.connect_nodes(0, 1)
+        self.sync_blocks(timeout=120)
+        assert_equal(validator.getblockcount(), start_height + n_blocks)
+        assert_equal(validator.getbestblockhash(), staker.getbestblockhash())
+        # The validator independently re-checks the same maturity invariant.
+        self._inspect_coinstake(validator, validator.getbestblockhash())
+
+        self.log.info("Coin-age source symmetry verified across create and validate")
+
+
+if __name__ == '__main__':
+    PosCoinageSourceTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -141,6 +141,7 @@ BASE_SCRIPTS = [
     'feature_bind_extra.py',
     'mempool_resurrect.py',
     'wallet_txn_doublespend.py --mineblock',
+    'feature_pos_coinage_source.py',
     'tool_wallet.py --legacy-wallet',
     'tool_wallet.py --descriptors',
     'wallet_txn_clone.py',


### PR DESCRIPTION
## Summary

Makes the staker and the validator read a coin's age from the same place. `CreateCoinStake`'s stake-split and input-combine gates previously read the previous coin's timestamp from a separate `txindex` disk lookup, while the reward-driving `GetCoinAge()` and the validator (`ConnectBlock`) read it from the UTXO set. This adds a `GetCoinAgeTimes()` accessor that resolves the prev-coin block time and `nTime` from the UTXO `Coin` (`coin.nTime` and `m_chain[coin.nHeight]`), and routes both structural gates through it, so all PoS age logic uses one source that is consistent with validation.

Values are identical to the former disk read in the normal case, so this is not a behavior change on the happy path. It removes latent skew between the staker's structural gate decisions and the validator's coin-age computation.

## Changes

- `src/pos/kernel.cpp`, `src/pos/kernel.h`: add `GetCoinAgeTimes()` accessor resolving prev-coin block time and `nTime` from the UTXO `Coin`.
- `src/pos/stake.cpp`: route the stake-split and input-combine gates through the new accessor instead of a separate `txindex` read.

## Testing

- `feature_pos_coinage_source.py`: stakes aged coins so the combine gate fires, verifies every folded-in input is matured, and confirms a second node accepts every block.

## Compatibility

No consensus change: the validator is untouched and computed values match the previous path in normal operation. Compatible with existing nodes.
