### PR TITLE
contrib: fix install_db4.sh config.guess/sub download from savannah

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -54,7 +54,10 @@ http_get() {
   if [ -f "${2}" ]; then
     echo "File ${2} already exists; not downloading again"
   elif check_exists curl; then
-    curl --insecure --retry 5 "${1}" -o "${2}"
+    # --location: follow HTTP redirects (e.g. the BerkeleyDB tarball host), so a
+    # redirect body is not saved in place of the file and then failed by the
+    # sha256 check. wget, the fallback below, follows redirects by default.
+    curl --insecure --location --retry 5 "${1}" -o "${2}"
   else
     wget --no-check-certificate "${1}" -O "${2}"
   fi
@@ -221,9 +224,13 @@ EOF
 # The packaged config.guess and config.sub are ancient (2009) and can cause build issues.
 # Replace them with modern versions.
 # See https://github.com/bitcoin/bitcoin/issues/16064
-CONFIG_GUESS_URL='https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
+# Fetch from savannah's cgit "plain" endpoint. The older gitweb blob_plain URLs
+# now 301-redirect to a gitweb. subdomain that is slow and returns HTTP errors
+# (the download saved the redirect body, failing the sha256 check). cgit serves
+# the raw file directly (HTTP 200); the pinned commit and hashes are unchanged.
+CONFIG_GUESS_URL='https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
 CONFIG_GUESS_HASH='2d1ff7bca773d2ec3c6217118129220fa72d8adda67c7d2bf79994b3129232c1'
-CONFIG_SUB_URL='https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
+CONFIG_SUB_URL='https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
 CONFIG_SUB_HASH='3a4befde9bcdf0fdb2763fc1bfa74e8696df94e1ad7aac8042d133c8ff1d2e32'
 
 rm -f "dist/config.guess"


### PR DESCRIPTION
## Summary

`contrib/install_db4.sh` builds BerkeleyDB 4.8 and, because that release ships a 2009-era `config.guess`/`config.sub` that does not recognize modern platforms, downloads current copies from `git.savannah.gnu.org`. That download now fails and hangs, aborting the build (the MSan CI job builds BerkeleyDB through this script, since it needs a memory-sanitizer-instrumented libc++ build of BDB rather than the depends copy):

```
100   178  100   178 ...
sha256sum: WARNING: 1 computed checksum did NOT match
dist/config.guess: FAILED
```

Two things were wrong:

1. The gitweb `blob_plain` URLs now answer `301 Moved Permanently`, redirecting to a `gitweb.` subdomain. `http_get()`'s curl ran without `--location`, so it saved the 178-byte redirect body instead of the file. Following the redirect does not help either: the gitweb backend is slow and returns HTTP errors, so curl retries and hangs.
2. The sha256 check then aborts with `dist/config.guess: FAILED`.

## What's included

- `contrib/install_db4.sh`:
  - Fetch `config.guess`/`config.sub` from savannah's cgit `plain` endpoint (`.../cgit/config.git/plain/config.guess?id=<commit>`), which serves the raw file directly with HTTP 200 and no redirect. The pinned commit id and the sha256 hashes are unchanged.
  - Add `--location` to the `curl` branch of `http_get()` so the remaining download (the BerkeleyDB tarball) tolerates redirects. The `wget` fallback already follows redirects.

## Why it is correct

Verified against the live server:

- The old gitweb URL returns `301 Moved Permanently` to `gitweb.git.savannah.gnu.org`; without `--location` curl writes the 178-byte redirect page, and following it returns HTTP errors and hangs.
- The cgit `plain` URL returns the file directly (HTTP 200): `config.guess` is 48295 bytes with sha256 `2d1ff7bca773d2ec3c6217118129220fa72d8adda67c7d2bf79994b3129232c1`, and `config.sub` is 31617 bytes with sha256 `3a4befde9bcdf0fdb2763fc1bfa74e8696df94e1ad7aac8042d133c8ff1d2e32`. Both match the hashes already pinned in the script.
- Same underlying git commit, so the content and the pinned hashes are unchanged.

## Testing

Downloaded both files from the cgit endpoint and confirmed the sha256 sums match the hashes hardcoded in the script. No build-system or output changes.

## Compatibility / scope

- Touches only `contrib/install_db4.sh`. No change to depends, the build system, or produced binaries.