### PR TITLE
rpc: read the coinstake value from the coinstake, not past the coinbase

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1327,7 +1327,11 @@ static RPCHelpMan getblocktemplate()
     result.pushKV("transactions", transactions);
     result.pushKV("coinbaseaux", aux);
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
-    result.pushKV("coinstakevalue", (int64_t)pblock->vtx[0]->vout[1].nValue);
+    // The coinstake is vtx[1], and its first output is the empty marker, so the
+    // staked value is in vout[1]. IsProofOfStake() guarantees both exist: it
+    // requires vtx[1] to be a coinstake, and a coinstake has at least two
+    // outputs. The coinbase itself only ever has one output.
+    result.pushKV("coinstakevalue", pblock->IsProofOfStake() ? (int64_t)pblock->vtx[1]->vout[1].nValue : 0);
     result.pushKV("longpollid", active_chain.Tip()->GetBlockHash().GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -132,6 +132,14 @@ class MiningTest(BitcoinTestFramework):
         coinstake_tx.deserialize(BytesIO(bytes.fromhex(tmpl['transactions'][0]['data'])))
         coinstake_tx.rehash()
 
+        # The reported values must come from the transactions they name. The
+        # coinstake pays out through its first real output, vout[0] being the
+        # empty marker, and a proof-of-stake coinbase carries a single empty
+        # output. The coinbase has only ever one output, so reading a coinstake
+        # value from it used to run off the end of its output vector.
+        assert_equal(tmpl['coinstakevalue'], coinstake_tx.vout[1].nValue)
+        assert_equal(tmpl['coinbasevalue'], 0)
+
         block = CBlock()
         block.nVersion = tmpl["version"]
         block.hashPrevBlock = int(tmpl["previousblockhash"], 16)


### PR DESCRIPTION
## Summary

`getblocktemplate` reported `coinstakevalue` from `vtx[0]->vout[1]`, the coinbase's second output. The coinbase only ever has one output: `miner.cpp` resizes it to one, and the proof-of-stake path empties that single output rather than adding another. Reading `vout[1]` therefore ran off the end of the vector on every call.

The ASan job caught it, and it took the node down with it, which is why `mining_getblocktemplate_longpoll.py` failed and the rest of that test's output is connection errors:

```
==30249==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6040002332b8
READ of size 8 at 0x6040002332b8 thread T6 (b-httpworker.0)
    #0 getblocktemplate()::$_10::operator()(...) ./rpc/mining.cpp:1330
0x6040002332b8 is located 0 bytes to the right of 40-byte region
allocated by thread T6 here:
    #1 __gnu_cxx::new_allocator<CTxOut>::allocate(unsigned long, void const*)
```

The 40 byte region is a one element `std::vector<CTxOut>`, and the read is the 8 byte `nValue` immediately past it.

This is undefined behaviour on a path any miner exercises, not only a sanitizer complaint. Without a sanitizer it silently returns whatever follows the allocation.

## Change

The value belongs to the coinstake, which is `vtx[1]`, and whose first output is the empty marker, so the staked amount is `vout[1]`. That is the same pair of indexes the block signature check already uses:

```cpp
// pos/signer.cpp
const CTxOut& txout = block.IsProofOfStake() ? block.vtx[1]->vout[1] : block.vtx[0]->vout[0];
```

so it looks like the indexes were simply transposed when the field was added.

No extra bounds check is needed. `IsProofOfStake()` requires `vtx[1]` to be a coinstake, and `IsCoinStake()` requires at least two outputs, so both indexes are guaranteed once that test passes.

Proof-of-work templates have no coinstake and now report zero instead of reading past the coinbase. The key is still always present, so nothing that consumes the RPC has to change.

## Related code audited

Every other place that indexes a coinstake or a second output was checked, and all of them are already guarded:

- `miner.cpp` 249, 252, 271, 279: inside `if (pblock->IsProofOfStake())`
- `validation.cpp` 1966 and 3509: inside `if (block.IsProofOfStake())`
- `validation.cpp` 2098 and 2107: inside the `else if (block.IsProofOfStake())` arm that begins at 2076
- `primitives/block.h` 160 and `pos/signer.cpp` 15, 86: guarded by an `IsProofOfStake()` ternary
- `qt/transactionrecord.cpp` 43: guarded by `wtx.is_coinstake`, which is `CWalletTx::IsCoinStake()` and so implies at least two outputs

There is no other `vtx[0]->vout[N]` for non zero N anywhere in the tree.

## Coverage

Nothing covered `coinstakevalue`, which is how this went unnoticed.

`mining_basic.py` already builds a block from a template and deserializes the coinstake in order to do so, and it runs well past `nLastPowHeight`, so the template it fetches is a proof-of-stake one. The second commit ties the reported values to the transactions they name there: `coinstakevalue` against the coinstake's `vout[1]`, and `coinbasevalue` against zero, since a proof-of-stake coinbase carries a single empty output.

## Testing

`rpc/mining.cpp` compiles clean and `mining_basic.py` passes `py_compile` and the python lint.

The new assertion was confirmed to catch the defect rather than merely accompany the fix. Run against a binary built before the change, it fails with:

```
AssertionError: not(293 == 30026977087940)
```

293 is what was read past the end of the coinbase's output vector, against the coinstake's actual value of 30026977087940. That is the same bug the sanitizer reported, visible here without a sanitizer, and it is a good illustration of what the RPC was returning to callers on an ordinary build: a small, plausible looking, entirely wrong number.

The ASan job remains the confirmation that the out of bounds read itself is gone, since `mining_getblocktemplate_longpoll.py` was aborting the node there.
