### PR TITLE
test: build a longer replacement branch in feature_bip68_sequence

### DIFF
--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -49,7 +49,16 @@ class BIP68Test(BitcoinTestFramework):
                 "-acceptnonstdtxn=1",
                 "-peertimeout=9999",  # bump because mocktime might cause a disconnect otherwise
             ],
-            ["-acceptnonstdtxn=0"],
+            [
+                "-acceptnonstdtxn=0",
+                # node1 is only here to relay from, and must not make blocks of
+                # its own. The reorg test below has node0 permanently invalidate
+                # a branch and build a replacement, and node0 can never accept
+                # the original back. A block staked by node1 onto that original
+                # leaves the two on chains neither will give up, which no amount
+                # of waiting resolves. Staking is on by default in every node.
+                "-staking=0",
+            ],
         ]
 
     def skip_test_if_missing_module(self):
@@ -358,7 +367,19 @@ class BIP68Test(BitcoinTestFramework):
         # Reconsider the invalidated blocks to restore the chain, then reset
         self.nodes[0].reconsiderblock(tx2_block_hash)
         self.nodes[0].invalidateblock(self.nodes[0].getblockhash(cur_height+1))
-        self.nodes[0].generate(10)
+
+        # Build the replacement branch longer than the one being replaced.
+        #
+        # That last invalidateblock is never reconsidered, so node0 rejects the
+        # original branch from here on. node1 has no such opinion and still
+        # holds it, all 11 blocks of it: tx2's block, the 9 that advance MTP,
+        # and tx3's block. node1 only gives it up for something with more work,
+        # and node0 can never accept it back, so a replacement of 10 leaves the
+        # two on chains neither will drop and no later sync can succeed.
+        #
+        # It only reached CI as a failure because node1 has to have caught up
+        # for its branch to be the longer one, which locally it often has not.
+        self.nodes[0].generate(12)
 
     def activateCSV(self):
         # ReddCoin CSV activation via BIP9:


### PR DESCRIPTION
# test: build a longer replacement branch in feature_bip68_sequence

## Summary

`feature_bip68_sequence` fails on the ASan job, after running for 2524 seconds:

```
File "test/functional/feature_bip68_sequence.py", line 81, in run_test
    self.activateCSV()
File "test/functional/feature_bip68_sequence.py", line 375, in activateCSV
    self.sync_blocks()
AssertionError: Block sync timed out after 2400s:
  '8584f5385c23a1899ef2372ec3e7e81670c2116afea50766024bcbe93a5afd8c'
  'dce6eee32dc5a7389359c3d1edd4ccd5e52cf4dbbc7f381d68ccaa2b0d51cf51'
```

Two tips, and forty minutes of waiting on them. Both nodes were alive, both answered RPC throughout, and neither had lost its peer. Nothing at all happened in that time: the last eight minutes of node logging carry 956 `getpeerinfo` calls, 954 `getbestblockhash` calls, and not one line about a block.

## Cause

The reorg test above it leaves node0 refusing the chain node1 is on, permanently.

It ends by invalidating the block at `cur_height+1` and never reconsidering it, so node0 rejects that branch from then on. node1 has no such opinion and still holds it, all eleven blocks of it: tx2's block, the nine that advance MTP, and tx3's block. node1 gives that up only for something with more work.

The replacement is ten blocks. So node1's branch stays the heavier of the two, node1 has no reason to move, and node0 cannot move even in principle. There is no state either node can reach from there, and every later `sync_blocks` is waiting for something that cannot happen.

That is a fixed shortfall of one block, not a race, but reaching it needs node1 to have caught up: it only holds the longer branch if the whole of it arrived before node0 disowned it. Locally node1 is often still behind, which is why this passed here.

## Change

Generate twelve rather than ten, so the replacement outweighs what it replaces.

Also stop node1 staking. Staking is on by default in every node the framework starts, and node1 has a funded wallet, so it is free to extend its own branch and put itself back ahead of any fixed number. It only relays in this test and makes no blocks of its own, so there is nothing to lose by turning it off and a whole class of divergence to avoid.

## Testing

Passes locally after the change.

The failure did not reproduce here beforehand, and the way it was pinned down is worth recording. Stopping node1 staking, on its own, made it fail locally at once, and the heights then said plainly what was wrong: node0 at 432, node1 at 433, on different chains. That also disposed of the first theory, that node1 was staking blocks of its own during the long ASan run, since it had the extra block with staking disabled. It was never a block node1 made, only one node0 had thrown away.

## Related

Worth noting separately that `-staking` defaults to true and the test framework does not override it, so every functional-test node stakes on its own throughout every test. Here it is a hazard worth closing off, but it is a general property and other tests that reorg or partition nodes are open to the same thing.
