### PR TITLE
depends: build openssl without the Windows certificate store

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -37,6 +37,11 @@ $(package)_config_opts+=no-tests
 $(package)_config_opts+=no-unit-test
 $(package)_config_opts+=no-weak-ssl-ciphers
 $(package)_config_opts+=no-whirlpool
+# The 3.x series added a store backed by the Windows certificate store, which
+# calls into crypt32 and so does not link unless that library is added to every
+# Windows target. Nothing here uses it, and capieng above is already disabled
+# for the same reason.
+$(package)_config_opts+=no-winstore
 $(package)_config_opts+=no-zlib
 $(package)_config_opts+=no-zlib-dynamic
 $(package)_config_opts+=$($(package)_cflags) $($(package)_cppflags)


### PR DESCRIPTION
## Summary

The Win64 job fails to link since the move to OpenSSL 3.5.7:

```
/usr/bin/x86_64-w64-mingw32-ld: depends/x86_64-w64-mingw32/lib/libcrypto.a(libdefault-lib-winstore_store.obj):
  winstore_store.c:(.text+0x1c4): undefined reference to `__imp_CertOpenSystemStoreW'
  ... undefined reference to `__imp_CertFindCertificateInStore'
  ... undefined reference to `__imp_CertFreeCertificateContext'
  ... undefined reference to `__imp_CertCloseStore'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:6304: reddcoind.exe] Error 1
```

The 3.x series added a store backed by the Windows certificate store, which 1.1.1 did not have. It calls the CryptoAPI certificate functions, and those live in crypt32, so every Windows binary now fails to link against the static libcrypto.

## Change

Configure the package with `no-winstore`.

Nothing in the tree uses that store. The only consumer of OpenSSL at all is the update check, which makes a single TLS request and does not consult any certificate store. The alternative, adding crypt32 to the Windows link, would pull a system library into every binary to satisfy a provider that is never called.

It also follows what the package already asks for: `no-capieng` is set a few lines above, and capieng is the same idea in the 1.1.1 series, so Windows certificate store integration was already unwanted here.

## Testing

Verified against the actual 3.5.7 release rather than assumed. Configure accepts the complete option set for `linux-x86_64`, `mingw64` and `mingw`, exiting 0 in each case, and the winstore object disappears from the generated build in all three. The only references that survive are to its documentation, which is not built anyway since the package passes `no-docs`.

The link itself can only be confirmed by the Win64 job.
