### PR TITLE
test: replay rpc_getblockstats data onto an empty chain

### DIFF
--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -33,7 +33,18 @@ class GetblockstatsTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = False  # Use cache with 199 blocks (90 PoW + 109 PoS)
+        # The recorded data holds the whole chain from genesis, not just the
+        # blocks this test adds, so replaying it wants a node with nothing in it.
+        # Starting from the cache instead only works while the cache reproduces
+        # the recorded chain exactly, and its proof-of-stake half does not: a
+        # staking attempt that has to be retried moves the timestamps of every
+        # block after it, so the chain a machine builds depends on how fast it
+        # is. Anything recorded then becomes a competing chain from the point
+        # the two disagree, and gets rejected.
+        #
+        # Generating fresh data is the one path that does want the cache, for a
+        # wallet with coins to spend. Options are parsed before this runs.
+        self.setup_clean_chain = not self.options.gen_test_data
         self.supports_cli = False
 
     def skip_test_if_missing_module(self):


### PR DESCRIPTION
# test: replay rpc_getblockstats data onto an empty chain

## Summary

`rpc_getblockstats` fails on the ASan job:

```
File "test/functional/rpc_getblockstats.py", line 111, in run_test
    stats = self.get_stats()
File "test/functional/rpc_getblockstats.py", line 43, in get_stats
    return [self.nodes[0].getblockstats(hash_or_height=self.start_height + i) ...]
JSONRPCException: Target block height 200 after current tip 199 (-8)
```

The node logs 49 rejections while the test loads its data, one of them a proof of stake failure:

```
ERROR: ProcessNewBlock: AcceptBlock FAILED (bad-pos, proof of stake is incorrect)
ERROR: CheckProofOfStake() : failed to get stake transaction for 14994f1170abe4c05906d4155b3a9
ERROR: ProcessNewBlock: AcceptBlock FAILED (Valid)          [x48]
```

## Cause

The recorded data is not the three blocks this test adds. `generate_test_data` walks from height 0 to the tip and dumps every block, so the file holds the entire chain, 203 of them. `load_test_data` submits all of it to a node that has already been started from the cache, at height 199.

That is only harmless while the cache reproduces the recorded chain exactly. Where it does, the first 199 submissions are blocks the node already has and are ignored, and only the last three attach. Upstream can count on that because its cache is proof of work and deterministic.

The proof of stake half of ours is not. Cache generation retries a staking attempt that finds no kernel, advancing the clock each time, so the number of retries and therefore the timestamp of every block after one depends on how fast the machine is. Two machines building the same cache from the same code can part company partway and stay parted.

Matching the rejected hashes in the CI log against the recorded file shows exactly that. The cache and the file agree to height 153 and disagree from 154, and all 49 blocks from 154 to 202 are the rejected ones. From the node's point of view they are a competing chain, and it cannot validate their coinstakes because the transactions being staked live on the recorded chain rather than the one it is on, which is the `failed to get stake transaction` above. Nothing connects, the tip stays at 199, and the test asks for stats at 200.

## Change

Load onto an empty chain. The recorded chain is then the only chain, every block arrives in order with its stake transaction already present, and the cache does not come into it.

Generating fresh data is the one path that does want the cache, since that is where its funded wallet comes from, so the flag follows `--gen-test-data`. Options are parsed before `set_test_params` runs, so it can be decided there.

## Testing

The test passes here with `test/cache` deleted outright and never recreated, which is the property that was missing: it no longer has an opinion about what the cache contains.

Worth recording what it took to see this, since the test passed locally throughout, including on a cache built from scratch. A cache built on one machine is stable on that machine, so the mismatch only shows where the recorded file came from somewhere else. The CI log was the evidence, and the failing block heights are what identified it rather than the error text, which points at the symptom.

## Related

The nondeterministic cache is worth keeping in mind beyond this test. Any test that records chain data and replays it over the cache has the same dependency, and this is the only one that does so today.
