### PR TITLE
test: decide IPv6 support the way the node decides it

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -148,10 +148,27 @@ def test_ipv6_local():
     import socket
     # By using SOCK_DGRAM this will not actually make a connection, but it will
     # fail if there is no route to IPv6 localhost.
-    have_ipv6 = True
     try:
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
         s.connect(('::1', 1))
     except socket.error:
-        have_ipv6 = False
-    return have_ipv6
+        return False
+
+    # A route on its own is not enough, because the node does not decide this
+    # the same way. It resolves through getaddrinfo with AI_ADDRCONFIG, see
+    # WrappedGetAddrInfo in src/netbase.cpp, which returns addresses only of a
+    # family the host has configured, and loopback does not count towards that.
+    # A container with a working ::1 and no other IPv6 address passes the check
+    # above while the node rejects the very same address:
+    #
+    #   Error: Invalid -proxy address or hostname: '[::1]:23501'
+    #
+    # Ask the question the way the node asks it, so tests skip their IPv6 parts
+    # where the node cannot follow.
+    try:
+        if not socket.getaddrinfo('::1', None, socket.AF_INET6, flags=socket.AI_ADDRCONFIG):
+            return False
+    except socket.gaierror:
+        return False
+
+    return True


### PR DESCRIPTION
# test: decide IPv6 support the way the node decides it

## Summary

`feature_proxy` fails on the 32-bit CentOS and TSan jobs, where node3 refuses to start:

```
Error: Invalid -proxy address or hostname: '[::1]:23501'
```

The test does guard its IPv6 sections, behind `test_ipv6_local()`, which opens a datagram socket and connects it to `::1`. That succeeds wherever loopback IPv6 exists, which in a container is usually all there is.

The node asks a different question. It resolves through `getaddrinfo` with `AI_ADDRCONFIG`, in `WrappedGetAddrInfo`, and the flag is there to *"only return addresses whose family we have an address configured for"*. Loopback does not count towards that.

So on those runners the test believes IPv6 works, hands the node an IPv6 proxy, and the node rejects the address the test just connected to.

## Change

Ask the question the node's way as well, so the IPv6 sections are skipped where the node cannot follow rather than failing the run.

## Testing

Both container cases were simulated, `getaddrinfo` returning nothing and raising, and both now report no IPv6.

On a host with a real IPv6 address the probe still reports support, so the IPv6 sections still run: `feature_proxy` passes here with all of them exercised. The change only takes coverage away where the node was going to refuse the address anyway.
