### PR TITLE
contrib: take config.guess and config.sub from the tree, not savannah

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -25,6 +25,11 @@ BDB_VERSION='db-4.8.30.NC'
 BDB_HASH='12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef'
 BDB_URL="https://download.oracle.com/berkeley-db/${BDB_VERSION}.tar.gz"
 
+# Where this repository keeps its own config.guess and config.sub, used further
+# below. Resolved here because the working directory changes once the tarball
+# has been unpacked.
+CONFIG_AUX_DIR="$(expand_path "$(dirname "${0}")/..")/depends"
+
 check_exists() {
   command -v "$1" >/dev/null
 }
@@ -224,20 +229,26 @@ EOF
 # The packaged config.guess and config.sub are ancient (2009) and can cause build issues.
 # Replace them with modern versions.
 # See https://github.com/bitcoin/bitcoin/issues/16064
-# Fetch from savannah's cgit "plain" endpoint. The older gitweb blob_plain URLs
-# now 301-redirect to a gitweb. subdomain that is slow and returns HTTP errors
-# (the download saved the redirect body, failing the sha256 check). cgit serves
-# the raw file directly (HTTP 200); the pinned commit and hashes are unchanged.
-CONFIG_GUESS_URL='https://git.savannah.gnu.org/cgit/config.git/plain/config.guess?id=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
-CONFIG_GUESS_HASH='2d1ff7bca773d2ec3c6217118129220fa72d8adda67c7d2bf79994b3129232c1'
-CONFIG_SUB_URL='https://git.savannah.gnu.org/cgit/config.git/plain/config.sub?id=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
-CONFIG_SUB_HASH='3a4befde9bcdf0fdb2763fc1bfa74e8696df94e1ad7aac8042d133c8ff1d2e32'
+#
+# Take the copies this repository already carries for depends rather than
+# downloading them. git.savannah.gnu.org is the only host this script needs
+# besides the tarball itself, and it keeps being unusable from CI: the gitweb
+# URLs redirect to a subdomain that is slow and returns errors, and the cgit
+# endpoint that replaced them now times out or answers 502 as well. The in tree
+# copies are newer than the pinned revision that was being fetched, are already
+# what configures depends, and need no hash pinning because they are version
+# controlled.
+if [ ! -f "${CONFIG_AUX_DIR}/config.guess" ] || [ ! -f "${CONFIG_AUX_DIR}/config.sub" ]; then
+  echo "Cannot find config.guess and config.sub in ${CONFIG_AUX_DIR}." >&2
+  echo "Run this script from a checkout, so it can find them." >&2
+  exit 1
+fi
 
 rm -f "dist/config.guess"
 rm -f "dist/config.sub"
 
-http_get "${CONFIG_GUESS_URL}" dist/config.guess "${CONFIG_GUESS_HASH}"
-http_get "${CONFIG_SUB_URL}" dist/config.sub "${CONFIG_SUB_HASH}"
+cp "${CONFIG_AUX_DIR}/config.guess" "dist/config.guess"
+cp "${CONFIG_AUX_DIR}/config.sub" "dist/config.sub"
 
 cd build_unix/
 


### PR DESCRIPTION
# contrib: take config.guess and config.sub from the tree, not savannah

- Base: `reddcoin-project/reddcoin:develop`
- Head: `reddink:contrib/db4-config-guess-from-tree`
- Commit: `contrib: take config.guess and config.sub from the tree, not savannah`

## Summary

`install_db4.sh` replaces BerkeleyDB's 2009 vintage `config.guess` and `config.sub`, which do not recognise modern hosts, by downloading newer ones from `git.savannah.gnu.org`. That host is the only thing the script needs besides the tarball itself, and it keeps being unusable.

The gitweb URLs began redirecting to a subdomain that is slow and returns errors, so the download saved a redirect body and then failed the checksum. Moving to the cgit endpoint fixed that. cgit has since started timing out and answering 502, which is what the MSan job hit:

```
curl: (7) Failed to connect to git.savannah.gnu.org port 443: Connection timed out
##[error]Process completed with exit code 7.
```

At the time of writing the endpoint is reachable but broken in a third way: the cgit URL now 301s to `cgit.git.savannah.gnu.org`, which answers 502, so following the redirect stores an error page and fails the checksum again.

## Change

This repository already carries `config.guess` and `config.sub` under `depends/`, where they configure every depends package. They are dated 2021, newer than the 2019 revision that was pinned for download, so the script copies those instead of fetching anything.

That removes the last reason for this script to reach the network beyond the tarball, makes the result reproducible, and needs no hash pinning because the files are version controlled rather than fetched.

The path is resolved before the script changes directory into the unpacked source, since it is not usable afterwards, and the script fails with a clear message rather than a confusing configure error if the files are somehow absent.

## Testing

`sh -n` and the `lint-shell` job both pass.

The path resolution was checked for each way the script gets invoked, since `$0` is the only handle it has on its own location and the working directory changes partway through: relative from the repository root, by absolute path, and from an unrelated working directory. All three resolve to the checkout's `depends`.

Worth confirming on a real run that BerkeleyDB still configures and builds, on the MSan job in particular, since that is the one that exercises this script.
