### PR TITLE
test: let rpc_fundrawtransaction retry its block generation

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -88,12 +88,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         # the test have reliable PoS staking (builds up coinstake UTXO pool
         # and advances the staking search time window).
         advance_time_for_pos(self.nodes, seconds=600)
-        self.nodes[0].generate(20)
+        self.generate(20)
         self.sync_all()
 
         # Fund node2 with a 50-coin UTXO to match test expectations
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 50)
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_all()
 
         self.test_change_position()
@@ -155,7 +155,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 1.0)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 5.0)
 
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_all()
 
         wwatch.unloadwallet()
@@ -529,7 +529,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Send 1.2 BTC to msig addr.
         self.nodes[0].sendtoaddress(mSigObj, 1.2)
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_all()
 
         oldBalance = self.nodes[1].getbalance()
@@ -541,7 +541,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         final_psbt = w2.finalizepsbt(signed_psbt['psbt'])
         self.nodes[2].sendrawtransaction(final_psbt['hex'])
         self.nodes[0].sendrawtransaction(final_psbt['hex'])
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_blocks()
 
         # Make sure funds are received at node1.
@@ -605,7 +605,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         signedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
         self.nodes[1].sendrawtransaction(signedTx['hex'])
         self.nodes[0].sendrawtransaction(signedTx['hex'])
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_blocks()
 
         # On ReddCoin PoS, balance checks are unreliable because coinstake
@@ -622,12 +622,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Empty node1, send some small coins from node0 to node1.
         txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
         self.nodes[0].sendrawtransaction(self.nodes[1].gettransaction(txid)['hex'])
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_blocks()
 
         for _ in range(20):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_blocks()
 
         # Fund a tx with ~20 small inputs.
@@ -646,7 +646,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Confirm the sendmany tx so the next test starts with a clean slate.
         self.nodes[0].sendrawtransaction(self.nodes[1].gettransaction(txId)['hex'])
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_blocks()
 
     def test_many_inputs_send(self):
@@ -656,12 +656,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Again, empty node1, send some small coins from node0 to node1.
         txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
         self.nodes[0].sendrawtransaction(self.nodes[1].gettransaction(txid)['hex'])
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_blocks()
 
         for _ in range(20):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_blocks()
 
         # Fund a tx with ~20 small inputs.
@@ -672,7 +672,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedAndSignedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
         self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
         self.nodes[0].sendrawtransaction(fundedAndSignedTx['hex'])
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_blocks()
         # Verify the tx was confirmed (balance checks unreliable with PoS coinstake)
         txid = self.nodes[0].decoderawtransaction(fundedAndSignedTx['hex'])['txid']
@@ -756,7 +756,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         signedtx = self.nodes[0].signrawtransactionwithwallet(signedtx["hex"])
         assert signedtx["complete"]
         self.nodes[0].sendrawtransaction(signedtx["hex"])
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_all()
 
         wwatch.unloadwallet()
@@ -975,7 +975,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.log.info("Test fundrawtx where BnB solution would result in a too large transaction, but Knapsack would not")
         # Build up staking UTXOs before the large sendmany consumes coins
         advance_time_for_pos(self.nodes, seconds=600)
-        self.nodes[0].generate(10)
+        self.generate(10)
         self.sync_blocks()
 
         self.nodes[0].createwallet("large")
@@ -993,7 +993,7 @@ class RawTransactionsTest(BitcoinTestFramework):
             outputs[recipient.getnewaddress()] = 0.1
         wallet.sendmany("", outputs)
         advance_time_for_pos(self.nodes, seconds=600)
-        self.nodes[0].generate(10)
+        self.generate(10)
         assert_raises_rpc_error(-4, "Transaction too large", recipient.fundrawtransaction, rawtx)
 
     def test_include_unsafe(self):
@@ -1022,7 +1022,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         wallet.sendrawtransaction(signedtx['hex'])
 
         # And we can also use them once they're confirmed.
-        self.nodes[0].generate(1)
+        self.generate(1)
         rawtx = wallet.createrawtransaction([], [{self.nodes[2].getnewaddress(): 3}])
         fundedtx = wallet.fundrawtransaction(rawtx, {"include_unsafe": True})
         tx_dec = wallet.decoderawtransaction(fundedtx['hex'])
@@ -1047,7 +1047,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         addr = w.getnewaddress(address_type="bech32")
         self.nodes[0].sendtoaddress(addr, 1)
-        self.nodes[0].generate(1)
+        self.generate(1)
         self.sync_all()
 
         # A P2WPKH input costs 68 vbytes; With a single P2WPKH output, the rest of the tx is 42 vbytes for a total of 110 vbytes.


### PR DESCRIPTION
## Summary

The descriptors run of this test fails in CI while making blocks after the 1500 output sendmany:

```
File "test/functional/rpc_fundrawtransaction.py", line 996, in test_transaction_too_large
    self.nodes[0].generate(10)
JSONRPCException: Could not create PoS block at height 243: no valid coinstake found
                  (wallet may need more age) (-1)
```

with the node logging this several thousand times beforehand:

```
CheckStakeKernelHash() : unable to determine stakemodifier
nStakeModifier=0, nStakeModifierHeight=241
```

## Cause

The sendmany just above spends the wallet down into freshly created outputs. A coin that new has no determinable stake modifier yet, so every kernel check fails and the coinstake search comes up empty.

Whether the wallet recovers in time depends on how the timing falls, which is why this passes locally and fails on the runner. The test is already aware of the general problem, calling `advance_time_for_pos()` before each of these, but a single `generate()` still has to succeed on its first attempt.

## Change

Generate through `self.generate()`, which advances mocktime and retries for exactly this, rather than calling `generate()` on the node directly.

All seventeen call sites are converted, not only the one that failed, since any of them can lose the same race. None used the return value, so the change is mechanical.

## Testing

Locally: the descriptors variant twice and the legacy variant once, all passing.

