### PR TITLE
test: wait for every peer to be timed in p2p_eviction

### DIFF
--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -152,6 +152,14 @@ class P2PEvict(BitcoinTestFramework):
             current_peer += 1
             self.wait_until(lambda: "ping" in fastpeer.last_message, timeout=10)
 
+        # Wait until the node has timed a ping for every peer. Waiting on the
+        # ping being sent, as above, does not mean the pong is back and counted,
+        # and a peer the node has not yet timed still ranks as infinitely slow.
+        # The snapshot below would then record an order the node is about to
+        # revise, and it evicts against its own, so a peer taken here to be
+        # protected can be the one that goes.
+        self.wait_until(lambda: all('minping' in peer for peer in node.getpeerinfo()), timeout=60)
+
         # Make sure by asking the node what the actual min pings are
         peerinfo = node.getpeerinfo()
         pings = {}


### PR DESCRIPTION
# test: wait for every peer to be timed in p2p_eviction

## Summary

`p2p_eviction` fails on the TSan job:

```
File "test/functional/p2p_eviction.py", line 184, in run_test
    assert evicted_peers[0] not in protected_peers
AssertionError
```

The eviction happened, and exactly one peer went, so the mechanism worked. What failed is that the peer it took was one the test had written down as protected.

## Cause

Eight of the twenty one peers are protected for having the fastest pings. The test does not assume which eight: it asks the node for the min ping of every peer and takes the eight lowest, precisely because the fast peers are not guaranteed to win that race.

The snapshot is taken too early though. What the test waits for first is a ping being *sent* to each fast peer:

```python
self.wait_until(lambda: "ping" in fastpeer.last_message, timeout=10)
```

which says nothing about the pong being back and counted. A peer the node has not yet timed carries no min ping at all, and ranks as infinitely slow. So peers can still be untimed when the order is read off, and the order recorded is one the node is about to revise as the outstanding pongs land.

The node evicts against its own order, a moment later. Where the two disagree, a peer the test recorded as protected is one the node no longer counts among its fastest, and it goes.

Whether the window matters depends on how long the pongs take relative to the test getting to the eviction, which is why it shows up under TSan and not elsewhere.

## Change

Wait for the node to have timed every peer before reading the order off. Once no peer is still untimed, the ranking the test records is the one the node holds.

The existing tolerance for unreliable pings is untouched, and still does its job: this does not assume the fast peers are the fastest, it only makes sure everyone has a time before the comparison.

## Testing

`p2p_eviction` passes here three times over.

The failure is timing dependent and does not reproduce locally, so those runs are a check against regression rather than a demonstration. The argument for the change is the ordering above: the test was reading a ranking it had not waited for, and now waits.
