### PR TITLE
bench: fix out-of-range vector access in AssembleBlock

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -39,7 +39,7 @@ static void AssembleBlock(benchmark::Bench& bench)
         tx.vin.back().scriptWitness = witness;
         tx.vout.emplace_back(1337, P2WSH_OP_TRUE);
         if (NUM_BLOCKS - b >= COINBASE_MATURITY)
-            txs.at(b) = MakeTransactionRef(tx);
+            txs.push_back(MakeTransactionRef(tx));
     }
     {
         LOCK(::cs_main); // Required for ::AcceptToMemoryPool.


### PR DESCRIPTION
## Summary

Fixes a `std::out_of_range` abort in the `AssembleBlock` benchmark. It collected the mined-coinbase-spending transactions with `txs.at(b)` into a vector that is never sized, so the first iteration threw and aborted the whole benchmark run:

```
libc++abi: terminating with uncaught exception of type std::out_of_range: vector
```

## Why it fails in CI

`make check` runs `bench_reddcoin > /dev/null` (`src/Makefile.test.include`), which runs every benchmark. `AssembleBlock` runs first and aborts (SIGABRT, exit 134), failing the unit-test step. It surfaced on the MSan job, but it is not sanitizer-specific: every job that runs the unit tests reaches the same `make check`.

## What's included

- `src/bench/block_assemble.cpp`: append the transactions with `push_back` instead of `txs.at(b) = ...`. `txs` is declared empty, so `at(b)` was out of range on the first element. The vector then holds exactly the transactions the following `AcceptToMemoryPool` loop consumes, with no gaps, which is what upstream does here. Pre-sizing to `NUM_BLOCKS` instead would be wrong: entries skipped by the `NUM_BLOCKS - b >= COINBASE_MATURITY` guard would stay null and the accept loop would dereference them.

## Testing

Benchmark-only change. `AssembleBlock` no longer aborts, so `bench_reddcoin > /dev/null` (and therefore `make check`) completes. The `.at(b)` index was not otherwise used; the loop over `txs` is order-independent.

## Compatibility / scope

- Touches only `src/bench/block_assemble.cpp`. No consensus, node, or non-bench behaviour is affected.