### PR TITLE
test/bench: cover proof-of-stake block assembly

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -72,6 +72,7 @@ bench_bench_reddcoin_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
 endif
 
 if ENABLE_WALLET
+bench_bench_reddcoin_SOURCES += bench/block_assemble_pos.cpp
 bench_bench_reddcoin_SOURCES += bench/coin_selection.cpp
 bench_bench_reddcoin_SOURCES += bench/wallet_balance.cpp
 endif

--- a/src/bench/block_assemble_pos.cpp
+++ b/src/bench/block_assemble_pos.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2023-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <chainparams.h>
+#include <miner.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <txmempool.h>
+#include <util/strencodings.h>
+#include <util/time.h>
+#include <validation.h>
+#include <wallet/wallet.h>
+
+#include <cassert>
+#include <cstdint>
+
+// ReddCoin: benchmark proof-of-stake block assembly, the counterpart to the
+// proof-of-work AssembleBlock benchmark. TestChain100Setup pre-stakes 11 PoS
+// blocks (heights 90-100) with a live staking wallet, so the tip is already in
+// the PoS phase and CreateNewBlock takes the coinstake path.
+static void AssemblePoSBlock(benchmark::Bench& bench)
+{
+    const auto test_setup = MakeNoLogFileContext<const TestChain100Setup>();
+    CWallet* const pwallet = test_setup->m_wallet.get();
+    assert(pwallet);
+
+    const CChainParams& chainparams = Params();
+    CChainState& chainstate = test_setup->m_node.chainman->ActiveChainstate();
+    CTxMemPool& mempool = *test_setup->m_node.mempool;
+    const CScript scriptPubKey = CScript() << ToByteVector(test_setup->coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+
+    int64_t t = GetTime();
+    bench.run([&] {
+        // Advance mocktime each iteration so the coinstake kernel search runs over
+        // a fresh, non-empty window: PoS CreateNewBlock only searches when the
+        // current time is past its last search time. No block is processed, so the
+        // tip and the stakeable coins stay fixed and the loop runs indefinitely.
+        // With a wallet set, CreateNewBlock returns nullptr when no kernel is found
+        // (it does not fall through to the pow-ended PoW path), so this never
+        // throws; some iterations find a stake and some do not, which is the cost
+        // this microbenchmark measures.
+        t += 64;
+        SetMockTime(t);
+        bool fPoSCancel{false};
+        LOCK(pwallet->cs_wallet);
+        BlockAssembler{chainstate, mempool, chainparams}.CreateNewBlock(scriptPubKey, pwallet, &fPoSCancel);
+    });
+
+    SetMockTime(0);
+}
+
+BENCHMARK(AssemblePoSBlock);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -9,6 +9,7 @@
 #include <consensus/tx_verify.h>
 #include <miner.h>
 #include <policy/policy.h>
+#include <pos/signer.h>
 #include <pow.h>
 #include <script/standard.h>
 #include <txmempool.h>
@@ -554,6 +555,35 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     TestPackageSelection(chainparams, scriptPubKey, txFirst);
 
     fCheckpointsEnabled = true;
+}
+
+// ReddCoin: once PoW ends (consensus.nLastPowHeight) blocks are produced by
+// staking. TestChain100Setup pre-stakes into the PoS phase (89 PoW + 11 PoS), so
+// the tip is already past nLastPowHeight; assemble one more block through the real
+// CreateNewBlock -> coinstake -> SignBlock path and assert it is a valid, signed
+// proof-of-stake block that connects.
+BOOST_FIXTURE_TEST_CASE(CreateNewBlock_PoS_validity, TestChain100Setup)
+{
+    const int nLastPowHeight{Params().GetConsensus().nLastPowHeight};
+    const int start_height{m_node.chainman->ActiveChain().Height()};
+    BOOST_CHECK_GT(start_height, nLastPowHeight);
+
+    // Advance mocktime so the coinstake kernel search has a non-empty window,
+    // matching how stakeBlocks() advances time between blocks.
+    SetMockTime(GetTime() + 60);
+
+    const CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+    const CBlock block{CreateAndProcessPoSBlock(/*txns=*/{}, scriptPubKey, m_wallet.get())};
+
+    // The chain advanced by one proof-of-stake block.
+    BOOST_CHECK_EQUAL(m_node.chainman->ActiveChain().Height(), start_height + 1);
+    BOOST_CHECK(block.IsProofOfStake());
+    BOOST_REQUIRE_GE(block.vtx.size(), 2U);
+    BOOST_CHECK(block.vtx[1]->IsCoinStake());  // coinstake sits at index 1
+    BOOST_CHECK(!block.vchBlockSig.empty());   // the block was signed
+    BOOST_CHECK(CheckBlockSignature(block));    // and the signature verifies
+
+    SetMockTime(0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -216,8 +216,12 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     }
 }
 
-TestChain100Setup::TestChain100Setup()
-    : TestingSetup(CBaseChainParams::REGTEST, {"-txindex=1"})
+TestChain100Setup::TestChain100Setup(const std::string& chain_name, const std::vector<const char*>& extra_args)
+    : TestingSetup(chain_name, [&extra_args] {
+          std::vector<const char*> args{"-txindex=1"};
+          args.insert(args.end(), extra_args.begin(), extra_args.end());
+          return args;
+      }())
 {
     // Set mock time to be after genesis block time
     SetMockTime(Params().GenesisBlock().nTime + 1);

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -116,7 +116,11 @@ class CScript;
  * (89 PoW + 11 PoS). Enables txindex for PoS staking support.
  */
 struct TestChain100Setup : public TestingSetup {
-    TestChain100Setup();
+    // extra_args are appended after the mandatory -txindex=1 (PoS staking needs
+    // the tx index). Defaulted so BOOST_FIXTURE_TEST_CASE default-constructs it,
+    // and so MakeNoLogFileContext<TestChain100Setup>() can pass -nodebuglogfile.
+    explicit TestChain100Setup(const std::string& chain_name = CBaseChainParams::REGTEST,
+                               const std::vector<const char*>& extra_args = {});
 
     /**
      * Create a new block with just given transactions, coinbase paying to


### PR DESCRIPTION
## Summary

Block-assembly coverage (the `miner_tests` suite and the `AssembleBlock` benchmark) only exercised the proof-of-work path. Reddcoin's `CreateNewBlock` takes a distinct coinstake path once the tip is past `nLastPowHeight`, and that path had no unit or benchmark coverage. This adds both.

## Changes

- **`src/test/miner_tests.cpp`**: new `CreateNewBlock_PoS_validity` case using the `TestChain100Setup` fixture, whose chain (89 PoW + 11 PoS blocks) is already in the PoS phase. It creates and processes a PoS block and asserts the block is proof-of-stake, has a coinstake at `vtx[1]`, carries a non-empty block signature, and that the signature verifies.
- **`src/bench/block_assemble_pos.cpp`** (new): `AssemblePoSBlock` benchmark, the PoS counterpart to `AssembleBlock`. It uses `TestChain100Setup` (11 pre-staked PoS blocks) and advances mock time each iteration so the coinstake kernel search runs over a fresh window. `CreateNewBlock` returns `nullptr` when no kernel is found (it does not fall through to the PoW path), so the loop never aborts.
- **`src/test/util/setup_common.{h,cpp}`**: give `TestChain100Setup` an optional `(chain_name, extra_args)` constructor so `MakeNoLogFileContext<TestChain100Setup>()` works (used to disable the debug log file in the benchmark hot loop). The change is backwards compatible: the arguments are defaulted, so existing `BOOST_FIXTURE_TEST_CASE` usage still default-constructs the fixture, and `-txindex=1` (required for PoS staking) is always prepended.
- **`src/Makefile.bench.include`**: build `block_assemble_pos.cpp` under `ENABLE_WALLET`.

## Testing

`miner_tests` passes including the new case, and `bench_reddcoin` runs `AssemblePoSBlock` without aborting.
