### PR TITLE
test: use v2 transactions in txvalidationcache_tests for the PoS version floor

### DIFF
--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -79,8 +79,10 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
     spends.resize(2);
     for (int i = 0; i < 2; i++)
     {
-        spends[i].nVersion = 1;
-        spends[i].nTime = 0;  // Reddcoin: version 1 transactions must have nTime=0
+        // PoS-era blocks and mempool reject tx nVersion < 2 (bad-txns-version-pos);
+        // a v>=2 Reddcoin tx serializes a non-zero nTime.
+        spends[i].nVersion = 2;
+        spends[i].nTime = 1;
         spends[i].vin.resize(1);
         spends[i].vin[0].prevout.hash = unspent_coinbase->GetHash();
         spends[i].vin[0].prevout.n = 0;
@@ -269,8 +271,12 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
     // coinbase tx.
     CMutableTransaction spend_tx;
 
-    spend_tx.nVersion = 1;
-    spend_tx.nTime = 0;  // Reddcoin: version 1 transactions must have nTime=0
+    // spend_tx is included in a block below, so it must satisfy the PoS-era tx
+    // version floor (nVersion >= 2); a v>=2 Reddcoin tx serializes a non-zero
+    // nTime. The transactions derived from it further down are only exercised
+    // through CheckInputScripts (never block-included), so they may stay v1.
+    spend_tx.nVersion = 2;
+    spend_tx.nTime = 1;
     spend_tx.vin.resize(1);
     spend_tx.vin[0].prevout.hash = unspent_coinbase->GetHash();
     spend_tx.vin[0].prevout.n = 0;


### PR DESCRIPTION
## Summary

Fixes the four `txvalidationcache_tests` failures on `develop`. The PoS-era transaction-version floor (`cfd12b5118`, #405) rejects transactions with `nVersion < 2` in blocks and in the mempool (`bad-txns-version-pos`), but this test still built its spend transactions at version 1. As a result the double-spend transactions could not enter the mempool, and `checkinputs_test` aborted with a fatal error when its funding transaction was mined (`ProcessNewBlock failed, block not accepted`).

This is the same class of breakage the `feature_segwit` functional test was already updated for in `6096619b8b`.

## Changes

- `tx_mempool_block_doublespend`: build `spends[0]` and `spends[1]` at   `nVersion = 2` with a non-zero `nTime`.
- `checkinputs_test`: build `spend_tx` (the transaction that gets mined) at   `nVersion = 2` with a non-zero `nTime`.

Both match the existing `fresh_spend` transaction in the same file, which was already v2. The transactions derived from `spend_tx` are only exercised through `CheckInputScripts` and are never block-included, so they stay at v1; the
version floor is a contextual block/mempool check and does not affect `CheckInputScripts`.

## Testing

`src/test/test_reddcoin --run_test=txvalidationcache_tests` passes (both `tx_mempool_block_doublespend` and `checkinputs_test`). No production code changes; test-only.