### PR TITLE
mempool: drop transactions spending immature coinstakes on reorg

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -532,7 +532,13 @@ void CTxMemPool::removeForReorg(CChainState& active_chainstate, int flags)
                 const Coin &coin = active_chainstate.CoinsTip().AccessCoin(txin.prevout);
                 if (m_check_ratio != 0) assert(!coin.IsSpent());
                 unsigned int nMemPoolHeight = active_chainstate.m_chain.Tip()->nHeight + 1;
-                if (coin.IsSpent() || (coin.IsCoinBase() && ((signed long)nMemPoolHeight) - coin.nHeight < params.GetCoinbaseMaturity())) {
+                // Coinstake outputs mature exactly as coinbase outputs do, and
+                // CheckTxInputs rejects a spend of either before then. Both have
+                // to be considered here, or a transaction spending a coinstake
+                // that a reorg has made immature again stays in the mempool, is
+                // taken into the next template, and fails TestBlockValidity with
+                // bad-txns-premature-spend-of-coinbase/coinstake.
+                if (coin.IsSpent() || ((coin.IsCoinBase() || coin.IsCoinStake()) && ((signed long)nMemPoolHeight) - coin.nHeight < params.GetCoinbaseMaturity())) {
                     txToRemove.insert(it);
                     break;
                 }


### PR DESCRIPTION
# mempool: drop transactions spending immature coinstakes on reorg

## Summary

Consensus and the mempool disagree about coinstake maturity.

`CheckTxInputs` refuses a spend of a coinbase or a coinstake until it has matured, treating the two alike:

```cpp
// src/consensus/tx_verify.cpp:185
if ((coin.IsCoinBase() || coin.IsCoinStake()) && nSpendHeight - coin.nHeight < params.GetCoinbaseMaturity())
```

`removeForReorg`, which clears out transactions a reorg has invalidated, only looks at coinbases:

```cpp
// src/txmempool.cpp:535
if (coin.IsSpent() || (coin.IsCoinBase() && ... < params.GetCoinbaseMaturity()))
```

So a transaction spending a coinstake that a reorg has pushed back below maturity stays in the mempool. The block assembler then takes it into the next template, and the block fails its own validity check:

```
CreateNewBlock: TestBlockValidity failed:
bad-txns-premature-spend-of-coinbase/coinstake, tried to spend coinbase at depth 59
```

## Why it matters beyond the test

This surfaced through `feature_bip68_sequence`, which invalidates a block and leaves behind a transaction one confirmation short of the sixty regtest requires. The same thing happens outside tests: a staking node that sees any reorg putting a spent-from coinstake back inside the maturity window will start failing to produce blocks, and keep failing until that transaction leaves the mempool by some other route.

## Change

Consider coinstakes in `removeForReorg` as well, so the two checks agree. `Coin` already carries `fCoinStake` and exposes `IsCoinStake()`, so nothing else was needed.

Every other maturity comparison in the tree was checked for the same asymmetry; there is none.

## Testing

`feature_bip68_sequence` passes, but that is not evidence either way: the binary it ran against predates this change, and the test passes locally with or without it, since reaching the failure depends on reorg timing. The TSan job is where it showed up and where confirmation has to come from.

A regression test would need to invalidate a block that a mempool transaction's coinstake input depends on, then assemble a template, which none of the current tests do directly.
