### PR TITLE
test: assign ZMQ ports from the framework rather than fixing them

### DIFF
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -23,6 +23,7 @@ from test_framework.util import (
     advance_time_for_pos,
     assert_equal,
     assert_raises_rpc_error,
+    zmq_port,
 )
 from io import BytesIO
 from time import sleep
@@ -250,7 +251,7 @@ class ZMQTest (BitcoinTestFramework):
         # Invalid zmq arguments don't take down the node, see #17185.
         self.restart_node(0, ["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
 
-        address = 'tcp://127.0.0.1:28332'
+        address = 'tcp://127.0.0.1:%d' % zmq_port(0)
         subs = self.setup_zmq_test([(topic, address) for topic in ["hashblock", "hashtx", "rawblock", "rawtx"]])
 
         hashblock = subs[0]
@@ -333,7 +334,7 @@ class ZMQTest (BitcoinTestFramework):
             self.log.info("Skipping reorg test because wallet is disabled")
             return
 
-        address = 'tcp://127.0.0.1:28333'
+        address = 'tcp://127.0.0.1:%d' % zmq_port(1)
 
         # Should only notify the tip if a reorg occurs
         hashblock, hashtx = self.setup_zmq_test(
@@ -395,7 +396,7 @@ class ZMQTest (BitcoinTestFramework):
         <32-byte hash>A<8-byte LE uint> : Transactionhash added mempool
         """
         self.log.info("Testing 'sequence' publisher")
-        [seq] = self.setup_zmq_test([("sequence", "tcp://127.0.0.1:28333")])
+        [seq] = self.setup_zmq_test([("sequence", "tcp://127.0.0.1:%d" % zmq_port(1))])
         self.disconnect_nodes(0, 1)
 
         # Mempool sequence number starts at 1
@@ -551,7 +552,7 @@ class ZMQTest (BitcoinTestFramework):
             return
 
         self.log.info("Testing 'mempool sync' usage of sequence notifier")
-        [seq] = self.setup_zmq_test([("sequence", "tcp://127.0.0.1:28333")])
+        [seq] = self.setup_zmq_test([("sequence", "tcp://127.0.0.1:%d" % zmq_port(1))])
 
         # In-memory counter, should always start at 1
         next_mempool_seq = self.nodes[0].getrawmempool(mempool_sequence=True)["mempool_sequence"]
@@ -655,8 +656,8 @@ class ZMQTest (BitcoinTestFramework):
         # chain lengths on node0 and node1; for this test we only need node0, so
         # we can disable syncing blocks on the setup)
         subscribers = self.setup_zmq_test([
-            ("hashblock", "tcp://127.0.0.1:28334"),
-            ("hashblock", "tcp://127.0.0.1:28335"),
+            ("hashblock", "tcp://127.0.0.1:%d" % zmq_port(2)),
+            ("hashblock", "tcp://127.0.0.1:%d" % zmq_port(3)),
         ], sync_blocks=False)
 
         # Generate 1 block in nodes[0] and receive all notifications

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -342,6 +342,17 @@ def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
 
+def zmq_port(n):
+    """Port for a ZMQ publisher, assigned like the p2p and rpc ones.
+
+    ZMQ has no default port: a publisher is given a whole address, so tests used
+    to name one themselves. A fixed port collides with any node already running
+    on the machine, and with another test run using a different port seed, so
+    take these from the same allocation as everything else instead.
+    """
+    return PORT_MIN + 2 * PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
+
+
 def rpc_url(datadir, i, chain, rpchost):
     rpc_u, rpc_p = get_auth_cookie(datadir, chain)
     host = '127.0.0.1'


### PR DESCRIPTION
## Summary

`interface_zmq.py` named tcp ports 28332 to 28335 itself. There is no default ZMQ port to collide with, since a publisher is handed a whole address and the daemon defaults only the high water marks, but those particular numbers are Bitcoin's convention and are exactly what a node running on the same machine is likely to be publishing on already. Reddcoin's own p2p and rpc ports moved to the 45000 range long ago; this file never followed.

The resulting failure is unhelpful. The node cannot bind, `CZMQNotificationInterface::Initialize` tears down every notifier rather than just the one that failed, and the test's sync up procedure then generates blocks indefinitely waiting for notifications that will never arrive:

```
zmq: Error: Failed to bind address, msg: Address already in use
zmq: Notifier pubhashblock failed (address = tcp://127.0.0.1:28332)
zmq: Shutdown notification interface
...
TestFramework (DEBUG): Didn't receive sync-up notification, trying again.   [x435]
```

Nothing says which port is at fault or that anything is wrong at all, and the run only ends when something kills it.

## Change

`zmq_port()` mirrors the existing `p2p_port()` and `rpc_port()`, taking its ports from the test run's port seed, one range above rpc. With the default `PORT_MIN` that gives p2p 11000, rpc 16000 and zmq 21000, and the three ranges stay disjoint under any `PORT_MIN`, including the 14000 that CI sets.

Two consequences beyond the collision this fixes: a test run no longer conflicts with a node on the same machine, and two runs with different port seeds no longer conflict with each other, which the fixed ports would have done.

## Testing

The test was run with a local wallet still publishing on 28332 and 28333, the situation that previously made it impossible to run at all. It passes.

Port allocation, for the record:

```
portseed=0    p2p 11000..11011   rpc 16000..16011   zmq [21000, 21001, 21002, 21003]
portseed=7    p2p 11084..11095   rpc 16084..16095   zmq [21084, 21085, 21086, 21087]
```

## Note for future merges

Upstream Bitcoin Core hardcodes these ports in the same file, so this is a deliberate divergence and merges touching `interface_zmq.py` will need to keep it.
