### PR TITLE
pos: annotate GetCoinAgeTimes EXCLUSIVE_LOCKS_REQUIRED(cs_main)

### DIFF
--- a/src/pos/kernel.h
+++ b/src/pos/kernel.h
@@ -51,7 +51,7 @@ uint64_t GetCoinAge(CChainState* active_chainstate, const CTransaction& tx, cons
 // former disk read (tx->nTime) provided. Returns false if the coin is absent or
 // spent in the view, or its creating block is not on the active chain.
 // Requires cs_main.
-bool GetCoinAgeTimes(CChainState* active_chainstate, CCoinsViewCache& view, const COutPoint& outpoint, uint32_t& nTimeBlockFrom, uint32_t& nTimeTxPrev);
+bool GetCoinAgeTimes(CChainState* active_chainstate, CCoinsViewCache& view, const COutPoint& outpoint, uint32_t& nTimeBlockFrom, uint32_t& nTimeTxPrev) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 // Function to calculate the coin age weight
 int64_t GetCoinAgeWeight(int64_t nIntervalBeginning, int64_t nIntervalEnd, const Consensus::Params& consensusParams);


### PR DESCRIPTION
## Summary

Adds the missing `cs_main` lock annotation to `GetCoinAgeTimes()`. The function asserts `AssertLockHeld(cs_main)` and reads the active chain and UTXO view, but its declaration carried no thread-safety attribute, so clang's `-Wthread-safety-analysis` could not prove the lock was held. Under `-Werror` (the ASan CI job) this fails to compile:

```
pos/kernel.cpp:481: error: calling function 'AssertLockHeldInternal<AnnotatedMixin<std::recursive_mutex>>' requires holding mutex 'cs_main' exclusively [-Werror,-Wthread-safety-analysis]
    AssertLockHeld(cs_main);
```

This is a pure annotation change with no behaviour impact.

## What's included

- `src/pos/kernel.h` - add `EXCLUSIVE_LOCKS_REQUIRED(cs_main)` to the `GetCoinAgeTimes()` declaration.

## Why it is correct

The requirement is already satisfied at every call site, so the annotation only makes the existing contract explicit to the analyzer:

- Both callers (`pos/stake.cpp:355` and `:408`) are inside `CreateCoinStake`, which holds `cs_main` via `LOCK2(cs_main, pwallet->cs_wallet)` (`pos/stake.cpp:158`).
- The header comment on `GetCoinAgeTimes` already documents "Requires cs_main.", and the body asserts it with `AssertLockHeld(cs_main)`.
- `kernel.h` already includes `validation.h`, so both `cs_main` and the `EXCLUSIVE_LOCKS_REQUIRED` macro are in scope; `kernel.cpp` includes `kernel.h`, so the definition body is analysed against the annotated declaration.

## Testing

Compile-only change. It resolves the `-Wthread-safety-analysis` error on the clang/`-Werror` ASan build; no runtime behaviour changes (the attribute is a compile-time contract).

## Compatibility / scope

- **No behaviour change** - a thread-safety attribute only. No consensus, serialization or runtime logic is touched.
