### PR TITLE
node: include what the update check uses

### DIFF
--- a/src/node/update_check.cpp
+++ b/src/node/update_check.cpp
@@ -30,10 +30,13 @@
 #include <openssl/opensslv.h>
 
 #include <chrono>
+#include <cstddef>
+#include <ostream>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 static std::string strDownloadLink = "https://download.reddcoin.com/bin/reddcoin-core-";
 static std::string strGithubLink = "/repos/reddcoin-project/reddcoin/releases/latest";

--- a/src/util/semver.h
+++ b/src/util/semver.h
@@ -25,6 +25,7 @@ SOFTWARE.
 #ifndef BITCOIN_UTIL_SEMVER_H
 #define BITCOIN_UTIL_SEMVER_H
 
+#include <ostream>
 #include <string>
 #include <regex>
 #include <vector>


### PR DESCRIPTION
## Summary

The MSan job builds against libc++ and stops in the vendored semver header:

```
In file included from node/update_check.cpp:8:
./util/semver.h:361:47: error: implicit instantiation of undefined template
'std::__1::basic_ostream<char, std::__1::char_traits<char>>'
        for (const auto s : version.str()) str.put(s);
```

The header defines an inline `operator<<` that calls `std::ostream::put`, so it needs the complete type, but it includes only `<string>`, `<regex>` and `<vector>`. libstdc++ reaches `<ostream>` through those, libc++ does not.

The header has always been incomplete in this way. It went unnoticed because it used to be included from `rpc/server.cpp`, after other headers that had already pulled `<ostream>` in. PR #428 moved it to `util/` and moved its only consumer to `node/update_check.cpp`, where it is included early enough that nothing else has provided `<ostream>` yet, so the omission became visible.

Include `<ostream>` directly, so the header stands on its own wherever it is used rather than depending on what happens to precede it.

`node/update_check.cpp` had the same latent problem, surviving only on transitive includes: `std::move` without `<utility>`, `std::size_t` without `<cstddef>`, and `std::ostream` without `<ostream>`. Those are added too, rather than waiting for another standard library to object to them one at a time.

## Testing

`node/update_check.cpp` compiles clean with `-Werror`.

Each header touched was also checked in isolation, by compiling a translation unit whose only content is that single include, to confirm it is self-contained rather than relying on include order.

The libc++ failure itself could not be reproduced locally, since there is no clang or libc++ on the machine this was prepared on. The change addresses the diagnostic directly: it reports that only the forward declaration of `basic_ostream` was visible, and `<ostream>` is the header that defines it. The MSan job is the real confirmation.

The lint follow-ups that accompanied this work are already on develop and are not part of this branch.
