### PR TITLE
test: stop the mocktime sync levelling feature_minchainwork's nodes

### DIFF
--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -54,6 +54,19 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         self.nodes[1].setmocktime(self.mocktime)
         self.nodes[2].setmocktime(genesis_time + 72 * 60 * 60)
 
+        # Opt out of the framework's automatic mocktime sync. setup_nodes()
+        # installs time_sync_callback on every node whenever there is more than
+        # one, and TestNode.generate() calls it after each block. That callback
+        # is sync_time(), which sets every node to the *maximum* mocktime it
+        # finds, so once node2's deliberate 24h lead is recorded in
+        # node2.mocktime it gets propagated straight back onto nodes 0 and 1.
+        # Their own tips then look 24h old, IsInitialBlockDownload() stays true,
+        # node1 never relays, and node2 never syncs. A test that wants nodes on
+        # deliberately different clocks cannot also have them levelled after
+        # every block, so this one manages mocktime itself throughout.
+        for n in self.nodes:
+            n.time_sync_callback = None
+
         for i in range(self.num_nodes-1):
             self.connect_nodes(i+1, i)
 


### PR DESCRIPTION
## Summary

`feature_minchainwork.py` fails intermittently with a 120s block-sync timeout.
The test parks node2 24h ahead of nodes 0 and 1 so the tip always looks old from
node2's side, which is what keeps it in IBD while the chain is built. That is
incompatible with the framework's automatic mocktime sync.

`setup_nodes()` installs `time_sync_callback` on every node whenever there is
more than one, and `TestNode.generate()` calls it after each block. The callback
is `sync_time()`, which reads `node.mocktime` from each node and sets them all
to the **maximum**. As soon as `run_test` records node2's deliberate lead in
`nodes[2].mocktime`, the next `generate()` propagates that lead onto nodes 0
and 1.

Their own tips are then 24h behind their clocks, so `IsInitialBlockDownload()`
stays true on node1, and **a node in IBD does not relay**. node2 receives
nothing and `sync_blocks` times out.

## Diagnosis

From node1's log, with the clock jumping a full day between receiving the block
and connecting it:

```
received block 47102b7a... peer=0        (mocktime: 2022-01-19T06:23:07Z)
UpdateTip: new best=47102b7a... height=50 (mocktime: 2022-01-20T06:23:07Z) (in IBD=true)
                                    date='2022-01-19T06:24:07Z'
```

`(in IBD=true)` at height 50 on a node that should be well clear of IBD is the
signature.

## Fix

Opt out of the callback in `setup_network`. A test that deliberately runs its
nodes on different clocks cannot also have them levelled after every block, so
this one manages mocktime itself throughout.

Re-setting the clocks afterwards would not work: the next `generate()` simply
undoes it. Setting only the RPC (`node.setmocktime(t)`) without the Python
attribute hides a node's offset from `sync_time`'s max but does not protect it
either, because `set_node_times` still writes the max to every node.

## Testing

Verified over three consecutive runs, plus a full functional suite.

Worth noting for anyone hitting this elsewhere: `sync_time()` will silently
level **any** deliberate per-node clock offset, and the damage flows the wrong
way, since the node that is ahead drags the others forward past their own tips.
