### PR TITLE
test: keep every node's clock together in p2p_segwit

### DIFF
--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -357,14 +357,17 @@ class SegWitTest(BitcoinTestFramework):
         for _ in range(nblocks):
             for attempt in range(10):
                 try:
-                    advance_time_for_pos(node, seconds=60)
+                    # Advance every node, not just this one. Under mocktime a
+                    # node whose clock runs ahead of its peers gets dropped, and
+                    # this is called repeatedly on the same node.
+                    advance_time_for_pos(self.nodes, seconds=60)
                     result = node.generate(1)
                     blocks.extend(result)
                     break
                 except Exception as e:
                     if "no valid coinstake found" in str(e):
                         if attempt < 9:
-                            advance_time_for_pos(node, seconds=120)
+                            advance_time_for_pos(self.nodes, seconds=120)
                         else:
                             raise
                     else:
@@ -388,7 +391,7 @@ class SegWitTest(BitcoinTestFramework):
         self.utxo = []
 
         # ReddCoin: Advance time to ensure coins have sufficient age for PoS
-        advance_time_for_pos(self.nodes[0], seconds=600)
+        advance_time_for_pos(self.nodes, seconds=600)
 
         # ReddCoin: Verify SegWit is NOT active yet (starting from cache at height 199)
         self.segwit_active = False


### PR DESCRIPTION
# test: keep every node's clock together in p2p_segwit

## Summary

The ASan run fails as soon as the test makes its first block:

```
File "test/functional/p2p_segwit.py", line 404, in run_test
    self.sync_blocks()
File "test/functional/test_framework/test_framework.py", line 685, in sync_blocks
    assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
AssertionError
```

`sync_blocks` makes that assertion while the nodes have not yet agreed on a tip, so it fires when a node has lost every peer before the block reached it.

## Cause

The test moved node0's clock and left the other two where they were: once before its first block, by ten minutes, and again inside `generate_pos_block` on every call, which is always made on node0.

Under mocktime a node whose clock has run away from its peers gets dropped. That is why the framework's own generate syncs time across all nodes, and why two of the five advance sites in this file already passed `self.nodes`.

## Change

Advance every node at the remaining three sites. Nothing else about the pacing changes: the same amounts are added at the same points.

## Testing

`p2p_segwit` passes here after the change.

Worth noting the failure is timing dependent, so a local pass is not proof. What can be said plainly is that advancing one node's clock ten minutes past its peers, under mocktime, is not something the test can rely on surviving, and it no longer does it.
