### PR TITLE
test: fix feature_csv_activation coinstake over-payment after coinstake fees

### DIFF
--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -57,6 +57,7 @@ from test_framework.messages import (
     COIN,
     CTransaction,
     CTxOut,
+    tx_from_hex,
 )
 from test_framework.p2p import P2PDataStore
 from test_framework.script import (
@@ -215,11 +216,41 @@ class BIP68_112_113Test(BitcoinTestFramework):
                 else:
                     raise
 
+        # The template's coinstake collects the fees of the mempool transactions
+        # this template would mine (FinalizeCoinStakeReward, added in b4951959).
+        # We strip those transactions and mine only `txs`, so the coinstake must
+        # not keep their fees: otherwise it pays base + stripped_fees while the
+        # block only carries this block's fees, and ConnectBlock rejects it as
+        # bad-posv-amount (the check is nStakeReward > GetProofOfStakeReward(
+        # nCoinAge, nFees), an upper bound). Remove the stripped fees so the
+        # coinstake pays the base reward only, which is always <= base + the
+        # block's actual fees.
+        stripped_fees = sum(int(t.get('fee', 0)) for t in tmpl['transactions'][1:])
+
         # Strip template to coinstake only (avoid mempool conflicts after invalidateblock)
         tmpl['transactions'] = [tmpl['transactions'][0]]
 
         # Build block: create_block handles coinbase + coinstake from template, txlist adds test txs
         block = create_block(tmpl=tmpl, txlist=txs)
+
+        if stripped_fees > 0:
+            # The reward is split 92% staker / 8% dev (dev output is the last
+            # coinstake output; see FinalizeCoinStakeReward / ConnectBlock).
+            # Mirror that split when removing the stripped fees, and drop one
+            # extra satoshi from the dev output so it stays strictly under the
+            # validator's dev-credit ceiling regardless of integer rounding.
+            coinstake = block.vtx[1]
+            dev_cut = stripped_fees * 8 // 100 + 1
+            staker_cut = stripped_fees - stripped_fees * 8 // 100
+            coinstake.vout[-1].nValue -= dev_cut
+            coinstake.vout[1].nValue -= staker_cut
+            # Re-sign the coinstake input(s) over the new output amounts.
+            for txin in coinstake.vin:
+                txin.scriptSig = b""
+            signed = node.signrawtransactionwithwallet(coinstake.serialize().hex())
+            assert signed['complete'], "failed to re-sign adjusted coinstake"
+            block.vtx[1] = tx_from_hex(signed['hex'])
+
         block.hashMerkleRoot = block.calc_merkle_root()
         block.rehash()
         block.solve()

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -333,7 +333,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         # Inputs at height = CSV_ACTIVATION_HEIGHT - 4 (= 428)
         #
         # Put inputs for all tests in the chain (time increases by ~600s per block)
-        # Note we reuse inputs for v1 and v2 txs so must test these separately
+        # Note we reuse inputs for the below-threshold (v2) and above-threshold (v3) txs so must test these separately
         # 16 normal inputs
         bip68inputs = []
         for _ in range(16):
@@ -429,7 +429,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.log.info("TESTING")
 
         self.log.info("Pre-Soft Fork Tests. All txs should pass.")
-        self.log.info("Test version 1 txs")
+        self.log.info("Test version 2 txs")
 
         success_txs = []
         # BIP113 tx, -1 CSV tx and empty stack CSV tx should succeed
@@ -451,7 +451,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.send_blocks([self.create_test_block(success_txs)])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
-        self.log.info("Test version 2 txs")
+        self.log.info("Test version 3 txs")
 
         success_txs = []
         # BIP113 tx, -1 CSV tx and empty stack CSV tx should succeed
@@ -472,7 +472,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.send_blocks([self.create_test_block(success_txs)])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
-        self.log.info("Test version 3 txs")
+        self.log.info("Test version 3 txs (BIP113)")
         # BIP113 with nVersion=3 (ReddCoin standard tx version) should also pass pre-activation
         # BIP68/BIP112 v3 already tested above (v2 vars use nVersion=3)
         tip_mtp = node.getblockheader(node.getbestblockhash())['mediantime']
@@ -522,14 +522,14 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.generate_blocks(4)
 
         self.log.info("BIP 68 tests")
-        self.log.info("Test version 1 txs - all should still pass")
+        self.log.info("Test version 2 txs - all should still pass")
 
         success_txs = []
         success_txs.extend(all_rlt_txs(bip68txs_v1))
         self.send_blocks([self.create_test_block(success_txs)])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
-        self.log.info("Test version 2 txs")
+        self.log.info("Test version 3 txs")
 
         # All txs with SEQUENCE_LOCKTIME_DISABLE_FLAG set pass
         bip68success_txs = [tx['tx'] for tx in bip68txs_v2 if tx['sdf']]
@@ -564,21 +564,21 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
         self.log.info("BIP 112 tests")
-        self.log.info("Test version 1 txs")
+        self.log.info("Test version 2 txs")
 
         # -1 OP_CSV tx and (empty stack) OP_CSV tx should fail
         self.send_blocks([self.create_test_block([bip112tx_special_v1])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Negative locktime)')
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v1])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Operation not valid with the current stack size)')
-        # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 1 txs should still pass
+        # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 2 txs should still pass
 
         success_txs = [tx['tx'] for tx in bip112txs_vary_OP_CSV_v1 if tx['sdf']]
         success_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_9_v1 if tx['sdf']]
         self.send_blocks([self.create_test_block(success_txs)])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
-        # If SEQUENCE_LOCKTIME_DISABLE_FLAG is unset in argument to OP_CSV, version 1 txs should now fail
+        # If SEQUENCE_LOCKTIME_DISABLE_FLAG is unset in argument to OP_CSV, version 2 txs should now fail
         fail_txs = all_rlt_txs(bip112txs_vary_nSequence_v1)
         fail_txs += all_rlt_txs(bip112txs_vary_nSequence_9_v1)
         fail_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_v1 if not tx['sdf']]
@@ -587,7 +587,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
             self.send_blocks([self.create_test_block([tx])], success=False,
                              reject_reason='non-mandatory-script-verify-flag (Locktime requirement not satisfied)')
 
-        self.log.info("Test version 2 txs")
+        self.log.info("Test version 3 txs")
 
         # -1 OP_CSV tx and (empty stack) OP_CSV tx should fail
         self.send_blocks([self.create_test_block([bip112tx_special_v2])], success=False,
@@ -595,7 +595,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.send_blocks([self.create_test_block([bip112tx_emptystack_v2])], success=False,
                          reject_reason='non-mandatory-script-verify-flag (Operation not valid with the current stack size)')
 
-        # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 2 txs should pass (all sequence locks are met)
+        # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 3 txs should pass (all sequence locks are met)
         success_txs = [tx['tx'] for tx in bip112txs_vary_OP_CSV_v2 if tx['sdf']]
         success_txs += [tx['tx'] for tx in bip112txs_vary_OP_CSV_9_v2 if tx['sdf']]
 


### PR DESCRIPTION
## Summary

Fixes `feature_csv_activation.py` on `develop`. The test built each PoS test block from a `getblocktemplate` coinstake, stripped the template's mempool transactions, and mined only its own test transactions. Since `b4951959` ("collect block transaction fees into the coinstake"), the template coinstake collects the fees of those mempool transactions via `FinalizeCoinStakeReward`,
so after stripping them the coinstake paid `base + stripped_fees` while the block only carried its own fees. `ConnectBlock` rejects that as `bad-posv-amount` (the check is `nStakeReward > GetProofOfStakeReward(nCoinAge, nFees)`, an upper bound), which discouraged and disconnected the test peer and left the test hanging on a P2P `wait_until`.

`b4951959` did not change the consensus validator; it changed the miner (`getblocktemplate`), and the test's strip-the-template pattern is what turned the now-fee-inclusive coinstake into an over-payment.

## Changes

- `test/functional/feature_csv_activation.py`, `create_test_block`: remove the stripped mempool fees from the coinstake so it pays the base reward only (always <= base + the block's actual fees). The reward is split 92% staker / 8% dev (dev output last), so reduce the dev output by the 8% share plus one satoshi (to stay under the validator's dev-credit ceiling regardless of integer rounding) and the staker output by the 92% share, then clear and re-sign the coinstake inputs over the new amounts with `signrawtransactionwithwallet`.

Test-only change; no consensus or production code is touched.

## Testing

`test/functional/feature_csv_activation.py` passes (all BIP68 / BIP112 / BIP113 phases across tx versions 1, 2 and 3). This completes the targeted validation set: with this fix, all of feature_pos_tx_version_floor, feature_compat_tx_versions,
feature_cltv, feature_csv_activation, mempool_accept, rpc_dumptxoutset, feature_reindex and feature_assumevalid pass.