### PR TITLE
test: disconnect nodes before node0's pre-activation taproot tests

### DIFF
--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1590,12 +1590,24 @@ class TaprootTest(BitcoinTestFramework):
         self.nodes[1].generate(ACTIVATION_HEIGHT + COINBASE_MATURITY + 1 - self.nodes[1].getblockcount())
         self.test_spenders(self.nodes[1], spenders_taproot_active(), input_counts=[1, 2, 2, 2, 2, 3])
 
-        # ReddCoin: connect nodes and sync so node0 receives its now-mature coins.
+        # ReddCoin: connect nodes and sync so node0 (previous release) validates
+        # node1's full post-activation taproot chain (the cross-version coverage
+        # this variant exists for) and receives its now-mature coins.
         # Sync mocktime first — node1's time is far ahead from block generation.
         from test_framework.util import set_node_times
         set_node_times(self.nodes, self.nodes[1].mocktime)
         self.connect_nodes(1, 0)
         self.sync_blocks()
+        # Disconnect before node0 stakes its own pre-activation blocks. Kept
+        # connected, node0 serves the test's rapid generate/sendrawtransaction
+        # calls *and* P2P block relay from node1 at once; under that combined
+        # load its RPC httpserver stops accepting connections (the persistent
+        # RPC connection desyncs and the reconnect is refused), aborting the
+        # test. node0 has already validated node1's chain by this point, so
+        # disconnecting loses no coverage; it just lets node0 run its own tests
+        # in isolation. This is a test-harness load artifact, not consensus:
+        # node0 accepts node1's entire chain with zero rejections.
+        self.disconnect_nodes(1, 0)
 
         # Pre-taproot activation tests.
         # Node0 uses -vbparams=taproot:-2:0 (NEVER_ACTIVE), so taproot rules


### PR DESCRIPTION
## Summary

`feature_taproot.py --previous_release` fails on `develop`. The variant runs the released v4.22.9 binary as node0. node1 (this build) stakes its post-activation taproot tests under rapid mocktime, the test syncs node0 to that chain, and then 
node0 runs its own pre-activation ("inactive") tests while the two nodes stay connected. The run aborts at the first `setmocktime` of the pre-activation phase with an RPC connection error.

## Root cause (fully investigated)

It is a test-harness load artifact, not a consensus problem.

Kept connected, node0 has to serve the pre-activation phase's rapid `generate`/`sendrawtransaction` calls and P2P block relay from node1 at the same time. Under that combined load node0's RPC httpserver stops accepting connections: the framework's persistent RPC connection desyncs (`CannotSendRequest: Request-sent`), the authproxy self-heal closes and reconnects, and the reconnect is refused (`ConnectionRefused`), so `setmocktime` fails and the test aborts. node0 is not crashed (no assert, no segfault, no OOM, no LevelDB corruption); it is simply saturated.

This was pinned with two un-instrumented runs. In both, node0 validated node1's entire post-activation taproot chain with zero consensus rejections: no `bad-pos`, no `posv-amount`/`dev-amount`, no coin-age divergence, zero `DisconnectTip`. node0 accepts every block node1 produced. The `CheckStakeKernelHash: nTimeTx < txPrev.nTime` lines that appear later are benign
coinstake-search noise from node0's own CreateCoinStake` (it skips those candidates and still stakes past them). The cross-version soft-fork compatibility this variant exists to exercise genuinely passes.

Consensus compatibility was independently reconfirmed by reindexing the entire real mainnet chain (genesis to height 6,520,000, all ~6.26M PoS coinstakes) with this build: zero coin-age/kernel/reward rejections, i.e. this build validates the real chain identically to v4.22.9.

## Changes

- `test/functional/feature_taproot.py`, `run_test`: after syncing node0 to node1's post-activation chain, `disconnect_nodes(1, 0)` before node0 stakes its  own pre-activation blocks. node0 has already validated node1's full chain by then, so no coverage is lost; it just runs its own tests in isolation without the concurrent P2P load. The sync keeps its original position, so node0 still validates node1's complete taproot-active chain.

## Rationale

The alternatives were rejected. Syncing node0 *before* node1's post-activation staking (an earlier draft of this fix) also avoids the load, but it stops node0 from ever validating node1's taproot-active blocks, which discards the very cross-version coverage the variant is for. Changing `GetCoinAge`/`CreateCoinStake` is unwarranted: the mainnet reindex proves this build is already mainnet-compatible, and no consensus divergence occurs in the test. Skipping the variant would drop the v4.22.9 coverage entirely. Disconnecting after the full sync keeps the coverage and removes only the harness-induced RPC saturation.

## Testing

`feature_taproot.py --previous_release` passes (`Tests successful`). node0 syncs and validates node1's full post-activation taproot chain with zero rejections, disconnects, and runs its pre-activation tests to completion. `feature_taproot.py` (default) is unaffected: both nodes are this build and the disconnect sits on the `--previous_release`-only path.