### PR TITLE
test: account for non-run functional scripts in test_runner.py

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -339,7 +339,16 @@ NON_SCRIPTS = [
     # These are python files that live in the functional tests directory, but are not test scripts.
     "combine_logs.py",
     "create_cache.py",
+    "create_rpc_psbt_data.py",  # ReddCoin: generates PSBT fixtures, not a test
     "test_runner.py",
+    # ReddCoin: test scripts intentionally not run yet. They are kept in the tree
+    # (and commented out in the script lists above), so list them here to satisfy
+    # the --ci check_script_list gate instead of leaving them orphaned. Move each
+    # back into the lists above when it is re-enabled.
+    "feature_backwards_compatibility.py",  # Group A: deferred until FEATURE_LATEST > v4.22.9
+    "wallet_upgradewallet.py",             # Group A: deferred until FEATURE_LATEST > v4.22.9
+    "feature_signet.py",                   # signet chain type not yet supported in ReddCoin
+    "feature_blockfilterindex_prune.py",   # prune mode incompatible with blockfilterindex
 ]
 
 def main():

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -80,7 +80,11 @@ TEST_FRAMEWORK_MODULES = [
 EXTENDED_SCRIPTS = [
     # These tests are not run by default.
     # Longest test should go first, to favor running tests in parallel
-    'feature_pruning.py',
+    # ReddCoin: prune mode is rejected at startup ("Prune mode is incompatible
+    # with Reddcoin and -txindex", init.cpp), because txindex is always on
+    # (DEFAULT_TXINDEX = true). feature_pruning.py can never pass; it is listed
+    # in NON_SCRIPTS instead of here.
+    # 'feature_pruning.py',
     'feature_dbcrash.py',
 ]
 
@@ -349,6 +353,7 @@ NON_SCRIPTS = [
     "wallet_upgradewallet.py",             # Group A: deferred until FEATURE_LATEST > v4.22.9
     "feature_signet.py",                   # signet chain type not yet supported in ReddCoin
     "feature_blockfilterindex_prune.py",   # prune mode incompatible with blockfilterindex
+    "feature_pruning.py",                  # prune mode rejected in ReddCoin (txindex is always on)
 ]
 
 def main():


### PR DESCRIPTION
## Summary

Makes `test/functional/test_runner.py`'s script accounting correct for ReddCoin. `check_script_list()` treats any `.py` in `test/functional/` that is absent from the run lists as an error under `--ci`, so every script that ReddCoin does not run has to be listed in `NON_SCRIPTS`. Two groups were unaccounted for: scripts that are intentionally deferred or unsupported (already commented out of the run lists), and `feature_pruning.py`, which cannot pass on ReddCoin at all. Test-only, no `src/` changes.

## What's included

**Register deferred / non-test scripts** (first commit)

Five scripts lived in `test/functional/` without being in any run list, so `check_script_list()` under `--ci` (`fail_on_warn=True`) aborted the whole functional-test step the moment `test_runner` started (it surfaced only as a bash `pop_var_context` error from `set -e` unwinding the failed call). Add them to `NON_SCRIPTS`:
- `create_rpc_psbt_data.py`: a PSBT fixture generator, not a test.
- `feature_backwards_compatibility.py`, `wallet_upgradewallet.py`: deferred Group-A wallet-evolution tests.
- `feature_signet.py`: signet chain type not supported in ReddCoin.
- `feature_blockfilterindex_prune.py`: prune mode incompatible with blockfilterindex.

Each carries a note to move it back into the run lists when it is re-enabled.

**Exclude feature_pruning.py** (second commit)

ReddCoin always maintains a transaction index (`DEFAULT_TXINDEX = true`, `validation.h`), and `init.cpp` rejects any `-prune` node at startup with "Prune mode is incompatible with Reddcoin and -txindex". `feature_pruning.py` drives `-prune` nodes, so it can never pass. Remove it from `EXTENDED_SCRIPTS` and register it in `NON_SCRIPTS` next to `feature_blockfilterindex_prune.py`.

## Testing

Simulated `check_script_list()` against the current `test/functional/` directory: with these changes no `.py` is orphaned, so the `--ci` gate passes. `feature_pruning.py` is confirmed absent from the run lists and present in `NON_SCRIPTS`. `test_runner.py` compiles.

## Compatibility / scope

- **Test-only** - touches only `test/functional/test_runner.py`. No `src/`, consensus, or build changes.
- No test that previously ran is removed from the run set: the registered scripts were already commented out of the run lists, and `feature_pruning.py` was in `EXTENDED_SCRIPTS` (only run under `--extended`) and cannot pass anyway.
