### PR TITLE
consensus: enforce a PoS-era transaction-version floor

### DIFF
--- a/contrib/devtools/audit_tx_version.py
+++ b/contrib/devtools/audit_tx_version.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Audit PoS-era transaction versions on ReddCoin mainnet/testnet.
+
+Consensus-safety check for the rule added to ContextualCheckBlock (and the
+mempool PreChecks) in src/validation.cpp:
+
+    for blocks at height > consensus.nLastPowHeight, every transaction must
+    have nVersion > POW_TX_VERSION (i.e. nVersion >= POSV_TX_VERSION == 2),
+    else the block is rejected with "bad-txns-version-pos".
+
+This rule is applied to ALL transactions in the block, INCLUDING the coinbase
+(vtx[0]) and the coinstake (vtx[1]). If any historical PoS-era block on a live
+network contains a transaction with nVersion <= 1, the new rule would reject
+valid chain history and fork the node during (re)validation. This script scans
+the chain and reports every such transaction so the rule can be verified safe
+before it ships.
+
+It talks to a running reddcoind over JSON-RPC and reads full blocks
+(getblock verbosity=2), so the node — not this script — does the deserialization.
+
+Exit status: 0 if no offending transactions were found, 1 if any were found,
+2 on a usage/connection error.
+
+Examples:
+    # mainnet, explicit RPC credentials
+    contrib/devtools/audit_tx_version.py --rpcuser U --rpcpassword P
+
+    # testnet, auto-read the cookie from the datadir
+    contrib/devtools/audit_tx_version.py --network test --datadir ~/.reddcoin
+
+    # resume a previous run (or scan a bounded range)
+    contrib/devtools/audit_tx_version.py --start-height 2000000 --stop-height 2100000
+"""
+import argparse
+import base64
+import json
+import os
+import sys
+import threading
+import time
+import http.client
+from concurrent.futures import ThreadPoolExecutor
+
+POW_TX_VERSION = 1                 # from src/primitives/transaction.h
+MIN_POS_TX_VERSION = POW_TX_VERSION + 1  # == POSV_TX_VERSION (2); the rule requires >= this
+
+# Per-network defaults (src/chainparamsbase.cpp, src/chainparams.cpp).
+NETWORK_DEFAULTS = {
+    'main':    {'rpcport': 45443, 'datadir_subdir': '',         'last_pow_height': 260799},
+    'test':    {'rpcport': 55443, 'datadir_subdir': 'testnet3', 'last_pow_height': 1439},
+    'regtest': {'rpcport': 56443, 'datadir_subdir': 'regtest',  'last_pow_height': 89},
+}
+
+
+class RPCError(Exception):
+    pass
+
+
+class RPCClient:
+    """Minimal JSON-RPC client with one HTTP connection per thread and batch support."""
+
+    def __init__(self, host, port, user, password, timeout=120):
+        self.host = host
+        self.port = port
+        self._authhdr = 'Basic ' + base64.b64encode(f'{user}:{password}'.encode()).decode()
+        self.timeout = timeout
+        self._local = threading.local()
+
+    def _conn(self):
+        conn = getattr(self._local, 'conn', None)
+        if conn is None:
+            conn = http.client.HTTPConnection(self.host, self.port, timeout=self.timeout)
+            self._local.conn = conn
+        return conn
+
+    def _post(self, payload):
+        body = json.dumps(payload).encode()
+        headers = {'Authorization': self._authhdr, 'Content-Type': 'application/json'}
+        last_err = None
+        for _ in range(3):
+            try:
+                conn = self._conn()
+                conn.request('POST', '/', body, headers)
+                resp = conn.getresponse()
+                data = resp.read()
+                if resp.status == 401:
+                    raise RPCError('RPC authentication failed (401). Check --rpcuser/--rpcpassword or the cookie file.')
+                if resp.status not in (200, 500):
+                    raise RPCError(f'HTTP {resp.status} {resp.reason}: {data[:200]!r}')
+                return json.loads(data)
+            except (http.client.HTTPException, OSError, ConnectionError) as e:
+                last_err = e
+                self._local.conn = None  # drop the poisoned connection and retry
+        raise RPCError(f'RPC request failed after retries: {last_err}')
+
+    def call(self, method, params=None):
+        r = self._post({'jsonrpc': '1.0', 'id': 'audit', 'method': method, 'params': params or []})
+        if r.get('error'):
+            raise RPCError(f'{method}: {r["error"]}')
+        return r['result']
+
+    def batch(self, calls):
+        """calls: list of (method, params). Returns results in the same order."""
+        payload = [{'jsonrpc': '1.0', 'id': i, 'method': m, 'params': p or []}
+                   for i, (m, p) in enumerate(calls)]
+        resp = self._post(payload)
+        by_id = {item['id']: item for item in resp}
+        out = []
+        for i, (m, _p) in enumerate(calls):
+            item = by_id[i]
+            if item.get('error'):
+                raise RPCError(f'{m}: {item["error"]}')
+            out.append(item['result'])
+        return out
+
+
+def resolve_credentials(args):
+    """Return (user, password) from explicit args or the datadir cookie file."""
+    if args.rpcuser and args.rpcpassword:
+        return args.rpcuser, args.rpcpassword
+
+    cookie = args.rpccookiefile
+    if not cookie:
+        subdir = NETWORK_DEFAULTS.get(args.network, {}).get('datadir_subdir', '')
+        datadir = os.path.expanduser(args.datadir)
+        cookie = os.path.join(datadir, subdir, '.cookie')
+    if not os.path.exists(cookie):
+        raise RPCError(f'No RPC credentials: pass --rpcuser/--rpcpassword, or ensure the cookie exists ({cookie}).')
+    with open(cookie) as fh:
+        user, _, password = fh.read().strip().partition(':')
+    return user, password
+
+
+def tx_role(index):
+    # In the PoS era (height > nLastPowHeight) blocks are PoS: vtx[0] coinbase, vtx[1] coinstake.
+    return {0: 'coinbase', 1: 'coinstake'}.get(index, 'regular')
+
+
+def scan(args):
+    if args.network not in NETWORK_DEFAULTS:
+        raise RPCError(f'Unsupported --network {args.network!r} (expected main or test).')
+    defaults = NETWORK_DEFAULTS[args.network]
+
+    port = args.rpcport or defaults['rpcport']
+    user, password = resolve_credentials(args)
+    rpc = RPCClient(args.rpcconnect, port, user, password, timeout=args.rpc_timeout)
+
+    # Confirm we're really talking to the network we think we are.
+    info = rpc.call('getblockchaininfo')
+    chain = info['chain']
+    tip = info['blocks']
+    if chain != args.network:
+        raise RPCError(f'Node reports chain={chain!r} but --network={args.network!r}. '
+                       f'Point at the right node or pass the matching --network.')
+
+    last_pow = args.last_pow_height if args.last_pow_height is not None else defaults['last_pow_height']
+    start = args.start_height if args.start_height is not None else last_pow + 1
+    stop = args.stop_height if args.stop_height is not None else tip
+    if start <= last_pow:
+        print(f'[note] start height {start} is within the PoW era (<= nLastPowHeight {last_pow}); '
+              f'the rule does not apply there. Clamping start to {last_pow + 1}.', file=sys.stderr)
+        start = last_pow + 1
+    if stop > tip:
+        stop = tip
+
+    total = max(0, stop - start + 1)
+    print(f'Network        : {chain}')
+    print(f'Chain tip      : {tip}')
+    print(f'nLastPowHeight : {last_pow}  (rule applies to height > this)')
+    print(f'Scan range     : {start} .. {stop}  ({total} blocks)')
+    print(f'Requiring      : every tx nVersion >= {MIN_POS_TX_VERSION} '
+          f'(reject nVersion <= {POW_TX_VERSION})')
+    print(f'Threads        : {args.threads}', flush=True)
+    if total == 0:
+        print('Nothing to scan.')
+        return 0
+
+    violations = []
+    version_hist = {}
+    tx_count = 0
+    hist_lock = threading.Lock()
+    t0 = time.time()
+
+    vfile = None
+    if args.out:
+        vfile = open(args.out, 'w')
+        vfile.write('height,tx_index,role,txid,version\n')
+
+    def fetch_block_versions(height):
+        # getblock needs a hash, so resolve the height first, then fetch the full
+        # block (verbosity=2) so the node deserializes each tx and reports version.
+        blkhash = rpc.call('getblockhash', [height])
+        block = rpc.call('getblock', [blkhash, 2])
+        return height, block
+
+    def handle(result):
+        nonlocal tx_count
+        height, block = result
+        local_hist = {}
+        local_txs = 0
+        for idx, tx in enumerate(block['tx']):
+            ver = tx['version']
+            local_txs += 1
+            local_hist[ver] = local_hist.get(ver, 0) + 1
+            if ver <= POW_TX_VERSION:
+                v = (height, idx, tx_role(idx), tx['txid'], ver)
+                violations.append(v)
+                line = f'{height},{idx},{v[2]},{v[3]},{ver}'
+                print(f'  !! VIOLATION  height={height} idx={idx} ({v[2]}) '
+                      f'version={ver} txid={v[3]}', file=sys.stderr, flush=True)
+                if vfile:
+                    vfile.write(line + '\n')
+                    vfile.flush()
+        with hist_lock:
+            tx_count += local_txs
+            for k, c in local_hist.items():
+                version_hist[k] = version_hist.get(k, 0) + c
+
+    # Process in ordered windows so progress/checkpointing is monotonic while
+    # still fetching each window's blocks concurrently.
+    done = 0
+    with ThreadPoolExecutor(max_workers=args.threads) as pool:
+        h = start
+        while h <= stop:
+            window = list(range(h, min(h + args.window, stop + 1)))
+            for res in pool.map(fetch_block_versions, window):
+                handle(res)
+            done += len(window)
+            h += len(window)
+            if done % args.progress_every < args.window or h > stop:
+                elapsed = time.time() - t0
+                rate = done / elapsed if elapsed else 0
+                remaining = (total - done) / rate if rate else 0
+                print(f'  ... {done}/{total} blocks  ({100*done/total:.1f}%)  '
+                      f'height={h-1}  {rate:.0f} blk/s  ETA {remaining/60:.1f} min  '
+                      f'violations={len(violations)}', flush=True)
+
+    if vfile:
+        vfile.close()
+
+    dt = time.time() - t0
+    print()
+    print('=' * 68)
+    print(f'Scanned {done} blocks / {tx_count} transactions in {dt/60:.1f} min')
+    print('nVersion distribution:')
+    for ver in sorted(version_hist):
+        flag = '  <-- BELOW PoS MINIMUM' if ver <= POW_TX_VERSION else ''
+        print(f'    v{ver}: {version_hist[ver]}{flag}')
+    print('=' * 68)
+    if violations:
+        print(f'RESULT: FAIL — {len(violations)} transaction(s) with nVersion <= {POW_TX_VERSION} '
+              f'in the PoS era. The rule WOULD reject chain history; do NOT ship it as-is.')
+        if args.out:
+            print(f'Offending transactions written to {args.out}')
+        # Show the first few inline for convenience.
+        for v in violations[:20]:
+            print(f'    height={v[0]} idx={v[1]} ({v[2]}) version={v[4]} txid={v[3]}')
+        if len(violations) > 20:
+            print(f'    ... and {len(violations) - 20} more')
+        return 1
+
+    print(f'RESULT: PASS — every PoS-era transaction has nVersion >= {MIN_POS_TX_VERSION}. '
+          f'The rule is consistent with {chain} history over the scanned range.')
+    return 0
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--network', choices=['main', 'test', 'regtest'], default='main',
+                   help='Network to audit (default: main). Must match the node.')
+    p.add_argument('--rpcconnect', default='127.0.0.1', help='RPC host (default: 127.0.0.1)')
+    p.add_argument('--rpcport', type=int, default=None, help='RPC port (default: per-network)')
+    p.add_argument('--rpcuser', default=None, help='RPC username')
+    p.add_argument('--rpcpassword', default=None, help='RPC password')
+    p.add_argument('--rpccookiefile', default=None, help='Path to the RPC .cookie file')
+    p.add_argument('--datadir', default='~/.reddcoin', help='Datadir to find the cookie (default: ~/.reddcoin)')
+    p.add_argument('--rpc-timeout', type=int, default=120, help='Per-request RPC timeout in seconds')
+    p.add_argument('--start-height', type=int, default=None, help='First height to scan (default: nLastPowHeight+1)')
+    p.add_argument('--stop-height', type=int, default=None, help='Last height to scan (default: chain tip)')
+    p.add_argument('--last-pow-height', type=int, default=None, help='Override nLastPowHeight')
+    p.add_argument('--threads', type=int, default=8, help='Concurrent block fetches (default: 8)')
+    p.add_argument('--window', type=int, default=256, help='Blocks per ordered window (default: 256)')
+    p.add_argument('--progress-every', type=int, default=5000, help='Progress print cadence in blocks')
+    p.add_argument('--out', default=None, help='Write offending transactions to this CSV file')
+    args = p.parse_args()
+
+    try:
+        return scan(args)
+    except RPCError as e:
+        print(f'ERROR: {e}', file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print('\nInterrupted. Re-run with --start-height to resume.', file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -67,6 +67,12 @@ public:
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.nLastPowHeight = 260799;
+        // Enforce the PoS tx-version floor only for future blocks. Seven historical
+        // v1 transactions exist at heights 6414327 and 6450671..6452200 (audited via
+        // contrib/devtools/audit_tx_version.py), so the floor MUST activate above them
+        // AND above the tip at release. TODO: replace with a concrete height safely
+        // above the mainnet tip at deployment (placeholder below).
+        consensus.nPosTxVersionFloorHeight = 6700000;
         consensus.nRevertCoinbase = 254208; //! disregard bip34 from this height (?)
         consensus.nCoinbaseMaturity = 30;
         consensus.BIP16Exception = uint256S("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -358,6 +364,9 @@ public:
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.nLastPowHeight = 1439;
+        // TODO: set above the testnet tip at release; re-run the audit on testnet to
+        // confirm the range from this height forward is clean (placeholder below).
+        consensus.nPosTxVersionFloorHeight = 5000000;
         consensus.nCoinbaseMaturity = 50;
         consensus.BIP16Exception = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
         consensus.POSVHeight = 1440;
@@ -622,6 +631,10 @@ public:
         consensus.signet_challenge.clear();
         consensus.nSubsidyHalvingInterval = 210000;
         consensus.nLastPowHeight = 89;  // Allow enough PoW blocks for TestChain100Setup
+        // Regtest: keep the floor active for the whole PoS era (height >= 90).
+        // Identical to the previous rule (nHeight > nLastPowHeight), so the
+        // functional tests exercise it unchanged.
+        consensus.nPosTxVersionFloorHeight = 90;
         consensus.nCoinbaseMaturity = 60;  // Fast maturity for regtest, gives ~40 mature coinbases at height 100
         consensus.BIP16Exception = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
         consensus.POSVHeight = 90;      // Activate at PoS transition (nLastPowHeight + 1), matching mainnet/testnet pattern

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -128,6 +128,12 @@ struct Params {
     int64_t nStakeMaxAge;
     int64_t nModifierInterval;
     int nLastPowHeight;
+    /** Height at (and above) which PoS-era blocks must contain only
+     *  nVersion > POW_TX_VERSION transactions (bad-txns-version-pos).
+     *  Set above the deployment tip so pre-existing v1 txs are grandfathered.
+     *  Defaults to "never active" so a network that does not set it (e.g. signet)
+     *  never spuriously rejects blocks. */
+    int nPosTxVersionFloorHeight{std::numeric_limits<int>::max()};
 
     /**
      * If true, witness commitments contain a payload equal to a Bitcoin Script solution

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -585,6 +585,17 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     if (tx.IsCoinBase() || tx.IsCoinStake())
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "coinbase");
 
+    // ReddCoin: mirror the PoS-era transaction-version floor enforced in
+    // ContextualCheckBlock so legacy nVersion <= POW_TX_VERSION (zero-nTime) txs are
+    // never relayed into, or mined for, a block subject to the floor. The tx would be
+    // confirmed in the next block (tip height + 1), so apply once that height reaches
+    // the activation height.
+    if (m_active_chainstate.m_chain.Height() + 1 >= args.m_chainparams.GetConsensus().nPosTxVersionFloorHeight
+        && tx.nVersion <= POW_TX_VERSION) {
+        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-version-pos",
+                             strprintf("transaction version %d below PoS minimum %d", tx.nVersion, POW_TX_VERSION + 1));
+    }
+
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     std::string reason;
     if (fRequireStandard && !IsStandardTx(tx, reason))
@@ -3404,6 +3415,26 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     for (const auto& tx : block.vtx) {
         if (!IsFinalTx(*tx, nHeight, nLockTimeCutoff)) {
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-txns-nonfinal", "non-final transaction");
+        }
+    }
+
+    // ReddCoin: after the PoW era the chain is PoS-only, so every transaction must
+    // carry a non-zero nTime. nTime is serialized only for nVersion > POW_TX_VERSION
+    // (primitives/transaction.h), so legacy nVersion <= POW_TX_VERSION ("v1") txs
+    // have no timestamp: their outputs enter the UTXO set with Coin.nTime == 0,
+    // which makes PoSV coin-age ambiguous (the nTime==0 fallback resolves
+    // differently across implementations -> consensus divergence). Require all
+    // such transactions to be nVersion >= POSV_TX_VERSION. Gated on
+    // nPosTxVersionFloorHeight (an activation height above the deployment tip) so
+    // that historical blocks — the PoW era AND a handful of PoS-era blocks that
+    // legitimately contain v1 txs (see contrib/devtools/audit_tx_version.py) —
+    // still validate. Only blocks at/after activation are constrained.
+    if (nHeight >= consensusParams.nPosTxVersionFloorHeight) {
+        for (const auto& tx : block.vtx) {
+            if (tx->nVersion <= POW_TX_VERSION) {
+                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-txns-version-pos",
+                                     strprintf("transaction version %d below PoS minimum %d", tx->nVersion, POW_TX_VERSION + 1));
+            }
         }
     }
 

--- a/test/functional/feature_pos_tx_version_floor.py
+++ b/test/functional/feature_pos_tx_version_floor.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the PoS-era transaction-version floor (bad-txns-version-pos).
+
+After the PoW era the chain is PoS-only, so every transaction must carry a
+non-zero nTime. nTime is serialized only for nVersion > POW_TX_VERSION, so a
+legacy v1 (nVersion <= POW_TX_VERSION) transaction has no timestamp and its
+outputs would enter the UTXO set with Coin.nTime == 0 — making PoSV coin age
+ambiguous. consensus.nPosTxVersionFloorHeight enforces a minimum version at and
+above that height (regtest = 90, i.e. the whole PoS era), rejecting v1 txs with
+reason bad-txns-version-pos in two places:
+
+  * the mempool  (MemPoolAccept::PreChecks), and
+  * block connection (ContextualCheckBlock).
+
+A companion rule in CheckTransaction requires nVersion > POW_TX_VERSION txs to
+carry a non-zero nTime (bad-txns-time-zero). Together they mean a PoS-era tx
+must be v2+ with a timestamp. This test drives, at the v1/v2 boundary:
+
+  * v1                      -> bad-txns-version-pos (floor; mempool and block),
+  * v2 with nTime == 0      -> bad-txns-time-zero (CheckTransaction),
+  * v2 with a valid nTime   -> accepted (above the floor) and mined,
+  * a normal v3 wallet tx   -> accepted and mined,
+  * an empty PoS block      -> accepted,
+
+so the floor rejects only v1 and correctly admits v2/v3.
+"""
+
+from test_framework.blocktools import (
+    create_block,
+    sign_block,
+    NORMAL_GBT_REQUEST_PARAMS,
+)
+from test_framework.messages import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+)
+from test_framework.script_util import keyhash_to_p2pkh_script
+from test_framework.address import hash160
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    advance_time_for_pos,
+)
+
+POW_TX_VERSION = 1                 # below the PoS-era floor
+POSV_TX_VERSION = 2                # first version above the floor (carries nTime)
+FLOOR_HEIGHT = 90                  # regtest consensus.nPosTxVersionFloorHeight
+
+
+class PosTxVersionFloorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = False  # cache tip (199) is above the regtest floor
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _v1_tx(self, outpoint, value_sat, spk):
+        """A structurally valid but unsigned v1 transaction. The version floor
+        rejects it before any script/input checks, so no signature is needed."""
+        tx = CTransaction()
+        tx.nVersion = POW_TX_VERSION  # v1: no nTime is serialized for nVersion <= 1
+        tx.nTime = 0
+        tx.vin = [CTxIn(outpoint)]
+        tx.vout = [CTxOut(value_sat, spk)]
+        tx.rehash()
+        return tx
+
+    def _new_spk(self, node):
+        return bytes.fromhex(node.getaddressinfo(node.getnewaddress())["scriptPubKey"])
+
+    def sign_block_with_coinstake_key(self, node, block):
+        """Sign a PoS block with the coinstake's key (coinstake vout[1] is P2PK)."""
+        spk = bytes(block.vtx[1].vout[1].scriptPubKey)
+        signing_key = None
+        if len(spk) in (35, 67) and spk[-1] == 0xac:  # <push> <pubkey> OP_CHECKSIG
+            p2pkh = keyhash_to_p2pkh_script(hash160(spk[1:-1]))
+            addr = node.decodescript(p2pkh.hex()).get('address')
+            if addr:
+                try:
+                    signing_key = node.dumpprivkey(addr)
+                except Exception as e:
+                    self.log.debug("coinstake key lookup failed: %s" % e)
+        if not signing_key:
+            signing_key = node.get_deterministic_priv_key().key
+        sign_block(block, signing_key)
+
+    def _build_pos_block(self, node, extra_txs):
+        """Build (but do not submit) a signed PoS block via GBT, appending
+        extra_txs after the coinstake."""
+        tmpl = None
+        for _ in range(10):
+            advance_time_for_pos(node, seconds=120)
+            try:
+                tmpl = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
+                break
+            except Exception as e:
+                if "no valid coinstake found" in str(e):
+                    continue
+                raise
+        assert tmpl is not None, "failed to get a PoS block template"
+        # Keep only the coinstake; append our own txs deterministically.
+        tmpl['transactions'] = tmpl['transactions'][:1]
+        block = create_block(tmpl=tmpl)
+        for tx in extra_txs:
+            tx.rehash()
+            block.vtx.append(tx)
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.rehash()
+        self.sign_block_with_coinstake_key(node, block)
+        return block
+
+    # ------------------------------------------------------------------
+    # Test
+    # ------------------------------------------------------------------
+
+    def run_test(self):
+        node = self.nodes[0]
+        assert node.getblockcount() >= FLOOR_HEIGHT
+        advance_time_for_pos(node, seconds=600)
+
+        # --- Mempool enforcement --------------------------------------------
+        # v1 is rejected by the version floor (MemPoolAccept::PreChecks).
+        self.log.info("Mempool: v1 tx -> bad-txns-version-pos")
+        utxo = node.listunspent(1)[0]
+        v1 = self._v1_tx(
+            COutPoint(int(utxo["txid"], 16), utxo["vout"]),
+            int(utxo["amount"] * COIN) - COIN,  # leave a 1-RDD fee
+            self._new_spk(node),
+        )
+        # maxfeerate=0 disables the fee guard so the version rule is what fires.
+        assert_raises_rpc_error(-26, "bad-txns-version-pos",
+                                node.sendrawtransaction, v1.serialize().hex(), 0)
+
+        # A v2 tx with nTime == 0 is rejected by the companion rule
+        # (bad-txns-time-zero, CheckTransaction) before any script check.
+        self.log.info("Mempool: v2 tx with nTime==0 -> bad-txns-time-zero")
+        v2_zero = CTransaction()
+        v2_zero.nVersion = POSV_TX_VERSION
+        v2_zero.nTime = 0
+        v2_zero.vin = [CTxIn(COutPoint(0xdeadbeef, 1))]
+        v2_zero.vout = [CTxOut(COIN, self._new_spk(node))]
+        v2_zero.rehash()
+        assert_raises_rpc_error(-26, "bad-txns-time-zero",
+                                node.sendrawtransaction, v2_zero.serialize().hex(), 0)
+
+        # A signed v2 tx with a valid nTime is accepted: v2 is above the floor.
+        self.log.info("Mempool: signed v2 tx with a valid nTime -> accepted")
+        u2 = node.listunspent(1)[1]
+        v2 = CTransaction()
+        v2.nVersion = POSV_TX_VERSION
+        v2.nTime = node.mocktime  # aligned with the chain, non-zero
+        v2.vin = [CTxIn(COutPoint(int(u2["txid"], 16), u2["vout"]))]
+        v2.vout = [CTxOut(int(u2["amount"] * COIN) - COIN, self._new_spk(node))]
+        v2.rehash()
+        signed = node.signrawtransactionwithwallet(v2.serialize().hex())
+        assert signed["complete"], "failed to sign v2 tx"
+        v2_txid = node.sendrawtransaction(signed["hex"], 0)
+        assert v2_txid in node.getrawmempool()
+
+        # A normal v3 wallet tx is also accepted; mine a block and confirm both
+        # the v2 and v3 txs are included (block-path acceptance of v2/v3).
+        self.log.info("Mempool: v3 wallet tx accepted; v2 and v3 mine into a PoS block")
+        v3_txid = node.sendtoaddress(node.getnewaddress(), 1)
+        assert v3_txid in node.getrawmempool()
+        advance_time_for_pos(node, seconds=60)
+        blk_txs = node.getblock(node.generate(1)[0])["tx"]
+        assert v2_txid in blk_txs and v3_txid in blk_txs, \
+            "v2 and v3 txs should mine into a PoS block"
+
+        # --- Block enforcement (ContextualCheckBlock) ------------------------
+        self.log.info("Block: a PoS block containing a v1 transaction is rejected")
+        tip = node.getbestblockhash()
+        # Use a dummy prevout so the v1 tx can never collide with a coinstake
+        # input; ContextualCheckBlock rejects on version before inputs are checked.
+        bad_block = self._build_pos_block(
+            node, [self._v1_tx(COutPoint(0xdeadbeef, 0), COIN, self._new_spk(node))])
+        resp = node.submitblock(bad_block.serialize().hex())
+        assert resp is not None and "bad-txns-version-pos" in resp, \
+            f"expected bad-txns-version-pos rejection, got: {resp!r}"
+        assert_equal(node.getbestblockhash(), tip)  # tip must not advance
+
+        # Positive control: the same block shape without the v1 tx is accepted.
+        self.log.info("Block: an empty PoS block (no v1 tx) is accepted")
+        good_block = self._build_pos_block(node, [])
+        resp = node.submitblock(good_block.serialize().hex())
+        assert resp is None, f"a valid empty PoS block was rejected: {resp!r}"
+        assert_equal(node.getbestblockhash(), good_block.hash)
+
+        self.log.info("PoS tx-version floor verified (mempool + block enforcement)")
+
+
+if __name__ == '__main__':
+    PosTxVersionFloorTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -242,6 +242,7 @@ BASE_SCRIPTS = [
     'mining_basic.py',
     'feature_pos_basic.py',
     'feature_pos_sync.py',
+    'feature_pos_tx_version_floor.py',
     # v4.22.9 ↔ v4.22.10 compatibility tests (require releases/v4.22.9/bin/)
     'feature_compat_p2p_sync.py',
     'feature_compat_pos_blocks.py',


### PR DESCRIPTION
## Summary

Fixes PoS blocks silently forfeiting their transaction fees. The block assembler builds the coinstake before the block's fees are known (`CreateCoinStake` uses `fees=0`) and never reconciled it afterward, so a PoS block's transaction fees were dropped and the money supply shrank. `ConnectBlock` already allows the fee-inclusive reward `GetProofOfStakeReward(nCoinAge, nFees, ...)`, split 92/8 with the dev fund, so fee-collecting coinstakes were always valid.

This adds `FinalizeCoinStakeReward()`, called from `CreateNewBlock` after `addPackageTxs` once `nFees` is known. It recomputes the reward with the actual fees, rewrites the coinstake outputs to match `ConnectBlock`'s expectation exactly, and re-signs. Fees are now paid to the staker and dev fund, and the money supply is conserved.

## Changes

- `src/pos/stake.cpp`, `src/pos/stake.h`: add `FinalizeCoinStakeReward()`.
- `src/miner.cpp`: call it from `CreateNewBlock` after fees are known.

## Testing

- `feature_pos_coinstake_fees.py`: verifies the collected fees, with a `--previous_release` mode confirming a v4.22.9 follower accepts the fee-collecting coinstakes past `DonationHeight`.

## Compatibility

The consensus validator is unchanged, so fee-collecting coinstakes were always valid and remain compatible with v4.22.9 followers. This corrects assembler behavior, not the consensus rule.
