### PR TITLE
test: keep the tx3 amount in Decimal in p2p_invalid_block

### DIFF
--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -276,7 +276,10 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         privkey2 = node.dumpprivkey(unspent2['address'])
         tx3_raw = node.createrawtransaction(
             [{"txid": unspent2['txid'], "vout": unspent2['vout']}],
-            [{node.getnewaddress(): float(unspent2['amount']) - 0.01}]
+            # Keep this in Decimal. The amount is a coinstake output, so it is
+            # an arbitrary number of satoshis, and going through float leaves a
+            # value the node will not accept.
+            [{node.getnewaddress(): unspent2['amount'] - Decimal('0.01')}]
         )
         tx3_signed = node.signrawtransactionwithkey(tx3_raw, [privkey2])['hex']
         tx3 = tx_from_hex(tx3_signed)


### PR DESCRIPTION
# test: keep the tx3 amount in Decimal in p2p_invalid_block

## Summary

`p2p_invalid_block` fails when building tx3:

```
File "test/functional/p2p_invalid_block.py", line 277, in run_test
    tx3_raw = node.createrawtransaction(
JSONRPCException: Invalid amount (-3)
```

## Cause

The output amount goes through `float`:

```python
[{node.getnewaddress(): float(unspent2['amount']) - 0.01}]
```

The UTXO it spends is a coinstake output, so its value is an arbitrary number of satoshis rather than a round figure, and a float cannot hold that exactly. What comes back out is not a payable amount and `createrawtransaction` refuses it.

The line directly above already reads the same amount as a `Decimal`, to compare it against 10, so the precision is there and is thrown away a line later.

Upstream took its coins from coinbases, whose round amounts survived the round trip, so the conversion was harmless there and is not here.

## Change

Subtract in `Decimal`. The framework already hands amounts over as `Decimal` and encodes them back the same way, so nothing else is needed.

## Testing

`p2p_invalid_block` passes locally.

## Related

This is the second instance of the same thing, after `rpc_packages`, and they will not be the last: inherited arithmetic that assumes round coin amounts breaks anywhere coinstake outputs reach the wallet, which on this chain is everywhere past the proof-of-work range. Worth grepping for `float(` around amounts when a test fails with `Invalid amount`.
