### PR TITLE
test: fix --usecli createwallet passphrase regression from 1efed379

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -733,8 +733,12 @@ class RPCOverloadWrapper():
         bip39_args = [wallet_type, mnemonic, mnemonic_passphrase, language, entropy_bits]
         has_bip39 = any(a is not None for a in bip39_args)
         if not has_bip39:
-            # Original positional call for backward compatibility
-            return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors, load_on_startup, external_signer)
+            # Original positional call for backward compatibility. Pass an empty
+            # string (not None) for an unset passphrase: in --usecli mode a None
+            # positional arg is serialized to the literal string "null", and
+            # since createwallet's passphrase is a string param the CLI keeps it
+            # verbatim, encrypting the wallet with the passphrase "null".
+            return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase if passphrase is not None else '', avoid_reuse, descriptors, load_on_startup, external_signer)
         # Use named args to avoid CLI "null" string issues with sparse optional params
         params = {'wallet_name': wallet_name, 'descriptors': descriptors}
         if disable_private_keys is not None:


### PR DESCRIPTION
## Summary

Fixes `wallet_createwallet.py`, `wallet_multiwallet.py` and `wallet_watchonly.py` under `--usecli` on `develop`. All three create wallets through RPCOverloadWrapper.createwallet`, and all three failed with `Please enter the wallet passphrase with walletpassphrase first (-13)` because the wallet was unexpectedly created encrypted.

`1efed379` changed the wrapper's `passphrase` default from `''` to `None` (to silence a Codacy/Bandit hardcoded-password warning). That is correct for the named-argument (BIP39) branch and for the RPC path, but the non-BIP39 branch still delegates `createwallet` positionally. In `--usecli` mode a `None` positional argument is serialized by `arg_to_cli` to the literal string
`"null"`, and because `createwallet`'s `passphrase` is a string parameter the CLI keeps it verbatim, so the wallet was created encrypted with the passphrase `"null"`. The RPC path was unaffected (authproxy sends real JSON `null`, which `createwallet` treats as no passphrase), which is why only `--usecli` failed.

## Changes

- `test/functional/test_framework/test_node.py`, `RPCOverloadWrapper.createwallet`: in the positional (non-BIP39) delegation,   pass an empty string for an unset passphrase instead of `None`, restoring the pre-`1efed379` behaviour while keeping the `None` default that satisfies the Codacy warning.

## Testing

`wallet_createwallet.py --usecli`, `wallet_multiwallet.py --usecli` and `wallet_watchonly.py --usecli --legacy-wallet` pass. The RPC (non-cli) variants were already passing and are unchanged.