### PR TITLE
ci: fetch Reddcoin's previous release, not Bitcoin's

### DIFF
--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -14,6 +14,6 @@ export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude fe
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
 export GOAL="install"
-export PREVIOUS_RELEASES_TO_DOWNLOAD="v0.15.2 v0.16.3 v0.17.2 v0.18.1 v0.19.1 v0.20.1"
+export PREVIOUS_RELEASES_TO_DOWNLOAD="v4.22.9"  # the release the compat tests run against
 export BITCOIN_CONFIG="--enable-zmq --with-libs=no --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports
 --enable-debug --disable-fuzz-binary  CFLAGS=\"-g0 -O2 -funsigned-char\" CXXFLAGS=\"-g0 -O2 -funsigned-char\""

--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -14,6 +14,6 @@ export TEST_RUNNER_EXTRA="--previous-releases --coverage --extended --exclude fe
 export RUN_UNIT_TESTS_SEQUENTIAL="true"
 export RUN_UNIT_TESTS="false"
 export GOAL="install"
-export PREVIOUS_RELEASES_TO_DOWNLOAD="v4.22.9"  # the release the compat tests run against
+export PREVIOUS_RELEASES_TO_DOWNLOAD="v4.22.9.3"  # the release the compat tests run against
 export BITCOIN_CONFIG="--enable-zmq --with-libs=no --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports
 --enable-debug --disable-fuzz-binary  CFLAGS=\"-g0 -O2 -funsigned-char\" CXXFLAGS=\"-g0 -O2 -funsigned-char\""

--- a/test/functional/feature_compat_p2p_sync.py
+++ b/test/functional/feature_compat_p2p_sync.py
@@ -26,7 +26,7 @@ the node falls back to a PoW template which is rejected past nLastPowHeight).
     Disconnect, node1 mines 50 PoS blocks, reconnect, node0 catches up.
     Repeat once more to test repeated long-gap sync.
 
-Requires previous releases (v4.22.9 binary), see test/README.md.
+Requires previous releases (the v4.22.9.3 binary), see test/README.md.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -71,7 +71,7 @@ class CompatP2PSyncTest(BitcoinTestFramework):
         self.add_nodes(
             self.num_nodes,
             extra_args=self.extra_args,
-            versions=[4220900, None],
+            versions=[4220903, None],
         )
         self.start_nodes()
         self.import_deterministic_coinbase_privkeys()

--- a/test/functional/feature_compat_pos_blocks.py
+++ b/test/functional/feature_compat_pos_blocks.py
@@ -56,7 +56,7 @@ class CompatPosBlocksTest(BitcoinTestFramework):
         mocktime drift that would cause peers to disconnect each other.
         """
         self.add_nodes(self.num_nodes, extra_args=self.extra_args, versions=[
-            4220900,  # node0 — v4.22.9 (follower)
+            4220903,  # node0 - v4.22.9.3 (follower)
             None,     # node1 — v4.22.10 (lead staker)
         ])
         self.start_nodes()

--- a/test/functional/feature_compat_softfork_signaling.py
+++ b/test/functional/feature_compat_softfork_signaling.py
@@ -46,7 +46,7 @@ from test_framework.util import (
 )
 
 # Version numbers
-VERSION_OLD = 4220900  # v4.22.9
+VERSION_OLD = 4220903  # v4.22.9.3
 VERSION_NEW = None     # v4.22.10 (current)
 
 # BIP9 regtest parameters

--- a/test/functional/feature_compat_staking_interop.py
+++ b/test/functional/feature_compat_staking_interop.py
@@ -72,7 +72,7 @@ class CompatStakingInteropTest(BitcoinTestFramework):
         self.add_nodes(
             self.num_nodes,
             extra_args=self.extra_args,
-            versions=[4220900, None, None],
+            versions=[4220903, None, None],
         )
         self.start_nodes()
         self.init_wallet(0)

--- a/test/functional/feature_compat_tx_versions.py
+++ b/test/functional/feature_compat_tx_versions.py
@@ -53,7 +53,7 @@ the chains intentionally divergent):
 v1 transactions are not tested because Reddcoin wallets do not produce v1
 (PoSV requires nTime → every Reddcoin wallet tx is v2+ by design).
 
-Requires previous releases (v4.22.9 binary), see test/README.md.
+Requires previous releases (the v4.22.9.3 binary), see test/README.md.
 """
 
 import hashlib
@@ -88,7 +88,7 @@ RELATIVE_LOCK_10_BLOCKS = 10
 NOT_FINAL_ERROR = "non-BIP68-final"
 
 # Version numbers
-VERSION_OLD = 4220900  # v4.22.9
+VERSION_OLD = 4220903  # v4.22.9.3
 VERSION_NEW = None     # v4.22.10 (current build)
 
 

--- a/test/functional/feature_pos_coinstake_fees.py
+++ b/test/functional/feature_pos_coinstake_fees.py
@@ -73,7 +73,7 @@ class PosCoinstakeFeesTest(BitcoinTestFramework):
     def setup_network(self):
         if self.compat:
             self.add_nodes(self.num_nodes, extra_args=self.extra_args, versions=[
-                4220900,  # node0 — v4.22.9 follower
+                4220903,  # node0 - v4.22.9.3 follower
                 None,     # node1 — current build, lead staker
             ])
             self.start_nodes()

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1241,9 +1241,9 @@ class TaprootTest(BitcoinTestFramework):
         be connected during initial block generation — mocktime drift causes
         header rejection. Connect after syncing mocktime."""
         self.add_nodes(self.num_nodes, self.extra_args, versions=[
-            # ReddCoin: use the v4.22.9 previous release (encoded 4220900), not
+            # ReddCoin: use the v4.22.9.3 previous release (encoded 4220903), not
             # upstream's pre-Taproot v0.20.1 (200100) which ReddCoin doesn't ship.
-            4220900 if self.options.previous_release else None,
+            4220903 if self.options.previous_release else None,
             None,
         ])
         self.start_nodes()

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -36,7 +36,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.add_nodes(self.num_nodes, extra_args=self.extra_args, versions=[
-            4220900,  # oldest version with getmempoolinfo.loaded (used to avoid intermittent issues)
+            4220903,  # oldest version with getmempoolinfo.loaded (used to avoid intermittent issues)
             None,
         ])
         self.start_nodes()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -209,12 +209,12 @@ BASE_SCRIPTS = [
     'example_test.py',
     'wallet_txn_doublespend.py --legacy-wallet',
     'wallet_txn_doublespend.py --descriptors',
-    # Group-A wallet-evolution tests are deferred: the v4.22.9 previous release is
-    # already at FEATURE_LATEST (169900) — identical to the current wallet version —
+    # Group-A wallet-evolution tests are deferred: the v4.22.9.3 previous release is
+    # already at FEATURE_LATEST (169900), identical to the current wallet version,
     # so there is no upgrade/cross-version delta to test yet. Re-enable and adapt them
-    # to use the v4.22.9 release (4220900) once FEATURE_LATEST is bumped past 169900
-    # (then v4.22.9 becomes a genuine old wallet). Until then they only fail (they
-    # request nonexistent Bitcoin Core v0.1x binaries).
+    # to use that release (4220903) once FEATURE_LATEST is bumped past 169900 (then
+    # it becomes a genuine old wallet). Until then they only fail (they request
+    # nonexistent Bitcoin Core v0.1x binaries).
     # 'feature_backwards_compatibility.py --legacy-wallet',
     # 'feature_backwards_compatibility.py --descriptors',
     'wallet_txn_clone.py --mineblock',
@@ -247,7 +247,7 @@ BASE_SCRIPTS = [
     'wallet_import_with_label.py --legacy-wallet',
     'wallet_importdescriptors.py --descriptors',
     # Deferred group-A wallet-evolution test (see note above); no cross-version
-    # delta until FEATURE_LATEST is bumped past v4.22.9's 169900.
+    # delta until FEATURE_LATEST is bumped past v4.22.9.3's 169900.
     # 'wallet_upgradewallet.py --legacy-wallet',
     'rpc_bind.py --ipv4',
     'rpc_bind.py --ipv6',
@@ -257,7 +257,10 @@ BASE_SCRIPTS = [
     'feature_pos_coinstake_fees.py',
     'feature_pos_sync.py',
     'feature_pos_tx_version_floor.py',
-    # v4.22.9 ↔ v4.22.10 compatibility tests (require releases/v4.22.9/bin/)
+    # Compatibility tests against the previous release (require
+    # releases/v4.22.9.3/bin/). That is v4.22.9 plus the commits that let it run
+    # regtest, which the released v4.22.9 cannot; the fourth version component
+    # is what distinguishes the two.
     'feature_compat_p2p_sync.py',
     'feature_compat_pos_blocks.py',
     'feature_pos_coinstake_fees.py --previous_release',

--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -20,45 +20,19 @@ import sys
 import hashlib
 
 
+# Checksums of the release archives this script downloads, keyed by hash.
+#
+# Reddcoin does not publish binaries the way bitcoincore.org does, so these are
+# the archives attached to the release for the tag. Add an entry per platform
+# as each is uploaded.
+#
+# The archives are the ones Guix produces, unchanged: contrib/guix/guix-build
+# writes guix-build-<version>/output/<host>/reddcoin-<version>-<host>.tar.gz,
+# which is already the name and the layout this expects. Pass FORCE_VERSION to
+# name it for the release rather than for the commit built. Guix also builds
+# Linux hosts against glibc 2.24, which matters here: the job that uses these
+# runs in ubuntu:18.04, and a host build wants far newer than it has.
 SHA256_SUMS = {
-    "d40f18b4e43c6e6370ef7db9131f584fbb137276ec2e3dba67a4b267f81cb644": "bitcoin-0.15.2-aarch64-linux-gnu.tar.gz",
-    "54fb877a148a6ad189a1e1ab1ff8b11181e58ff2aaf430da55b3fd46ae549a6b": "bitcoin-0.15.2-arm-linux-gnueabihf.tar.gz",
-    "2b843506c3f1af0eeca5854a920264f9a829f02d0d50328005950ddcbe88874d": "bitcoin-0.15.2-i686-pc-linux-gnu.tar.gz",
-    "87e9340ff3d382d543b2b69112376077f0c8b4f7450d372e83b68f5a1e22b2df": "bitcoin-0.15.2-osx64.tar.gz",
-    "566be44190fd76daa01f13d428939dadfb8e3daacefc8fa17f433cad28f73bd5": "bitcoin-0.15.2-x86_64-linux-gnu.tar.gz",
-    #
-    "0768c6c15caffbaca6524824c9563b42c24f70633c681c2744649158aa3fd484": "bitcoin-0.16.3-aarch64-linux-gnu.tar.gz",
-    "fb2818069854a6ad20ea03b28b55dbd35d8b1f7d453e90b83eace5d0098a2a87": "bitcoin-0.16.3-arm-linux-gnueabihf.tar.gz",
-    "75a537844313b0a84bdb61ffcdc5c4ce19a738f7ddf71007cd2edf664efd7c37": "bitcoin-0.16.3-i686-pc-linux-gnu.tar.gz",
-    "78c3bff3b619a19aed575961ea43cc9e142959218835cf51aede7f0b764fc25d": "bitcoin-0.16.3-osx64.tar.gz",
-    "5d422a9d544742bc0df12427383f9c2517433ce7b58cf672b9a9b17c2ef51e4f": "bitcoin-0.16.3-x86_64-linux-gnu.tar.gz",
-    #
-    "5a6b35d1a348a402f2d2d6ab5aed653a1a1f13bc63aaaf51605e3501b0733b7a": "bitcoin-0.17.2-aarch64-linux-gnu.tar.gz",
-    "d1913a5d19c8e8da4a67d1bd5205d03c8614dfd2e02bba2fe3087476643a729e": "bitcoin-0.17.2-arm-linux-gnueabihf.tar.gz",
-    "d295fc93f39bbf0fd937b730a93184899a2eb6c3a6d53f3d857cbe77ef89b98c": "bitcoin-0.17.2-i686-pc-linux-gnu.tar.gz",
-    "a783ba20706dbfd5b47fbedf42165fce70fbbc7d78003305d964f6b3da14887f": "bitcoin-0.17.2-osx64.tar.gz",
-    "943f9362b9f11130177839116f48f809d83478b4c28591d486ee9a7e35179da6": "bitcoin-0.17.2-x86_64-linux-gnu.tar.gz",
-    #
-    "88f343af72803b851c7da13874cc5525026b0b55e63e1b5e1298390c4688adc6": "bitcoin-0.18.1-aarch64-linux-gnu.tar.gz",
-    "cc7d483e4b20c5dabd4dcaf304965214cf4934bcc029ca99cbc9af00d3771a1f": "bitcoin-0.18.1-arm-linux-gnueabihf.tar.gz",
-    "989e847b3e95fc9fedc0b109cae1b4fa43348f2f712e187a118461876af9bd16": "bitcoin-0.18.1-i686-pc-linux-gnu.tar.gz",
-    "b7bbcee7a7540f711b171d6981f939ca8482005fde22689bc016596d80548bb1": "bitcoin-0.18.1-osx64.tar.gz",
-    "425ee5ec631ae8da71ebc1c3f5c0269c627cf459379b9b030f047107a28e3ef8": "bitcoin-0.18.1-riscv64-linux-gnu.tar.gz",
-    "600d1db5e751fa85903e935a01a74f5cc57e1e7473c15fd3e17ed21e202cfe5a": "bitcoin-0.18.1-x86_64-linux-gnu.tar.gz",
-    #
-    "3a80431717842672df682bdb619e66523b59541483297772a7969413be3502ff": "bitcoin-0.19.1-aarch64-linux-gnu.tar.gz",
-    "657f28213823d240dd3324d14829702f9ad6f0710f8bdd1c379cb3c447197f48": "bitcoin-0.19.1-arm-linux-gnueabihf.tar.gz",
-    "10d1e53208aa7603022f4acc084a046299ab4ccf25fe01e81b3fb6f856772589": "bitcoin-0.19.1-i686-pc-linux-gnu.tar.gz",
-    "1ae1b87de26487075cd2fd22e0d4ead87d969bd55c44f2f1d873ecdc6147ebb3": "bitcoin-0.19.1-osx64.tar.gz",
-    "aa7a9563b48aa79252c8e7b6a41c07a5441bd9f14c5e4562cc72720ea6cb0ee5": "bitcoin-0.19.1-riscv64-linux-gnu.tar.gz",
-    "5fcac9416e486d4960e1a946145566350ca670f9aaba99de6542080851122e4c": "bitcoin-0.19.1-x86_64-linux-gnu.tar.gz",
-    #
-    "60c93e3462c303eb080be7cf623f1a7684b37fd47a018ad3848bc23e13c84e1c": "bitcoin-0.20.1-aarch64-linux-gnu.tar.gz",
-    "55b577e0fb306fb429d4be6c9316607753e8543e5946b542d75d876a2f08654c": "bitcoin-0.20.1-arm-linux-gnueabihf.tar.gz",
-    "b9024dde373ea7dad707363e07ec7e265383204127539ae0c234bff3a61da0d1": "bitcoin-0.20.1-osx64.tar.gz",
-    "c378d4e21109f09e8829f3591e015c66632dff2925a60b64d259be05a334c30b": "bitcoin-0.20.1-osx.dmg",
-    "fa71cb52ee5e0459cbf5248cdec72df27995840c796f58b304607a1ed4c165af": "bitcoin-0.20.1-riscv64-linux-gnu.tar.gz",
-    "376194f06596ecfa40331167c39bc70c355f960280bd2a645fdbf18f66527397": "bitcoin-0.20.1-x86_64-linux-gnu.tar.gz",
 }
 
 
@@ -79,26 +53,27 @@ def download_binary(tag, args) -> int:
             return 0
         shutil.rmtree(tag)
     Path(tag).mkdir()
-    bin_path = 'bin/bitcoin-core-{}'.format(tag[1:])
-    match = re.compile('v(.*)(rc[0-9]+)$').search(tag)
-    if match:
-        bin_path = 'bin/bitcoin-core-{}/test.{}'.format(
-            match.group(1), match.group(2))
-    tarball = 'bitcoin-{tag}-{platform}.tar.gz'.format(
+    tarball = 'reddcoin-{tag}-{platform}.tar.gz'.format(
         tag=tag[1:], platform=args.platform)
-    tarballUrl = 'https://bitcoincore.org/{bin_path}/{tarball}'.format(
-        bin_path=bin_path, tarball=tarball)
+    # Release assets live on the GitHub release for the tag. Override the base
+    # for a mirror or a staging location; the archive name is still appended.
+    baseUrl = os.environ.get(
+        'PREVIOUS_RELEASES_URL',
+        'https://github.com/reddcoin-project/reddcoin/releases/download')
+    tarballUrl = '{baseUrl}/{tag}/{tarball}'.format(
+        baseUrl=baseUrl.rstrip('/'), tag=tag, tarball=tarball)
 
     print('Fetching: {tarballUrl}'.format(tarballUrl=tarballUrl))
 
     header, status = subprocess.Popen(
-        ['curl', '--head', tarballUrl], stdout=subprocess.PIPE).communicate()
+        ['curl', '--location', '--head', tarballUrl],
+        stdout=subprocess.PIPE).communicate()
     if re.search("404 Not Found", header.decode("utf-8")):
         print("Binary tag was not found")
         return 1
 
     curlCmds = [
-        ['curl', '--remote-name', tarballUrl]
+        ['curl', '--location', '--remote-name', tarballUrl]
     ]
 
     for cmd in curlCmds:
@@ -119,7 +94,7 @@ def download_binary(tag, args) -> int:
     # Extract tarball
     ret = subprocess.run(['tar', '-zxf', tarball, '-C', tag,
                           '--strip-components=1',
-                          'bitcoin-{tag}'.format(tag=tag[1:])]).returncode
+                          'reddcoin-{tag}'.format(tag=tag[1:])]).returncode
     if ret:
         return ret
 
@@ -128,7 +103,7 @@ def download_binary(tag, args) -> int:
 
 
 def build_release(tag, args) -> int:
-    githubUrl = "https://github.com/bitcoin/bitcoin"
+    githubUrl = "https://github.com/reddcoin-project/reddcoin"
     if args.remove_dir:
         if Path(tag).is_dir():
             shutil.rmtree(tag)


### PR DESCRIPTION
# ci: fetch Reddcoin's previous release, not Bitcoin's

## Summary

The `previous releases, qt5, DEBUG` job fails:

```
FileNotFoundError: [Errno 2] No such file or directory:
'/home/runner/work/reddcoin/reddcoin/releases/x86_64-pc-linux-gnu/v4.22.9/bin/reddcoind'
```

## Cause

Nothing had ever been asked to produce that file. The previous-release machinery is still entirely Bitcoin's:

```
export PREVIOUS_RELEASES_TO_DOWNLOAD="v0.15.2 v0.16.3 v0.17.2 v0.18.1 v0.19.1 v0.20.1"
```

and the job duly fetches them:

```
Releases directory: /home/runner/work/reddcoin/reddcoin/releases/x86_64-pc-linux-gnu
Fetching: https://bitcoincore.org/bin/bitcoin-core-0.15.2/bitcoin-0.15.2-x86_64-linux-gnu.tar.gz
```

Meanwhile `TEST_RUNNER_EXTRA` forces `--previous-releases` on, and the compat tests want v4.22.9. So the job downloads six Bitcoin releases nothing will use, and none of the one thing it needs.

`get_previous_releases.py` was half converted. Its build path already moves `reddcoind`, `reddcoin-cli` and `reddcoin-tx` into place at the end, but still clones `bitcoin/bitcoin` to get them. Its download path is bitcoincore.org and Bitcoin's checksums throughout.

## Changes

The shape stays upstream's, since that is worth keeping: fetch an archive for the tag, check it against a recorded sum, extract it into place.

**Download from our own release assets.** The archive is `reddcoin-<version>-<platform>.tar.gz`, taken from the release for the tag. `PREVIOUS_RELEASES_URL` overrides the base for a mirror or a staging location. `curl` follows redirects now, which release assets need.

**Clone Reddcoin in the build path**, so the fallback matches what it then packages.

**Empty the checksum table** of Bitcoin's sums, to be filled as archives are uploaded.

**Ask for v4.22.9.3** in the qt5 environment, for the reason below.

## Which release, and why it is not v4.22.9

The build the compat tests need is not the released v4.22.9, which cannot run regtest at all. It is that release plus the five commits on the `v4.22.9-regtest` branch, which enable the CSV, SegWit and CLTV deployments there.

Giving that its own version is cheaper than it looks. The framework already builds the release directory from four components and only strips a trailing zero:

```python
're.sub(r'\.0$', '', 'v{}.{}.{}.{}'.format(...))'
```

so `4220900` was always v4.22.9 build 0, and `4220903` is the same release at build 3, resolving to `releases/v4.22.9.3/bin`. Builds 1 and 2 are already spoken for by earlier candidates. The fourth component is already part of the scheme rather than something added for this, and nothing in the framework changes. `configure.ac` is left alone, so the binary still reports v4.22.9; nothing reads that, the directory name is what the framework keys on.

The prose in those tests still says v4.22.9 where it describes behaviour, which stays accurate. The build differs from the release only in what it will start, not in how it validates.

## The archive this needs

Nothing needs packaging for it. Guix already writes exactly what the fetch expects:

```
guix-build-<version>/output/<host>/reddcoin-<version>-<host>.tar.gz
```

with a `reddcoin-<version>` directory inside it, since `DISTNAME` is `reddcoin-${VERSION}` and the binaries are staged under `installed/${DISTNAME}`. Pass `FORCE_VERSION=4.22.9.3` so it is named for the release rather than for the commit built, `HOSTS=x86_64-linux-gnu` to build only the one host the job needs, and upload the result.

Guix also settles the harder of the two requirements. This job builds in ubuntu:18.04, which carries glibc 2.27, and a tree built on a current host will not start there: the binaries to hand want GLIBC_2.34. Guix builds Linux hosts against glibc 2.24, comfortably below what the container provides.

The other requirement is one only the source tree can meet: it has to be a build that can run regtest at all, which the released v4.22.9 cannot. That is what the five commits on the `v4.22.9-regtest` branch are for, enabling CSV, SegWit and CLTV signaling there. Guix should be run against that tree.

## Testing

The whole chain is verified end to end, against a local server standing in for the release host and an archive built from the existing `v4.22.9-regtest` tree. It fetches, matches the checksum, and extracts to `releases/<target>/v4.22.9.3/bin/` with `reddcoind`, `reddcoin-cli` and `reddcoin-tx` in it.

`feature_compat_p2p_sync` then passes against it, which is the part worth having: it resolves `4220903` to that directory and starts the old binary. A missing one raises, which is how this failed in CI, so passing means it ran.

That archive was a host build, so it stands in for the shape and not for the contents; a Guix one differs in what it links against, not in how it is named or laid out.

The job itself cannot pass until an archive is uploaded, and the checksum table is deliberately empty until one is. Fetching an asset that is not there fails on the 404 check, and fetching one whose sum is unrecorded fails on the checksum, so neither can pass silently.
