### PR TITLE
test: fix scrypt-missing fallback and the feature_minchainwork sync stall, clear flake8 debt

### DIFF
--- a/test/functional/create_rpc_psbt_data.py
+++ b/test/functional/create_rpc_psbt_data.py
@@ -24,7 +24,7 @@ import sys
 
 # Add test framework to path for segwit_addr
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_framework'))
-from segwit_addr import bech32_decode, bech32_encode
+from segwit_addr import bech32_decode, bech32_encode  # noqa: E402
 
 
 NTIME = 1609459200  # 2021-01-01 00:00:00 UTC
@@ -250,11 +250,10 @@ def _patch_raw_tx(tx_hex, ntime=NTIME):
     # Detect segwit
     pos = f.tell()
     marker = struct.unpack('B', f.read(1))[0]
-    is_segwit = False
     if marker == 0:
         flag = struct.unpack('B', f.read(1))[0]
         if flag != 0:
-            is_segwit = True
+            pass
         else:
             f.seek(pos)
     else:

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -221,7 +221,6 @@ class AssumeValidTest(BitcoinTestFramework):
 
         # Combine all headers for sending (PoW block headers + PoS fake headers)
         all_headers = [CBlockHeader(b) for b in self.blocks] + self.pos_headers
-        total_height = POW_HEIGHT + POS_HEADERS  # = 2289
 
         self.nodes[0].disconnect_p2ps()
 

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -27,12 +27,9 @@ from test_framework.messages import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    assert_equal,
-    assert_greater_than,
     assert_raises_rpc_error,
     satoshi_round,
     softfork_active,
-    advance_time_for_pos,
 )
 from test_framework.script_util import DUMMY_P2WPKH_SCRIPT
 

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -12,7 +12,6 @@ from test_framework.blocktools import (
     create_block,
     create_coinbase,
     create_tx_with_script,
-    get_legacy_sigopcount_block,
     MAX_BLOCK_SIGOPS,
     NORMAL_GBT_REQUEST_PARAMS,
     sign_block,
@@ -27,7 +26,6 @@ from test_framework.messages import (
     CTxOut,
     MAX_BLOCK_BASE_SIZE,
     tx_from_hex,
-    uint256_from_compact,
     uint256_from_str,
 )
 from test_framework.p2p import P2PDataStore
@@ -185,8 +183,6 @@ class FullBlockTest(BitcoinTestFramework):
         self.log.info("Don't reorg to a chain of the same length")
         self.move_tip(1)
         b3 = self.next_block(3, spend=out[1])
-        # PoS fork block: spend tx may be at vtx[2] if included, or vtx[1] (coinstake) if not
-        txout_b3 = b3.vtx[2] if len(b3.vtx) > 2 else b3.vtx[1]
         self.send_blocks([b3], False)
 
         # Now we add another block to make the alternative chain longer.
@@ -605,7 +601,6 @@ class FullBlockTest(BitcoinTestFramework):
         # push past the limit. Spend just enough P2SH outputs to get close, then
         # add a big padding sigops tx.
         p2sh_per_tx = 1
-        sigops_per_combined_tx = p2sh_per_tx * b39_sigops_per_output
         # Use only ~100 P2SH txs (fast validation), then pad with legacy sigops
         numTxes = min(100, b39_p2sh_count)
         p2sh_needed = numTxes * p2sh_per_tx
@@ -966,13 +961,13 @@ class FullBlockTest(BitcoinTestFramework):
         # None in PoS (coinbase is empty, BIP30 check skipped). Skip entire section.
         if duplicate_tx is not None:
             self.move_tip(57)
-            b_spend_dup_cb = self.next_block('spend_dup_cb')
+            self.next_block('spend_dup_cb')
             tx = CTransaction()
             tx.vin.append(CTxIn(COutPoint(duplicate_tx.sha256, 0)))
             tx.vout.append(CTxOut(0, CScript([OP_TRUE])))
             self.sign_tx(tx, duplicate_tx)
             tx.rehash()
-            b_spend_dup_cb = self.update_block('spend_dup_cb', [tx])
+            self.update_block('spend_dup_cb', [tx])
 
         # PoS: BIP30 continuation (b_spend_dup_cb, b_dup_2) skipped — duplicate_tx is None
         # because PoS coinbase is empty and BIP30 check is skipped for PoS.
@@ -1226,7 +1221,6 @@ class FullBlockTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         # Build competing fork from b77 using node.generate (needs 3 blocks to be longer)
-        main_tip = node.getbestblockhash()  # b79
         b78_hash = format(self.blocks[78].sha256, '064x')
         # Invalidate b78 to go back to b77
         node.invalidateblock(b78_hash)
@@ -1310,11 +1304,9 @@ class FullBlockTest(BitcoinTestFramework):
         LARGE_REORG_SIZE = 1088
 
         # Build main chain of 1088 blocks
-        main_tip_before = node.getbestblockhash()
         advance_time_for_pos(node, seconds=3600)
         self.log.info(f"  Generating {LARGE_REORG_SIZE} blocks for main chain...")
         main_hashes = node.generate(LARGE_REORG_SIZE)
-        chain1_tip_hash = node.getbestblockhash()
         chain1_height = node.getblockcount()
         self.log.info(f"  Main chain: {LARGE_REORG_SIZE} blocks, tip height={chain1_height}")
 
@@ -1323,7 +1315,6 @@ class FullBlockTest(BitcoinTestFramework):
         advance_time_for_pos(node, seconds=3600)
         self.log.info(f"  Generating {LARGE_REORG_SIZE} blocks for alt chain...")
         fork_hashes = node.generate(LARGE_REORG_SIZE)
-        fork_tip = node.getbestblockhash()
         self.log.info(f"  Alt chain: {LARGE_REORG_SIZE} blocks, same length")
 
         # Alt chain is same length — no reorg (first-seen wins, which is alt since main invalidated)

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -31,14 +31,14 @@ from test_framework.script import (
     OP_NOP,
     OP_TRUE,
 )
-
-# OP_TRUE with NOP padding to ensure spends meet minimum tx size (82 bytes)
-OP_TRUE_SCRIPT = CScript([OP_TRUE] + [OP_NOP] * 50)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     advance_time_for_pos,
 )
+
+# OP_TRUE with NOP padding to ensure spends meet minimum tx size (82 bytes)
+OP_TRUE_SCRIPT = CScript([OP_TRUE] + [OP_NOP] * 50)
 
 # BIP9 activation: window=144, threshold=108 (75%)
 # Period 0 (0-143): DEFINED -> STARTED (block time > nStartTime=0)
@@ -187,7 +187,7 @@ class BIP65Test(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
-        peer = node.add_p2p_connection(P2PInterface())
+        node.add_p2p_connection(P2PInterface())
 
         self.test_cltv_info(is_active=False)
 

--- a/test/functional/feature_compat_tx_versions.py
+++ b/test/functional/feature_compat_tx_versions.py
@@ -57,7 +57,6 @@ Requires previous releases (v4.22.9 binary), see test/README.md.
 """
 
 import hashlib
-import time
 
 from test_framework.messages import (
     COIN,

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -14,11 +14,6 @@ from test_framework.blocktools import (
     sign_block,
 )
 from test_framework.messages import (
-    COIN,
-    COutPoint,
-    CTransaction,
-    CTxIn,
-    CTxOut,
     tx_from_hex,
 )
 from test_framework.p2p import P2PInterface
@@ -115,7 +110,7 @@ class BIP66Test(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
-        peer = node.add_p2p_connection(P2PInterface())
+        node.add_p2p_connection(P2PInterface())
 
         self.test_dersig_info(is_active=False)
 

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -16,7 +16,6 @@ import sys
 import tempfile
 import urllib
 
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -99,12 +99,15 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         time.sleep(5)
         assert ("headers" not in peer.last_message or len(peer.last_message["headers"].headers) == 0)
 
-        self.log.info("Generating one more block")
-        self.nodes[0].generate(1)
-
-        self.log.info("Verifying nodes are all synced")
-
-        # Sync mocktime from node0 to nodes 1/2 so P2P relay works
+        # Sync mocktime from node0 to nodes 1/2 so P2P relay works. This MUST run
+        # before generating the block that crosses node2's minimumchainwork: that
+        # block triggers relay and makes node2 start downloading. If node2's clock
+        # were jumped forward *after* the download had begun (as it was originally,
+        # just above sync_blocks), the leap past each in-flight block's download
+        # deadline trips the peer block-download stalling timeout, and node2
+        # disconnects node1 - its only block source - stranding it at height 3 so
+        # sync_blocks times out. Setting the offset first records the download
+        # deadlines in the same clock epoch the timeout is later evaluated in.
         if self.nodes[0].mocktime:
             # Keep node2's time offset (it's deliberately ahead for IBD testing)
             node2_offset = 24 * 60 * 60  # 24h ahead of nodes 0/1
@@ -112,6 +115,11 @@ class MinimumChainWorkTest(BitcoinTestFramework):
             self.nodes[1].mocktime = self.nodes[0].mocktime
             self.nodes[2].setmocktime(self.nodes[0].mocktime + node2_offset)
             self.nodes[2].mocktime = self.nodes[0].mocktime + node2_offset
+
+        self.log.info("Generating one more block")
+        self.nodes[0].generate(1)
+
+        self.log.info("Verifying nodes are all synced")
 
         self.sync_blocks(timeout=120)
         self.log.info("Blockcounts: %s", [n.getblockcount() for n in self.nodes])

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -12,7 +12,6 @@ Generate COINBASE_MATURITY (CB) more blocks to ensure the coinbases are mature.
 [Consensus] Check that the new NULLDUMMY rules are not enforced on block CB + 4.
 [Policy/Consensus] Check that the new NULLDUMMY rules are enforced on block CB + 5.
 """
-import time
 
 from test_framework.blocktools import (
     COINBASE_MATURITY,

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -20,7 +20,6 @@ from test_framework.script import CScript, OP_DROP
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error, satoshi_round
 from test_framework.script_util import DUMMY_P2WPKH_SCRIPT, DUMMY_2_P2WPKH_SCRIPT
-from test_framework.wallet import MiniWallet
 
 MAX_REPLACEMENT_LIMIT = 100
 

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -6,10 +6,8 @@
 
 from test_framework.blocktools import (
     COINBASE_MATURITY,
-    create_coinbase,
     create_block,
     add_witness_commitment,
-    MAX_BLOCK_SIGOPS_WEIGHT,
     NORMAL_GBT_REQUEST_PARAMS,
     WITNESS_SCALE_FACTOR,
     sign_block,
@@ -84,7 +82,7 @@ from test_framework.script_util import (
     script_to_p2wsh_script,
 )
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_raises_rpc_error, assert_equal
+from test_framework.util import assert_equal
 from test_framework.key import generate_privkey, compute_xonly_pubkey, sign_schnorr, tweak_add_privkey, ECKey
 from test_framework.address import (
     hash160,

--- a/test/functional/feature_utxo_set_hash.py
+++ b/test/functional/feature_utxo_set_hash.py
@@ -36,7 +36,7 @@ class UTXOSetHashTest(BitcoinTestFramework):
 
         # Create a spending transaction using the node wallet and mine it
         addr = node.getnewaddress()
-        txid = node.sendtoaddress(addr, 1)
+        node.sendtoaddress(addr, 1)
         tx_block_hash = node.generate(1)[0]
         blocks.append(from_hex(CBlock(), node.getblock(tx_block_hash, False)))
 

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test bitcoin-cli"""
 
-from decimal import Decimal
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework

--- a/test/functional/mempool_accept_wtxid.py
+++ b/test/functional/mempool_accept_wtxid.py
@@ -46,9 +46,6 @@ class MempoolWtxidTest(BitcoinTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
         node = self.nodes[0]
 

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -35,6 +35,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
         # Helper: create a spend of a specific UTXO, return {hex, txid, vout, value}
         fee = Decimal("0.01")
+
         def create_spend(utxo, locktime=0):
             addr = node.getnewaddress()
             out_value = utxo['value'] - fee

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -33,6 +33,7 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
 
         # Helper: create a raw spend of a UTXO, return {hex, txid}
         fee = Decimal("0.01")
+
         def create_spend(utxo):
             addr = node.getnewaddress()
             raw = node.createrawtransaction(

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -9,7 +9,6 @@
 - submitblock"""
 
 import copy
-from decimal import Decimal
 from io import BytesIO
 
 from test_framework.blocktools import (
@@ -24,7 +23,6 @@ from test_framework.messages import (
     BLOCK_HEADER_SIZE,
 )
 from test_framework.script import CScript
-from test_framework.p2p import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -18,7 +18,7 @@ from test_framework.p2p import (
     p2p_lock,
 )
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, advance_time_for_pos
+from test_framework.util import assert_equal
 import random
 import time
 

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -42,7 +42,6 @@ from test_framework.messages import (
     MSG_CMPCT_BLOCK,
     MSG_WITNESS_FLAG,
     NODE_NETWORK,
-    NODE_WITNESS,
     P2PHeaderAndShortIDs,
     PrefilledTransaction,
     calculate_shortid,

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -135,7 +135,8 @@ class FeeFilterTest(BitcoinTestFramework):
         conn.clear_invs()
 
         self.log.info("Test txs paying 0.00125 RDD/kB are no longer received by test connection (below filter)")
-        low_fee_txids = [miniwallet.send_self_transfer(fee_rate=Decimal('0.00125'), from_node=node1)['wtxid'] for _ in range(3)]
+        for _ in range(3):
+            miniwallet.send_self_transfer(fee_rate=Decimal('0.00125'), from_node=node1)
         advance_time_for_pos(self.nodes, seconds=10)  # Longer time to ensure trickle relay fires
         self.sync_mempools()  # must be sure node 0 has received all txs
 

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -11,7 +11,6 @@ from test_framework.p2p import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    advance_time_for_pos,
     assert_equal,
 )
 

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -21,7 +21,6 @@ import copy
 
 from test_framework.blocktools import (
     create_block,
-    create_tx_with_script,
     NORMAL_GBT_REQUEST_PARAMS,
     sign_block,
 )
@@ -179,10 +178,6 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         tx1_signed = node.signrawtransactionwithkey(tx1_raw, [privkey])['hex']
         tx1 = tx_from_hex(tx1_signed)
         tx1.calc_sha256()
-
-        # Create tx2 that chains from tx1
-        tx1_amount = int(tx1_output_amount * COIN)
-        tx2 = create_tx_with_script(tx1, 0, script_sig=b'', amount=tx1_amount - 100000)
 
         # Now build the block using the same template (same coinstake) + tx1
         block2 = create_block(tmpl=tmpl, txlist=[tx1])

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -10,7 +10,7 @@ import random
 import struct
 import time
 
-from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment, get_witness_script, WITNESS_COMMITMENT_HEADER, sign_block, NORMAL_GBT_REQUEST_PARAMS
+from test_framework.blocktools import create_block, add_witness_commitment, get_witness_script, WITNESS_COMMITMENT_HEADER, sign_block, NORMAL_GBT_REQUEST_PARAMS
 from test_framework.key import ECKey
 from test_framework.messages import (
     BIP125_SEQUENCE_NUMBER,
@@ -27,7 +27,6 @@ from test_framework.messages import (
     MSG_BLOCK,
     MSG_TX,
     MSG_WITNESS_FLAG,
-    MSG_WITNESS_TX,
     MSG_WTX,
     NODE_NETWORK,
     NODE_WITNESS,

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -73,8 +73,7 @@ Part 5: Test handling of headers that don't connect (simplified for ReddCoin)
 - Tests that unconnecting headers trigger getheaders requests
 - Tests disconnect after too many unconnecting headers
 """
-from test_framework.blocktools import create_block, create_coinbase, NORMAL_GBT_REQUEST_PARAMS, sign_block
-from test_framework.messages import CInv, CBlock, CBlockHeader as MsgCBlockHeader, from_hex
+from test_framework.messages import CInv, CBlock, from_hex
 from test_framework.p2p import (
     CBlockHeader,
     NODE_WITNESS,
@@ -276,7 +275,6 @@ class SendHeadersTest(BitcoinTestFramework):
         tip_height = self.nodes[0].getblockcount()
         hash_to_invalidate = self.nodes[0].getblockhash(tip_height - (length - 1))
         fork_height = tip_height - length
-        original_tip = self.nodes[0].getbestblockhash()
 
         # Disconnect nodes to prevent automatic block relay during mining
         self.disconnect_nodes(1, 0)

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -59,11 +59,9 @@ Node1 is unused in tests 3-7:
    work on its chain).
 """
 
-import time
-
 from test_framework.blocktools import create_block, create_coinbase, create_tx_with_script
-from test_framework.messages import CBlockHeader, CInv, MSG_BLOCK, msg_block, msg_headers, msg_inv
-from test_framework.p2p import p2p_lock, P2PInterface
+from test_framework.messages import CBlockHeader, msg_block, msg_headers
+from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -36,7 +36,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
-    assert_greater_than_or_equal,
     assert_raises,
     assert_raises_rpc_error,
     assert_is_hex_string,

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -9,7 +9,6 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
-import hashlib
 from pathlib import Path
 
 

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -8,7 +8,6 @@
 # Test getblockstats rpc call
 #
 
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -9,7 +9,6 @@ Tests correspond to code in rpc/net.cpp.
 
 from decimal import Decimal
 from itertools import product
-import time
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.p2p import P2PInterface

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -32,8 +32,10 @@ import time
 from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, assert_equal
 
-# Try to import scrypt for ReddCoin PoW mining (similar to Litecoin's litecoin_scrypt)
-# If not available, solve() will fall back to SHA256 (which will fail validation)
+# Try to import scrypt for ReddCoin PoW mining (similar to Litecoin's litecoin_scrypt).
+# The module is required to mine PoW blocks: CBlock.solve() raises without it. The
+# SHA256d fallback in scrypt_hash() below exists only so that hashing PoS headers
+# (whose scrypt256 is never checked against a target) still works when it is absent.
 try:
     import scrypt as scrypt_module
     SCRYPT_AVAILABLE = True
@@ -46,7 +48,10 @@ def scrypt_hash(data):
     if SCRYPT_AVAILABLE:
         return scrypt_module.hash(data, data, N=1024, r=1, p=1, buflen=32)
     else:
-        # Fallback to SHA256 (will fail validation but useful for testing serialization)
+        # scrypt is unavailable. This value is NOT a valid PoW hash; it only keeps
+        # header serialization and PoS header hashing working. CBlock.solve()
+        # refuses to mine PoW blocks in this state rather than emit blocks the node
+        # will reject with "CheckProofOfWork() : hash doesn't match nBits".
         return hashlib.sha256(hashlib.sha256(data).digest()).digest()
 
 MAX_LOCATOR_SZ = 101
@@ -836,6 +841,16 @@ class CBlock(CBlockHeader):
         # They are validated by block signature, so nonce stays at 0
         if self.nVersion > POW_BLOCK_VERSION:
             return
+        # Fail loudly instead of grinding a SHA256d nonce that the node validates
+        # with real scrypt and rejects as "hash doesn't match nBits". A missing
+        # module must not masquerade as a consensus/timeout failure at run time.
+        if not SCRYPT_AVAILABLE:
+            raise RuntimeError(
+                "ReddCoin PoW mining requires the 'scrypt' Python module, which is "
+                "not installed. CBlock.solve() cannot grind a valid proof-of-work "
+                "without it, so the node would reject every mined block with "
+                "'CheckProofOfWork() : hash doesn't match nBits'. Install it with "
+                "'pip3 install scrypt'.")
         target = uint256_from_compact(self.nBits)
         # ReddCoin: Use scrypt256 for PoW validation (computed in calc_sha256 like Litecoin)
         while self.scrypt256 > target:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -19,7 +19,6 @@ import tempfile
 import time
 
 from typing import List
-from .address import ADDRESS_BCRT1_P2WSH_OP_TRUE
 from .authproxy import JSONRPCException
 from . import coverage
 from .p2p import NetworkThread

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -53,7 +53,6 @@ Test that the nodes generate the correct change address type:
 from decimal import Decimal
 import itertools
 
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.descriptors import (
     descsum_create,

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -16,7 +16,6 @@ make assumptions about execution order.
 from decimal import Decimal
 
 from test_framework.blocktools import (
-    COINBASE_MATURITY,
     send_to_witness,
 )
 from test_framework.messages import (

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -16,7 +16,6 @@ variants.
   and test the values returned."""
 
 from test_framework.address import key_to_p2pkh
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.descriptors import descsum_create
 from test_framework.util import (

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -15,7 +15,6 @@ variants.
 - `test_address()` is called to call getaddressinfo for an address on node1
   and test the values returned."""
 
-from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.script import (
     CScript,
     OP_NOP,
@@ -593,7 +592,6 @@ class ImportMultiTest(BitcoinTestFramework):
             "rcrt1qfqeppuvj0ww98r6qghmdkj70tv8qpche0shx59",  # wpkh at m/0'/0'/1'
         ]
         desc = "sh(wpkh(" + xpriv + "/0'/0'/*'" + "))"
-        wpkh_desc = "wpkh(" + xpriv + "/0'/0'/*'" + ")"
         self.log.info("Ranged descriptor import should fail without a specified range")
         self.test_importmulti({"desc": descsum_create(desc),
                                "timestamp": "now"},


### PR DESCRIPTION
## Summary

Three test-only fixes that make the functional suite fail honestly and pass reliably. Two address failures that presented as opaque timeouts but had nothing to do with timeouts, and one clears the flake8 debt that built up while CI was not running. There are no `src/` changes; node behaviour is untouched.

## What's included

**Fail loudly when the scrypt module is missing** (`test/functional/test_framework/messages.py`)

ReddCoin's proof-of-work is scrypt, so the framework mines blocks in Python by grinding the nonce against `scrypt256`. When the `scrypt` module could not be imported, `scrypt_hash()` silently fell back to a SHA256d digest, so `CBlock.solve()` produced blocks the node then rejected with `CheckProofOfWork() : hash doesn't match nBits`. The rejection was invisible at the mining site and only surfaced much later as `waitforblockheight` / `wait_until` timeouts or tip assertions, which sent debugging toward phantom consensus and load problems (for example example_test.py, feature_assumevalid.py, p2p_unrequested_blocks.py all failed this way with the module absent). `CBlock.solve()` now raises a clear, actionable error when it is asked to mine a PoW block (`nVersion <= POW_BLOCK_VERSION`) without scrypt. The SHA256d fallback stays only for hashing PoS headers, whose `scrypt256` is never checked against a target, so PoS-only tests keep working without the module.

**Prevent node2 from disconnecting its only peer in feature_minchainwork** (`test/functional/feature_minchainwork.py`)

node2 is deliberately given a future-dated mocktime so its tip always looks old and it stays in initial block download. The offset was applied after generating the block that crosses node2's `minimumchainwork`, i.e. after that block had already triggered relay and node2 had begun downloading. The resulting +24h clock leap pushed past the in-flight block's download deadline, so node2's next `SendMessages` concluded its only peer (node1) was stalling and disconnected it (`net_processing.cpp` "Timeout downloading block ... disconnecting"). Stranded without a block source, node2 stopped at height 3 and `sync_blocks` timed out after 120s. The mocktime choreography now runs before generating the threshold-crossing block, so download deadlines are recorded in the same clock epoch the stall timeout is later evaluated in. All three nodes now sync to height 50.

**Clear accumulated flake8 lint debt** (34 functional tests)

The lint job's flake8 pass (F401/F841/E402/E306/F811) had accumulated 66 findings across 34 functional tests while CI was not running. Removes the unused imports and dead local bindings, keeping any calls whose side effects the tests rely on (p2p connections, wallet sends, block updates); fixes three import-order and two nested-def spacing nits; drops a duplicate `skip_test_if_missing_module` override. No test behaviour changes.

## Testing

`feature_minchainwork.py` now passes end to end (all three nodes reach height 50). The scrypt change was verified by confirming that PoW mining raises immediately when the module is absent and mines valid blocks when it is present; the previously affected tests (example_test.py, feature_assumevalid.py, p2p_unrequested_blocks.py) pass once scrypt is installed. The flake8 changes are import/dead-code only and leave test behaviour unchanged.

## Compatibility / scope

- **No `src/` changes** — test tooling only.
- The fail-loud change needs the `scrypt` Python module present wherever the functional tests run. This was already required for those tests to pass; the change only converts the silent failure into an explicit one. CI installs it via a separate `ci/test/04_install.sh` change (not part of this branch) and local runs need `pip3 install scrypt`. If this merges without the CI-side install landing alongside it, the affected functional tests will error out clearly on the missing module instead of failing opaquely.
