### PR TITLE
chainparams: regenerate regtest assumeutxo hash for the PoS test chain

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -740,7 +740,7 @@ public:
         m_assumeutxo_data = MapAssumeutxo{
             {
                 110,
-                {AssumeutxoHash{uint256S("106f9f9bd6c57cea84444957b5630e4a1679a658c73455a0e0362ff0174ee181")}, 132},
+                {AssumeutxoHash{uint256S("080f5ece159087ec489488c9f32f2ca67e1e5a0f4587e9f239bfa0e8e365baa7")}, 132},
             },
             {
                 200,


### PR DESCRIPTION
## Summary

Fixes `validation_chainstatemanager_tests/chainstatemanager_activate_snapshot` on `develop`. The regtest assumeutxo `hash_serialized` for height 110 no longer matched the UTXO set the `TestChain100Setup` regtest chain produces at that
height, so activating a valid snapshot was rejected with a content-hash mismatch. The PoS consensus work merged into `develop` (staking rewards, coin age, and the transaction-version floor) changed the output values in the test chain, and the hardcoded baseline was never regenerated.

## Changes

- `src/chainparams.cpp`: update the height-110 regtest assumeutxo   `hash_serialized` to the current HASH_SERIALIZED value of the UTXO set (confirmed identical across runs).

`nChainTx` (132) is unchanged: `ActivateSnapshot` forces `tip->nChainTx = au_data.nChainTx`, so the test's post-activation `nChainTx` check is self-consistent regardless of the underlying count.

## Notes on correctness

The new hash is the HASH_SERIALIZED of the full UTXO set at height 110, taken from the unmalleated snapshot activation (not from one of the malleation sub-cases, which load a deliberately-modified set). With the correct value the malleation checks (missing UTXO, wrong count, wrong base hash) are once again rejected for their own reasons rather than all being masked by a hash mismatch, and the positive activation succeeds.

This updates a regtest-only consensus-params baseline and assumes the current PoS chain state is the intended one (the consensus changes are deliberately-merged PRs). The height-200 entry in the same map is not exercised by any test and is left unchanged; it may also be stale if a future test activates a 200-height snapshot.

## Testing

`src/test/test_reddcoin --run_test=validation_chainstatemanager_tests` passes (3/3 cases). Functionally there is no `feature_assumeutxo.py` that depends on this value, and `rpc_dumptxoutset.py` (the related UTXO-dump functional test)
passes.