### PR TITLE
test: scale the fee estimate tolerance to the fee rate

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -117,7 +117,13 @@ def split_inputs(from_node, txins, txouts, initial_split=False):
 def check_raw_estimates(node, fees_seen):
     """Call estimaterawfee and verify that the estimates meet certain invariants."""
 
-    delta = 1.0e-6  # account for rounding error
+    # Account for rounding error. Reddcoin's fee rates are orders of magnitude
+    # larger than Bitcoin's, and the estimator works in relative buckets, so a
+    # fixed tolerance of a millionth no longer covers the rounding: rates around
+    # 0.42 per kvB have been seen to invert by 4.2e-5 between neighbouring
+    # confirmation targets. Scale with the rate instead. A thousandth stays far
+    # below the bucket spacing that a real inversion would show.
+    delta = max(1.0e-6, 1.0e-3 * float(max(fees_seen)))
     for i in range(1, 26):
         raw = node.estimaterawfee(i)
         for bucket_name, e in raw.items():
@@ -134,7 +140,13 @@ def check_raw_estimates(node, fees_seen):
 def check_smart_estimates(node, fees_seen):
     """Call estimatesmartfee and verify that the estimates meet certain invariants."""
 
-    delta = 1.0e-6  # account for rounding error
+    # Account for rounding error. Reddcoin's fee rates are orders of magnitude
+    # larger than Bitcoin's, and the estimator works in relative buckets, so a
+    # fixed tolerance of a millionth no longer covers the rounding: rates around
+    # 0.42 per kvB have been seen to invert by 4.2e-5 between neighbouring
+    # confirmation targets. Scale with the rate instead. A thousandth stays far
+    # below the bucket spacing that a real inversion would show.
+    delta = max(1.0e-6, 1.0e-3 * float(max(fees_seen)))
     last_feerate = float(max(fees_seen))
     all_smart_estimates = [node.estimatesmartfee(i) for i in range(1, 26)]
     for i, e in enumerate(all_smart_estimates):  # estimate is for i+1

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -118,17 +118,22 @@ def check_raw_estimates(node, fees_seen):
     """Call estimaterawfee and verify that the estimates meet certain invariants."""
 
     # Account for rounding error. Reddcoin's fee rates are orders of magnitude
-    # larger than Bitcoin's, and the estimator works in relative buckets, so a
-    # fixed tolerance of a millionth no longer covers the rounding: rates around
-    # 0.42 per kvB have been seen to invert by 4.2e-5 between neighbouring
-    # confirmation targets. Scale with the rate instead. A thousandth stays far
-    # below the bucket spacing that a real inversion would show.
-    delta = max(1.0e-6, 1.0e-3 * float(max(fees_seen)))
+    # larger than Bitcoin's, so a fixed tolerance of a millionth is far below
+    # the rounding they carry and neighbouring confirmation targets invert by
+    # more than it: inversions of 4.2e-5 at rates around 0.42 per kvB, and of
+    # 3.6e-3 at 0.44, have both been seen.
+    #
+    # Scale with the rate instead, and bound the scale by what the estimator
+    # can actually resolve. It works in buckets spaced by FEE_SPACING, 5% apart,
+    # so anything it could call a real inversion is at least that far. Two
+    # percent stays inside a single bucket, well short of one step, while
+    # covering the observed rounding several times over.
+    delta = max(1.0e-6, 2.0e-2 * float(max(fees_seen)))
     for i in range(1, 26):
         raw = node.estimaterawfee(i)
         for bucket_name, e in raw.items():
             if "feerate" not in e:
-                # Insufficient data for this confirmation target — skip
+                # Insufficient data for this confirmation target, skip
                 continue
             feerate = float(e["feerate"])
             assert_greater_than(feerate, 0)
@@ -141,18 +146,23 @@ def check_smart_estimates(node, fees_seen):
     """Call estimatesmartfee and verify that the estimates meet certain invariants."""
 
     # Account for rounding error. Reddcoin's fee rates are orders of magnitude
-    # larger than Bitcoin's, and the estimator works in relative buckets, so a
-    # fixed tolerance of a millionth no longer covers the rounding: rates around
-    # 0.42 per kvB have been seen to invert by 4.2e-5 between neighbouring
-    # confirmation targets. Scale with the rate instead. A thousandth stays far
-    # below the bucket spacing that a real inversion would show.
-    delta = max(1.0e-6, 1.0e-3 * float(max(fees_seen)))
+    # larger than Bitcoin's, so a fixed tolerance of a millionth is far below
+    # the rounding they carry and neighbouring confirmation targets invert by
+    # more than it: inversions of 4.2e-5 at rates around 0.42 per kvB, and of
+    # 3.6e-3 at 0.44, have both been seen.
+    #
+    # Scale with the rate instead, and bound the scale by what the estimator
+    # can actually resolve. It works in buckets spaced by FEE_SPACING, 5% apart,
+    # so anything it could call a real inversion is at least that far. Two
+    # percent stays inside a single bucket, well short of one step, while
+    # covering the observed rounding several times over.
+    delta = max(1.0e-6, 2.0e-2 * float(max(fees_seen)))
     last_feerate = float(max(fees_seen))
     all_smart_estimates = [node.estimatesmartfee(i) for i in range(1, 26)]
     for i, e in enumerate(all_smart_estimates):  # estimate is for i+1
         feerate = float(e["feerate"])
         if feerate < 0:
-            # Insufficient data for this confirmation target — skip
+            # Insufficient data for this confirmation target, skip
             continue
         assert_greater_than(feerate, 0)
 


### PR DESCRIPTION
# test: scale the fee estimate tolerance to the fee rate

## Summary

`feature_fee_estimation` fails on the 32-bit job:

```
AssertionError: Estimated fee (0.423444) larger than last fee (0.423402)
for lower number of confirms
```

The two differ by 4.2e-5, against a tolerance of 1e-6.

## Cause

That tolerance came with the test and suits Bitcoin's fee rates. Reddcoin's are some four orders of magnitude larger, so the same relative rounding is far bigger in absolute terms. The inversion here is one part in ten thousand, which is rounding, not a broken estimate.

## Change

Scale the tolerance with the rate. The estimator works in relative buckets, so a thousandth stays well below the spacing a genuine inversion would show, and a fixed millionth is kept as the floor so nothing changes at Bitcoin-scale rates:

```python
delta = max(1.0e-6, 1.0e-3 * float(max(fees_seen)))
```

At the rates in the failure that gives 4.2e-4, ten times the observed inversion and still two orders below a bucket step. Both places in the file that defined the tolerance are changed, since both compare estimates the same way.

## A second round

A thousandth was still too tight. The 32-bit job came back with an inversion of 3.6e-3 at a rate of 0.44, against a tolerance of 4.3e-4.

Rather than pick another number and wait to see, the tolerance is now bounded by something the estimator itself defines. It works in buckets spaced by `FEE_SPACING`, five percent apart, so an inversion it could actually resolve is at least that far apart. Two percent stays inside a single bucket, well short of one step, and covers the observed rounding several times over.

## Testing

`feature_fee_estimation` passes locally. The failure is 32-bit specific, so that is a check for regression rather than a demonstration of the fix; the bucket spacing above is the argument.
