### PR TITLE
init: Advertise NODE_WITNESS only when SegWit is actually scheduled

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1608,18 +1608,16 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         }
     }
 
-    if (chainparams.GetConsensus().vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout != 0) {
-        // Only advertise witness capabilities if segwit has a defined activation window.
-        // This allows deploying segwit code before scheduling activation by setting nTimeout=0.
-        // Once activation is scheduled (nTimeout != 0), nodes will advertise NODE_WITNESS.
+    if (DeploymentEnabled(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) {
+        // Only advertise witness capabilities once SegWit is scheduled, that is once
+        // nStartTime is something other than NEVER_ACTIVE. A node that does not enforce
+        // SegWit must not claim to serve witness data: if it advertises NODE_WITNESS it
+        // will also request witness blocks (GetFetchFlags), and ContextualCheckBlock
+        // then rejects every one of them as unexpected-witness because fHaveWitness is
+        // false while the deployment is inactive.
         //
         // Note: setting NODE_WITNESS is never strictly required. The only downside from not
         // doing so is that after activation, upgraded nodes won't fetch witness blocks from you.
-        //
-        // ReddCoin: Using nTimeout check (pre-buried style) instead of DeploymentEnabled()
-        // because segwit is not yet activated on mainnet. DeploymentEnabled() returns true
-        // for any nStartTime != NEVER_ACTIVE, which would incorrectly advertise NODE_WITNESS
-        // before segwit activation is scheduled.
         nLocalServices = ServiceFlags(nLocalServices | NODE_WITNESS);
     }
 

--- a/test/functional/feature_segwit_nonupgraded_sync.py
+++ b/test/functional/feature_segwit_nonupgraded_sync.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that a node without SegWit stays in sync across SegWit activation.
+
+This is the end-to-end form of RED-48. A node that does not enforce SegWit but
+still advertises NODE_WITNESS asks its peers for witness-serialized blocks
+(GetFetchFlags, and compact block version 2). Once an upgraded peer activates
+SegWit its coinbase carries the 32-byte reserved witness value, so the
+non-upgraded node receives witness data for a block it believes commits to
+none, and ContextualCheckBlock rejects it as unexpected-witness. Every
+post-activation block fails the same way, which is a chain split on any
+partially upgraded network.
+
+Both nodes are current builds. A v4.22.9 node would not reproduce this: it
+already gates NODE_WITNESS on DeploymentEnabled and therefore asks for stripped
+blocks.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+# Consensus::BIP9Deployment sentinels, src/consensus/params.h
+NEVER_ACTIVE = -2
+NO_TIMEOUT = 9223372036854775807  # std::numeric_limits<int64_t>::max()
+
+# Regtest SegWit locks in over three 144-block BIP9 windows and activates here.
+SEGWIT_ACTIVATION_HEIGHT = 432
+
+# WarningBitsConditionChecker fires for a bit the node itself does not signal.
+SEGWIT_BIT = 3
+WARN_UNKNOWN_RULES = "Unknown new rules activated (versionbit {})".format(SEGWIT_BIT)
+
+
+class SegwitNonUpgradedSyncTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [
+            [
+                # node0 is the non-upgraded node: SegWit is unscheduled, exactly
+                # as on mainnet. nTimeout MUST be NO_TIMEOUT rather than 0. The
+                # gate this test guards read "nTimeout != 0", so segwit:-2:0
+                # would make a regressed build withhold NODE_WITNESS and pass
+                # for the wrong reason. Do not "simplify" the timeout away.
+                f"-vbparams=segwit:{NEVER_ACTIVE}:{NO_TIMEOUT}",
+                # Neither node may stake on its own account. node1 is the sole
+                # block producer so the heights below stay deterministic, and a
+                # block staked by node0 would fork the pair for unrelated
+                # reasons. Staking is on by default in every node.
+                "-staking=0",
+                "-peertimeout=9999",  # mocktime jumps over ~230 blocks would otherwise disconnect
+            ],
+            [
+                # node1 is the upgraded node: default regtest, SegWit activates.
+                "-staking=0",
+                "-peertimeout=9999",
+            ],
+        ]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def segwit_scheduled(self, node):
+        # getblockchaininfo omits deployments for which DeploymentEnabled() is
+        # false, which is the same predicate the NODE_WITNESS gate uses.
+        return "segwit" in node.getblockchaininfo()["softforks"]
+
+    def segwit_active(self, node):
+        # Note this is DeploymentActiveAfter: it reports whether SegWit applies
+        # to the block after the tip, not to the tip itself.
+        softforks = node.getblockchaininfo()["softforks"]
+        return "segwit" in softforks and softforks["segwit"]["active"]
+
+    def block_has_witness(self, node, blockhash):
+        """Whether the block's coinbase carries witness data.
+
+        A witness-bearing transaction has a wtxid distinct from its txid. Post
+        activation the coinbase holds the 32-byte reserved value added by
+        UpdateUncommittedBlockStructures, which is the data a node with SegWit
+        inactive rejects as unexpected-witness.
+        """
+        coinbase = node.getblock(blockhash, 2)["tx"][0]
+        return coinbase["hash"] != coinbase["txid"]
+
+    def run_test(self):
+        node0, node1 = self.nodes
+
+        self.log.info("node0 has SegWit unscheduled, node1 has it scheduled")
+        assert not self.segwit_scheduled(node0)
+        assert self.segwit_scheduled(node1)
+        # node0's service bits are asserted at the end rather than here, so that
+        # a regressed build fails on the chain split itself instead of on the
+        # precondition. feature_segwit_service_bit.py is the direct guard on the
+        # advertisement; this test exists to show what the advertisement costs.
+        self.log.info("node0 advertises %s", node0.getnetworkinfo()["localservicesnames"])
+
+        self.log.info("Sync the pair up to the last pre-activation block")
+        blocks_to_lock_in = SEGWIT_ACTIVATION_HEIGHT - 1 - node1.getblockcount()
+        assert blocks_to_lock_in > 0
+        self.generate(blocks_to_lock_in, node=node1)
+        self.sync_blocks()
+        assert_equal(node1.getblockcount(), SEGWIT_ACTIVATION_HEIGHT - 1)
+        # Blocks up to here carry no witness, so both nodes see identical bytes
+        # however they ask for them and the pair cannot have split yet.
+        assert not self.block_has_witness(node1, node1.getbestblockhash())
+        assert_equal(node0.getbestblockhash(), node1.getbestblockhash())
+
+        self.log.info("Cross activation: node1's blocks now carry a coinbase witness")
+        assert self.segwit_active(node1)  # active for the next block, 432
+        self.generate(4, node=node1)
+        assert self.block_has_witness(node1, node1.getblockhash(SEGWIT_ACTIVATION_HEIGHT))
+
+        self.log.info("node0 accepts the post-activation blocks")
+        # A regressed build fails here. node0 asked for witness serialization,
+        # so it rejects block SEGWIT_ACTIVATION_HEIGHT with unexpected-witness /
+        # BLOCK_MUTATED, scores node1 as Misbehaving 100 and drops the
+        # connection, which surfaces as sync_blocks finding no peers at all.
+        self.sync_blocks()
+        assert_equal(node0.getbestblockhash(), node1.getbestblockhash())
+        assert_equal(node0.getblockcount(), SEGWIT_ACTIVATION_HEIGHT + 3)
+
+        self.log.info("node0 followed the chain without adopting the new rules")
+        assert not self.segwit_scheduled(node0)
+        assert "WITNESS" not in node0.getnetworkinfo()["localservicesnames"]
+        assert "WITNESS" in node1.getnetworkinfo()["localservicesnames"]
+        assert WARN_UNKNOWN_RULES in node0.getblockchaininfo()["warnings"]
+
+
+if __name__ == '__main__':
+    SegwitNonUpgradedSyncTest().main()

--- a/test/functional/feature_segwit_service_bit.py
+++ b/test/functional/feature_segwit_service_bit.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that NODE_WITNESS is advertised only when SegWit is scheduled.
+
+A node that does not enforce SegWit must not claim to serve witness data. If it
+advertises NODE_WITNESS it also requests witness blocks (GetFetchFlags), so an
+upgraded peer sends it post-activation blocks with the coinbase witness attached
+and ContextualCheckBlock rejects every one of them as unexpected-witness. On a
+partially upgraded network that is a chain split the moment SegWit activates.
+
+RED-48: the gate in init.cpp read
+
+    vDeployments[DEPLOYMENT_SEGWIT].nTimeout != 0
+
+but no network sets nTimeout to 0, so it was always true and mainnet advertised
+NODE_WITNESS with SegWit NEVER_ACTIVE. The gate is now DeploymentEnabled(), i.e.
+nStartTime != NEVER_ACTIVE, which is what "scheduled" actually means.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+
+# Consensus::BIP9Deployment sentinels, src/consensus/params.h
+NEVER_ACTIVE = -2
+NO_TIMEOUT = 9223372036854775807  # std::numeric_limits<int64_t>::max()
+
+
+class SegwitServiceBitTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def advertises_witness(self):
+        return "WITNESS" in self.nodes[0].getnetworkinfo()["localservicesnames"]
+
+    def segwit_scheduled(self):
+        # getblockchaininfo omits deployments for which DeploymentEnabled() is
+        # false, so this is an independent read of the same predicate the
+        # NODE_WITNESS gate uses. It confirms -vbparams was actually applied,
+        # rather than the service bit being absent for some unrelated reason.
+        return "segwit" in self.nodes[0].getblockchaininfo()["softforks"]
+
+    def run_test(self):
+        self.log.info("Default regtest schedules SegWit (nStartTime=0): WITNESS advertised")
+        assert self.segwit_scheduled()
+        assert self.advertises_witness()
+
+        # NOTE: nTimeout MUST be NO_TIMEOUT here, not 0. The regressed gate
+        # tested "nTimeout != 0", so -vbparams=segwit:-2:0 makes the buggy build
+        # withhold the bit and pass this test for the wrong reason. NEVER_ACTIVE
+        # with NO_TIMEOUT is mainnet's exact configuration and is the only vector
+        # that reproduces RED-48. Do not "simplify" the timeout away.
+        self.log.info("SegWit NEVER_ACTIVE with NO_TIMEOUT: WITNESS withheld")
+        self.restart_node(0, [f"-vbparams=segwit:{NEVER_ACTIVE}:{NO_TIMEOUT}"])
+        assert not self.segwit_scheduled()
+        assert not self.advertises_witness()
+
+        self.log.info("SegWit scheduled with NO_TIMEOUT: WITNESS advertised")
+        self.restart_node(0, [f"-vbparams=segwit:0:{NO_TIMEOUT}"])
+        assert self.segwit_scheduled()
+        assert self.advertises_witness()
+
+
+if __name__ == '__main__':
+    SegwitServiceBitTest().main()

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -45,9 +45,14 @@ class CompactFiltersTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.rpc_timeout = 480
         self.num_nodes = 2
+        # SegWit starts in 2033, so the deployment never leaves DEFINED and never
+        # activates over the life of this test. It is still scheduled, though,
+        # because nStartTime is not NEVER_ACTIVE, so both nodes advertise
+        # NODE_WITNESS as upstream expects. nTimeout is not consulted from
+        # DEFINED and its value here is immaterial.
         self.extra_args = [
-            ["-whitelist=127.0.0.1", "-blockfilterindex", "-peerblockfilters", "-vbparams=segwit:2000000000:1"],  # Far future start, nTimeout=1 → NODE_WITNESS],
-            ["-whitelist=127.0.0.1", "-blockfilterindex","-vbparams=segwit:2000000000:1"],
+            ["-whitelist=127.0.0.1", "-blockfilterindex", "-peerblockfilters", "-vbparams=segwit:2000000000:1"],
+            ["-whitelist=127.0.0.1", "-blockfilterindex", "-vbparams=segwit:2000000000:1"],
         ]
 
     def skip_test_if_missing_module(self):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -132,10 +132,12 @@ BASE_SCRIPTS = [
     'wallet_address_types.py --legacy-wallet',
     'wallet_address_types.py --descriptors',
     'feature_bip68_sequence.py',
+    'feature_segwit_nonupgraded_sync.py',
     'p2p_feefilter.py',
     'feature_reindex.py',
     'feature_abortnode.py',
     # vv Tests less than 30s vv
+    'feature_segwit_service_bit.py',
     'wallet_keypool_topup.py --legacy-wallet',
     'wallet_keypool_topup.py --descriptors',
     'feature_fee_estimation.py',


### PR DESCRIPTION
## Summary

`src/init.cpp` gated NODE_WITNESS advertisement on
`vDeployments[DEPLOYMENT_SEGWIT].nTimeout != 0`. No network sets `nTimeout` to 0
(mainnet uses `NO_TIMEOUT`, which is `INT64_MAX`), so the condition was always
true and the node advertised NODE_WITNESS even with SegWit `NEVER_ACTIVE` and
unenforced.

This restores the `DeploymentEnabled` gate that `922df06fa0` replaced.
`DeploymentEnabled` is `nStartTime != NEVER_ACTIVE`, which is precisely "SegWit
is scheduled", so it already expressed the intent that commit was reaching for.

Fixes RED-48.

## Why it matters

Latent today, because no block on the network carries witness data, so
witness-serialized and stripped blocks are byte-identical. It bites on a
partially upgraded network the moment SegWit activates:

1. A node advertising NODE_WITNESS also requests witness blocks
   (`GetFetchFlags`, and compact block version 2).
2. An upgraded peer's post-activation coinbase carries the 32-byte reserved
   witness value added by `UpdateUncommittedBlockStructures`.
3. `ContextualCheckBlock` leaves `fHaveWitness` false while the deployment is
   inactive, so it rejects the block as `unexpected-witness` / `BLOCK_MUTATED`.

v4.22.9 does **not** have this problem: it uses the `DeploymentEnabled` gate,
withholds the bit, receives stripped blocks and accepts them. The released node
soft-forks cleanly where develop does not, which is backwards. The buggy gate
has never shipped, so there is no live network risk; the exposure is shipping a
release with it while SegWit is still unscheduled.

## Confirmed at runtime

The issue was raised from static analysis. It now reproduces, and slightly worse
than described. Against a build without the fix, a non-upgraded node peered with
an upgraded one on default regtest:

```
ERROR: AcceptBlock: unexpected-witness, ContextualCheckBlock : unexpected witness data found
Misbehaving: peer=0 (0 -> 100) DISCOURAGE THRESHOLD EXCEEDED
disconnecting peer=0
```

The non-upgraded node does not merely stall at activation. Block 432 takes the
upgraded peer straight to the discourage threshold and the connection is
dropped, so the two sides stop talking altogether rather than sitting on
divergent tips.

## Tests

`test/functional/feature_segwit_service_bit.py` (5s) asserts NODE_WITNESS is
withheld while SegWit is unscheduled and advertised once it is scheduled. This
is the direct guard on the regressed line.

`test/functional/feature_segwit_nonupgraded_sync.py` (57s) is the end to end
form: the two nodes cross activation at height 432 together and the
non-upgraded node stays on the same chain without adopting the new rules,
logging `Unknown new rules activated (versionbit 3)`.

Both were run red against a build without the fix and green with it.

**The `-vbparams` vector matters.** It must be `segwit:-2:9223372036854775807`,
that is NEVER_ACTIVE with NO_TIMEOUT, which is mainnet's exact configuration.
The regressed gate read `nTimeout != 0`, so `segwit:-2:0` makes an unfixed build
withhold the bit and pass for the wrong reason. Both tests carry a comment
saying so, because it is an inviting thing to simplify away.

## Blast radius

Exactly two existing tests set SegWit `-vbparams`:

| test | vector | old gate | after | changes |
| --- | --- | --- | --- | --- |
| `p2p_blockfilters.py:49-50` | `segwit:2000000000:1` | `nTimeout=1`, advertises | scheduled, advertises | no |
| `wallet_taproot.py:180,182,183` | `segwit:-1:0` | `nTimeout=0`, **withholds** | ALWAYS_ACTIVE, **advertises** | **yes** |

`wallet_taproot`'s previous behaviour was wrong: those nodes ask for SegWit
`ALWAYS_ACTIVE` yet were denied NODE_WITNESS because `nTimeout` happened to be
0. Nothing in it depended on that, and it passes unmodified.

The third commit corrects a now-misleading comment in `p2p_blockfilters.py`. It
credited `nTimeout=1` for the advertisement, which was only ever true of the
gate being replaced here, and was never the reason SegWit stays inactive in that
test either: with `nStartTime` in 2033 the deployment never leaves `DEFINED`, so
`nTimeout` is not consulted at all.

## Testing

`feature_segwit_service_bit.py`, `feature_segwit_nonupgraded_sync.py`,
`p2p_blockfilters.py`, `wallet_taproot.py`, `feature_segwit.py --legacy-wallet`
and `p2p_segwit.py` all pass against the fixed build.
