### PR TITLE
test: de-flake wallet_tests/CreateWallet mempool transaction check

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -946,6 +946,26 @@ BOOST_FIXTURE_TEST_CASE(CreateWallet, TestChain100Setup)
     // After rescan completes, sync with validation interface queue to process any pending notifications
     SyncWithValidationInterfaceQueue();
 
+    // mempool_tx was broadcast before this wallet registered for notifications.
+    // Its transactionAddedToMempool notification is dispatched asynchronously, so
+    // whether the wallet is registered in time to receive it depends on when the
+    // scheduler thread drains the queue. That race made this case fail
+    // intermittently on slower runners, with mempool_tx missing from mapWallet.
+    // Request the current mempool contents explicitly instead, exactly as
+    // CWallet::postInitProcess does when a wallet is loaded for real (this test
+    // builds the CWallet directly, so that step is otherwise skipped). Delivery is
+    // synchronous, and re-notifying an already added transaction is expected and
+    // handled by AddToWallet.
+    //
+    // Hold cs_wallet across the call like postInitProcess does. requestMempoolTransactions
+    // takes cs_main internally, so acquiring it here first keeps the cs_wallet ->
+    // cs_main order this test already uses above, instead of inverting it. cs_wallet
+    // is recursive, so the nested lock in transactionAddedToMempool is fine.
+    {
+        LOCK(wallet->cs_wallet);
+        m_node.chain->requestMempoolTransactions(*wallet);
+    }
+
     // Verify both target transactions are in the wallet
     {
         LOCK(wallet->cs_wallet);


### PR DESCRIPTION
## Summary

`wallet_tests/CreateWallet` fails intermittently on slower CI runners, most recently the ARM unit test job, with:

```
wallet/test/wallet_tests.cpp(953): error: in "wallet_tests/CreateWallet":
  check wallet->mapWallet.count(mempool_tx.GetHash()) == 1U has failed [0 != 1]
```

## Cause

The second phase of the test broadcasts `mempool_tx` and only afterwards constructs the wallet and registers it for notifications. `transactionAddedToMempool` is dispatched asynchronously by the scheduler thread, so whether the wallet is registered in time to receive that notification depends on when the queue happens to be drained. When the scheduler drains it before the wallet registers, the wallet never learns about the transaction and the count check fails.

The transaction itself is fine: the `BOOST_CHECK` on `broadcastTransaction` passes and the run reports only this one failure, so `mempool_tx` really is in the mempool. Only the delivery to the wallet is racy.

The first phase of the test is not affected. It blocks the validation interface queue with a promise until after the wallet is registered, so no notification can be processed early and the outcome is already deterministic.

## Change

After syncing the validation interface queue, request the current mempool contents explicitly:

```cpp
{
    LOCK(wallet->cs_wallet);
    m_node.chain->requestMempoolTransactions(*wallet);
}
```

This is what `CWallet::postInitProcess` does when a wallet is loaded for real. The test constructs the `CWallet` directly rather than going through the normal load path, so that step never runs and the mempool is never picked up. Delivery is synchronous, so the result no longer depends on notification timing.

`cs_wallet` is held across the call for the same reason `postInitProcess` holds it. `requestMempoolTransactions` acquires `cs_main` internally before calling back into the wallet, so taking `cs_wallet` first preserves the `cs_wallet` to `cs_main` order the test already establishes when it sets the last processed block. Calling it unlocked inverts that order and trips the deadlock detector. `cs_wallet` is a recursive mutex, so the nested acquisition inside `transactionAddedToMempool` is fine.

Re-notifying an already added transaction is safe and expected. The `requestMempoolTransactions` documentation states that async notifications can still arrive during and after the synchronous ones and that clients must tolerate notifications about already added transactions, which `AddToWallet` does. Phase 2 resets `addtx_count` but makes no further assertion on it, so the extra `AddToWallet` call does not affect any other check.

## Testing

`wallet_tests` passes, including the lock order check under `DEBUG_LOCKORDER`. The change removes the race by construction rather than by retrying, so it is not verifiable by a single green run alone.
