### PR TITLE
test: sync test_assumeutxo height-110 hash with chainparams

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(test_assumeutxo)
     // Reddcoin: UTXO set hash and nChainTx for the regtest PoS test chain,
     // computed via gettxoutsetinfo (HASH_SERIALIZED) on the chain built by the
     // C++ staking helpers (genesis + 89 PoW + PoS blocks).
-    BOOST_CHECK_EQUAL(out110.hash_serialized.ToString(), "106f9f9bd6c57cea84444957b5630e4a1679a658c73455a0e0362ff0174ee181");
+    BOOST_CHECK_EQUAL(out110.hash_serialized.ToString(), "080f5ece159087ec489488c9f32f2ca67e1e5a0f4587e9f239bfa0e8e365baa7");
     BOOST_CHECK_EQUAL(out110.nChainTx, 132U);  // genesis + 89 PoW + 21 PoS (2 tx each)
 
     const auto out210 = *ExpectedAssumeutxo(200, *params);


### PR DESCRIPTION
## Summary

Fixes a stale expected value in the `validation_tests/test_assumeutxo` unit test. Commit e84bac25 ("chainparams: regenerate regtest assumeutxo hash for the PoS test chain") updated the height-110 assumeutxo hash in `src/chainparams.cpp` to `080f5ece159087ec489488c9f32f2ca67e1e5a0f4587e9f239bfa0e8e365baa7`, but the matching literal in the test was left at the old `106f9f9bd6c57cea84444957b5630e4a1679a658c73455a0e0362ff0174ee181`, so the unit-test suite failed on every job that runs it.

`out110` in the test comes straight from `ExpectedAssumeutxo(110, *params)` - i.e. the chainparams entry itself - so the hardcoded string is only a mirror of the chainparams value and has to move with it. This points it at the value e84bac25 already validated.

## What's included

- `src/test/validation_tests.cpp` - update the height-110 `hash_serialized` literal in `test_assumeutxo` from `106f9f9b...` to `080f5ece...`. One line.

## Testing

The failing assertion was:

```
validation_tests.cpp(189): error: check out110.hash_serialized.ToString() == "106f9f9b..." has failed [080f5ece... != 106f9f9b...]
```

The reported actual value (`080f5ece...`) is exactly the chainparams value from e84bac25, so the update makes the assertion pass. The height-200 assertion in the same test case was unaffected and is unchanged.

## Compatibility / scope

- **Test-only** - a single expected-value update in a unit test; no `src/` behaviour, chainparams, or consensus change (the chainparams value was already updated in e84bac25).
