### PR TITLE
test: give rpc_fundrawtransaction blocks it can actually stake

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -11,7 +11,6 @@ from itertools import product
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
-    STAKE_MODIFIER_SELECTION_INTERVAL,
     advance_time_for_pos,
     assert_approx,
     assert_equal,
@@ -975,15 +974,25 @@ class RawTransactionsTest(BitcoinTestFramework):
     def generate_spaced_for_pos(self, nblocks):
         """Generate blocks far enough apart in time to be stakeable in turn.
 
-        A coin cannot be staked until the chain holds a block at least a stake
-        modifier selection interval after the one that created it, and mock time
-        alone does not satisfy that: the blocks themselves have to carry the
-        later timestamps. Blocks generated back to back therefore leave a wallet
-        holding coinstakes that never become usable. Move the clock on by more
-        than the interval between each one instead.
+        Blocks generated back to back leave a wallet holding coins it can never
+        stake, for two separate reasons, and the gap has to satisfy both.
+
+        A coin is not eligible until the chain holds a block at least a stake
+        modifier selection interval after the one that created it, about 35
+        minutes here. Moving mock time on is not enough by itself: the blocks
+        have to carry the later timestamps, so the gap has to be left as they
+        are generated.
+
+        The coin also has to be worth at least one whole coin-day, because
+        GetCoinAge works in integer coin-days and CreateCoinStake treats zero as
+        a failure, reporting "failed to calculate coin age". Coin-days are
+        roughly value times age in days, so a ten coin stake needs about two and
+        a half hours and a one coin stake a full day.
+
+        A day covers both comfortably.
         """
         for _ in range(nblocks):
-            advance_time_for_pos(self.nodes, seconds=2 * STAKE_MODIFIER_SELECTION_INTERVAL)
+            advance_time_for_pos(self.nodes, seconds=24 * 60 * 60)
             self.generate(1)
 
     def test_transaction_too_large(self):

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -972,11 +972,32 @@ class RawTransactionsTest(BitcoinTestFramework):
         signedtx = self.nodes[0].signrawtransactionwithwallet(fundedtx['hex'])
         self.nodes[0].sendrawtransaction(signedtx['hex'])
 
+    def generate_spaced_for_pos(self, nblocks):
+        """Generate blocks far enough apart in time to be stakeable in turn.
+
+        A coin cannot be staked until the chain holds a block at least a stake
+        modifier selection interval after the one that created it, and mock time
+        alone does not satisfy that: the blocks themselves have to carry the
+        later timestamps. Blocks generated back to back therefore leave a wallet
+        holding coinstakes that never become usable. Move the clock on by more
+        than the interval between each one instead.
+        """
+        for _ in range(nblocks):
+            advance_time_for_pos(self.nodes, seconds=2 * STAKE_MODIFIER_SELECTION_INTERVAL)
+            self.generate(1)
+
     def test_transaction_too_large(self):
         self.log.info("Test fundrawtx where BnB solution would result in a too large transaction, but Knapsack would not")
-        # Build up staking UTXOs before the large sendmany consumes coins
-        advance_time_for_pos(self.nodes, seconds=600)
-        self.generate(10)
+        # Build up staking UTXOs before the large sendmany consumes coins.
+        #
+        # These have to be spaced out in time, not just generated. A coin only
+        # becomes stakeable once the chain holds a block at least a stake
+        # modifier selection interval, about 35 minutes on regtest, after the
+        # one that created it. Blocks made back to back never satisfy that for
+        # each other, so a run of them leaves the wallet holding coins none of
+        # which can be staked. Leaving a gap wider than the interval between
+        # blocks means each one makes its predecessor's coinstake usable.
+        self.generate_spaced_for_pos(10)
         self.sync_blocks()
 
         self.nodes[0].createwallet("large")
@@ -993,17 +1014,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         for _ in range(1500):
             outputs[recipient.getnewaddress()] = 0.1
         wallet.sendmany("", outputs)
-        # The sendmany leaves the wallet holding little besides the coins it
-        # just created, and a coin cannot be staked until the chain holds a
-        # block at least a stake modifier selection interval after the one that
-        # created it, which is about 35 minutes on regtest. Move the clock on by
-        # more than that between blocks, so each block makes the previous
-        # block's coinstake usable, rather than running out of coins old enough
-        # to stake partway through. The confirmations themselves are what the
-        # funding call below needs.
-        for _ in range(10):
-            advance_time_for_pos(self.nodes, seconds=2 * STAKE_MODIFIER_SELECTION_INTERVAL)
-            self.generate(1)
+        # Confirm the sendmany. The spacing matters here for the same reason as
+        # above: the wallet is now holding 1500 outputs it has just been sent,
+        # none of which can be staked, so the blocks have to come from coins the
+        # earlier run left old enough.
+        self.generate_spaced_for_pos(10)
         assert_raises_rpc_error(-4, "Transaction too large", recipient.fundrawtransaction, rawtx)
 
     def test_include_unsafe(self):

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -11,6 +11,7 @@ from itertools import product
 from test_framework.descriptors import descsum_create
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    STAKE_MODIFIER_SELECTION_INTERVAL,
     advance_time_for_pos,
     assert_approx,
     assert_equal,
@@ -992,8 +993,17 @@ class RawTransactionsTest(BitcoinTestFramework):
         for _ in range(1500):
             outputs[recipient.getnewaddress()] = 0.1
         wallet.sendmany("", outputs)
-        advance_time_for_pos(self.nodes, seconds=600)
-        self.generate(10)
+        # The sendmany leaves the wallet holding little besides the coins it
+        # just created, and a coin cannot be staked until the chain holds a
+        # block at least a stake modifier selection interval after the one that
+        # created it, which is about 35 minutes on regtest. Move the clock on by
+        # more than that between blocks, so each block makes the previous
+        # block's coinstake usable, rather than running out of coins old enough
+        # to stake partway through. The confirmations themselves are what the
+        # funding call below needs.
+        for _ in range(10):
+            advance_time_for_pos(self.nodes, seconds=2 * STAKE_MODIFIER_SELECTION_INTERVAL)
+            self.generate(1)
         assert_raises_rpc_error(-4, "Transaction too large", recipient.fundrawtransaction, rawtx)
 
     def test_include_unsafe(self):

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -1006,11 +1006,21 @@ class RawTransactionsTest(BitcoinTestFramework):
         # each other, so a run of them leaves the wallet holding coins none of
         # which can be staked. Leaving a gap wider than the interval between
         # blocks means each one makes its predecessor's coinstake usable.
+        #
+        # The payment itself is made from a wallet of its own. Blocks are staked
+        # by the default wallet, and a payment this size takes the very coins it
+        # would otherwise stake with, which left it unable to make the blocks
+        # needed to confirm that payment. Fund the payer first so the transfer
+        # confirms in the run below.
+        wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].createwallet("payer")
+        payer = self.nodes[0].get_wallet_rpc("payer")
+        wallet.sendtoaddress(payer.getnewaddress(), 200)
+
         self.generate_spaced_for_pos(10)
         self.sync_blocks()
 
         self.nodes[0].createwallet("large")
-        wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
         recipient = self.nodes[0].get_wallet_rpc("large")
         outputs = {}
         rawtx = recipient.createrawtransaction([], {wallet.getnewaddress(): 147.99899260})
@@ -1022,12 +1032,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         # is not implemented yet. For now we just check that we get an error.
         for _ in range(1500):
             outputs[recipient.getnewaddress()] = 0.1
-        wallet.sendmany("", outputs)
-        # Confirm the sendmany. The spacing matters here for the same reason as
-        # above: the wallet is now holding 1500 outputs it has just been sent,
-        # none of which can be staked, so the blocks have to come from coins the
-        # earlier run left old enough.
-        self.generate_spaced_for_pos(10)
+        payer.sendmany("", outputs)
+        # Confirm the payment. One block is enough to make the outputs spendable,
+        # and asking for fewer blocks asks less of the wallet staking them.
+        self.generate_spaced_for_pos(1)
         assert_raises_rpc_error(-4, "Transaction too large", recipient.fundrawtransaction, rawtx)
 
     def test_include_unsafe(self):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -464,6 +464,20 @@ def set_node_times(nodes, t):
         node.mocktime = t  # Track for sync_time()
 
 
+# Mirrors GetStakeModifierSelectionInterval() in src/pos/kernel.cpp for regtest,
+# where consensus.nModifierInterval is 60 seconds and MODIFIER_INTERVAL_RATIO is
+# 3, giving a little under 35 minutes.
+#
+# A coin cannot be staked until the chain holds a block whose timestamp is at
+# least this far after the block that created it, because the kernel walks
+# forward from that block looking for one. Moving mock time on is not enough on
+# its own: the blocks themselves have to carry the later timestamps. Tests that
+# stake coins they have just created need to advance by more than this between
+# blocks.
+STAKE_MODIFIER_SELECTION_INTERVAL = sum(
+    60 * 63 // (63 + (63 - section) * (3 - 1)) for section in range(64))
+
+
 def advance_time_for_pos(nodes, seconds=60):
     """Advance mock time on all nodes to age coins for PoS staking.
 


### PR DESCRIPTION
# test: give rpc_fundrawtransaction blocks it can actually stake

The retry conversion that opened this work merged separately as #434 and is not repeated here.

## Summary

The descriptors run of this test fails in CI while making blocks after the 1500 output sendmany:

```
File "test/functional/rpc_fundrawtransaction.py", line 996, in test_transaction_too_large
    self.nodes[0].generate(10)
JSONRPCException: Could not create PoS block at height 243: no valid coinstake found
                  (wallet may need more age) (-1)
```

with the node logging this several thousand times beforehand:

```
CheckStakeKernelHash() : unable to determine stakemodifier
nStakeModifier=0, nStakeModifierHeight=241
```

## Cause

That message is not about coin age, despite what it says. `GetKernelStakeModifier` walks the chain forward from the block that created the coin, looking for one whose timestamp is at least a stake modifier selection interval later, and gives up when it runs out of blocks. On regtest that interval works out at 2087 seconds, a little under 35 minutes, from an `nModifierInterval` of 60 seconds.

So a coin cannot be staked until the chain carries a block roughly 35 minutes after the one that created it, and mock time alone cannot satisfy that: the blocks themselves have to hold the later timestamps.

Meanwhile each proof-of-stake block spends a coin and returns outputs too new to stake again, and the `sendmany` just above leaves the wallet holding little else. Ten blocks in a row therefore need ten coins old enough, and the wallet runs out partway.

## Changes

**Stake past the modifier interval.** Retrying alone turned out not to fix it, which is what the interval above explains: the retry advances a minute per attempt, at most nine minutes over ten attempts, and could never reach thirty five. The blocks after the sendmany are now generated one at a time, moving the clock on by twice the selection interval between them, so each block makes the previous block's coinstake usable again instead of the test depending on a stock of old coins.

`STAKE_MODIFIER_SELECTION_INTERVAL` is computed the way `kernel.cpp` computes it rather than written out, since it follows from `nModifierInterval` and `MODIFIER_INTERVAL_RATIO` and would otherwise be a number with no derivation.

## Two further rounds, and what each showed

CI answered twice more, and each answer named a different constraint.

Spacing only the blocks that confirm the sendmany was not enough, because moving
the clock on before a block only sets that block's own timestamp. A coin is
judged against blocks already in the chain, so the run of blocks that builds the
staking pool has to be spaced as it is generated. Both runs now go through one
helper.

That got past the modifier interval and into a different failure:

```
CreateCoinStake : added kernel type=pubkeyhash
ERROR: CreateCoinStake : failed to calculate coin age
```

A kernel was now being found, so eligibility was satisfied; what failed was the
age that follows. `GetCoinAge` works in whole coin-days, value times age in days,
and `CreateCoinStake` treats zero as failure. The gap in use was a little over an
hour, chosen to clear the thirty five minute interval, which left a ten coin
coinstake worth 0.48 coin-days and therefore worth nothing. A day clears both
requirements with room to spare, and is what the helper now leaves.

## What it actually was

Three rounds of spacing each cleared a real constraint and each uncovered the next, and the last of them made the underlying problem plain. With the modifier interval satisfied and a day of coin age behind every coin, the node was still reporting:

```
CreateCoinStake : added kernel type=pubkeyhash
ERROR: CreateCoinStake : failed to calculate coin age
```

a hundred times over, with no modifier failures left at all. Kernels were being found, so eligibility was no longer the issue. What the wallet did not have was coins.

The reason is that one wallet was doing both jobs. The default wallet stakes the blocks, and the payment being confirmed is 1500 outputs of 0.1 RDD sent from that same wallet, which is large enough to take the coins it would otherwise have staked with. Confirming that payment therefore asked the wallet to make ten blocks immediately after removing what it needed to make them with. Spacing the blocks out could buy age for whatever survived, but could not put back what the payment had spent.

Locking the staking coins is not a way out either. `CreateCoinStake` selects through `AvailableCoins`, which skips locked coins, so locking them to keep the payment off them stops them being staked as well.

**Give the payment its own wallet.** A `payer` wallet is created and funded before the staking pool is built, so the transfer confirms in the same run that builds the pool, and the payment then spends the payer's coins. The staking wallet is never drained and keeps everything the spacing aged for it.

With the two jobs separated, confirming the payment needs one block rather than ten, so the demand on staking drops as well as the supply being preserved.

## Testing

The descriptors and legacy variants both pass locally.

The earlier rounds of this were argued from arithmetic because none of it reproduced locally. This last one does not need that: the wallet spending the coins it was about to stake with is visible in the test regardless of whether the shortage happens to bite on a given machine, and separating them is correct on its own terms.

The commits are kept separate because each answers a different thing CI said, and the first three remain wanted: the modifier interval and the coin age minimum are both real requirements that the test was not meeting, independently of which wallet pays.

## Related

This is not unique to this test. 228 raw `self.nodes[N].generate(...)` calls remain across 60 functional tests, and each is a place where a transient staking failure ends the run rather than being retried. They are left alone here, but the same treatment is likely to be wanted as those tests surface in CI.

The wider point is worth stating too: on this chain the wallet that pays and the wallet that produces blocks are the same wallet by default, and any test that makes a large payment and then expects to confirm it is open to this. Inherited tests were written where those two things were unrelated.
