### PR TITLE
bench: set up chain params before reading Params() in AssembleBlock

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -20,8 +20,11 @@
 
 static void AssembleBlock(benchmark::Bench& bench)
 {
-    const CChainParams& chainparams = Params();
+    // TestingSetup calls SelectParams(), which populates globalChainParams; it
+    // must be constructed before Params() is read, or Params() aborts on the
+    // globalChainParams assertion when this benchmark runs first under `make check`.
     const auto test_setup = MakeNoLogFileContext<const TestingSetup>();
+    const CChainParams& chainparams = Params();
 
     CScriptWitness witness;
     witness.stack.push_back(WITNESS_STACK_ELEM_OP_TRUE);


### PR DESCRIPTION
## Summary

Fixes an ordering bug in the `AssembleBlock` benchmark that aborts `make check`. The benchmark read `Params()` before constructing its `TestingSetup`, but `TestingSetup`'s constructor is what calls `SelectParams()` to populate `globalChainParams`. When the benchmark runs before any other params-using benchmark has set them up, `Params()` aborts:

```
chainparams.cpp: const CChainParams &Params(): Assertion `globalChainParams' failed.
```

## Why it fails in CI

`make check` runs `bench_reddcoin > /dev/null` (`src/Makefile.test.include`), which executes every benchmark. `AssembleBlock` runs first, before anything calls `SelectParams()`, so the abort is deterministic: it fails the unit-test step (SIGABRT, exit 134). It surfaced on the MSan job, but it is not sanitizer-specific: every job that runs the unit tests reaches the same `make check` and would hit it.

## What's included

- `src/bench/block_assemble.cpp`: construct the `TestingSetup` before reading `Params()`, so `globalChainParams` is populated first. This matches the order already used in `src/bench/duplicate_inputs.cpp`. A short comment records the requirement.

## Testing

Reorder only; the benchmark body is unchanged. `chainparams` is still read once and used further down (for `GetCoinbaseMaturity()` and the block template), now after the setup that makes `Params()` valid. Behaviour of the benchmark is otherwise identical.

## Compatibility / scope

- Touches only `src/bench/block_assemble.cpp`. No consensus, node, or non-bench behaviour is affected.