### PR TITLE
test: point the compat tests at the v4.22.9.3 previous release

### DIFF
--- a/test/functional/feature_compat_p2p_sync.py
+++ b/test/functional/feature_compat_p2p_sync.py
@@ -26,7 +26,7 @@ the node falls back to a PoW template which is rejected past nLastPowHeight).
     Disconnect, node1 mines 50 PoS blocks, reconnect, node0 catches up.
     Repeat once more to test repeated long-gap sync.
 
-Requires previous releases (v4.22.9 binary), see test/README.md.
+Requires previous releases (the v4.22.9.3 binary), see test/README.md.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -71,7 +71,7 @@ class CompatP2PSyncTest(BitcoinTestFramework):
         self.add_nodes(
             self.num_nodes,
             extra_args=self.extra_args,
-            versions=[4220900, None],
+            versions=[4220903, None],
         )
         self.start_nodes()
         self.import_deterministic_coinbase_privkeys()

--- a/test/functional/feature_compat_pos_blocks.py
+++ b/test/functional/feature_compat_pos_blocks.py
@@ -56,7 +56,7 @@ class CompatPosBlocksTest(BitcoinTestFramework):
         mocktime drift that would cause peers to disconnect each other.
         """
         self.add_nodes(self.num_nodes, extra_args=self.extra_args, versions=[
-            4220900,  # node0 — v4.22.9 (follower)
+            4220903,  # node0 - v4.22.9.3 (follower)
             None,     # node1 — v4.22.10 (lead staker)
         ])
         self.start_nodes()

--- a/test/functional/feature_compat_softfork_signaling.py
+++ b/test/functional/feature_compat_softfork_signaling.py
@@ -46,7 +46,7 @@ from test_framework.util import (
 )
 
 # Version numbers
-VERSION_OLD = 4220900  # v4.22.9
+VERSION_OLD = 4220903  # v4.22.9.3
 VERSION_NEW = None     # v4.22.10 (current)
 
 # BIP9 regtest parameters

--- a/test/functional/feature_compat_staking_interop.py
+++ b/test/functional/feature_compat_staking_interop.py
@@ -72,7 +72,7 @@ class CompatStakingInteropTest(BitcoinTestFramework):
         self.add_nodes(
             self.num_nodes,
             extra_args=self.extra_args,
-            versions=[4220900, None, None],
+            versions=[4220903, None, None],
         )
         self.start_nodes()
         self.init_wallet(0)

--- a/test/functional/feature_compat_tx_versions.py
+++ b/test/functional/feature_compat_tx_versions.py
@@ -16,22 +16,25 @@ This produces a coherent version-version delta:
   - Mempool delta on v2 unsatisfied-lock txs: v4.22.10 ACCEPTS (>= 3
     exempts v2 from BIP68), v4.22.9 REJECTS (>= 2 enforces v2). Observable
     pre-CSV too — STANDARD flags don't depend on CSV state.
-  - Consensus delta on v2 unsatisfied-lock blocks: only fires post-CSV
-    (block-validation gates LOCKTIME_VERIFY_SEQUENCE on CSV deployment).
-    Then v4.22.10 accepts the block, v4.22.9 rejects it. Chain split.
+  - No consensus delta on v2 unsatisfied-lock blocks. Block validation gates
+    LOCKTIME_VERIFY_SEQUENCE on DeploymentActiveAt(DEPLOYMENT_CSV), and CSV
+    is NEVER_ACTIVE in every release up to and including v4.22.9, so that
+    node never enforces BIP68 in blocks and cannot be made to by network
+    signalling. It accepts what v4.22.10 mines. Relay diverges, chains do not.
   - No divergence on v3 sends (the v4.22.10 wallet default after RED-13):
     v3 meets both thresholds; both versions enforce BIP68 identically.
 
-Test phases (execution order: A, B, C, E, D; D is last because it leaves
-the chains intentionally divergent):
+Test phases (execution order: A, B, C, E, D):
 
   Phase A — Pre-CSV: mempool delta on v2 unsat
     node1 (v4.22.10) accepts v2 unsat into mempool; node0 (v4.22.9) rejects.
     Chain stays in sync — block-validation BIP68 isn't active yet.
 
-  Phase B — Activate CSV via BIP9 signalling on v4.22.10 (also v4.22.9-regtest)
-    Node1 restarts with CSV signalling enabled, generates blocks through
-    BIP9 activation. Node0 follows; v4.22.9-regtest also signals CSV.
+  Phase B — Activate CSV via BIP9 signalling on v4.22.10 only
+    Node1 restarts with CSV signalling enabled and generates blocks through
+    BIP9 activation. Node0 follows the chain, but CSV stays NEVER_ACTIVE on
+    it: since ced15b87da the v4.22.9.3 build carries mainnet's deployment
+    state, so there is no BIP9 window for CSV to move through there.
 
   Phase C — v2 satisfied lock — both accept
     Different reasoning per version (v4.22.10 exempts v2; v4.22.9 enforces
@@ -43,12 +46,13 @@ the chains intentionally divergent):
       - v3 unsatisfied-lock: both reject from mempool
       - v3 satisfied-lock:   both accept; mined block syncs
 
-  Phase D — v2 unsatisfied lock post-CSV: consensus divergence
+  Phase D — v2 unsatisfied lock post-CSV: relay divergence only
     Mempool delta from Phase A re-asserted. node1 mines a block that
     naturally includes the v2 unsat tx (its mempool accepted it — no
-    generateblock force-include needed). node0 receives the block, rejects
-    it at consensus (BIP68 enforced post-CSV). Documented chain split —
-    RED-8. This phase intentionally leaves the chains divergent.
+    generateblock force-include needed). node0 will not relay that tx, but
+    it ACCEPTS the block, because BIP68 is not a consensus rule on a node
+    with CSV NEVER_ACTIVE. The chains converge. RED-8's residual risk is to
+    propagation, not to consensus.
 
 v1 transactions are not tested because Reddcoin wallets do not produce v1
 (PoSV requires nTime → every Reddcoin wallet tx is v2+ by design).
@@ -363,20 +367,27 @@ class CompatTxVersionsTest(BitcoinTestFramework):
     # ------------------------------------------------------------------
 
     def phase_d_v2_unsatisfied_lock_divergence(self):
-        """Documented consensus divergence (RED-8). Under Path B, v4.22.10's
-        BIP68 threshold is >= 3 in both mempool AND consensus (HEAD's
-        hardcoded tx_verify.cpp from pr/core-fixes). v4.22.9's threshold is
-        >= 2 in both layers. So for a v2 unsatisfied-lock tx:
+        """Documented divergence (RED-8), which is relay-only. Under Path B,
+        v4.22.10's BIP68 threshold is >= 3 in both mempool AND consensus
+        (HEAD's hardcoded tx_verify.cpp from pr/core-fixes). v4.22.9's
+        threshold is >= 2 in both layers. So for a v2 unsatisfied-lock tx:
 
           mempool:    node1 accepts (>= 3 exempts v2); node0 rejects (>= 2 enforces)
-          block-val:  node1 accepts a block containing it; node0 rejects (post-CSV)
+          block-val:  node1 accepts a block containing it; so does node0
+
+        The block-validation halves agree for a reason that has nothing to do
+        with the threshold: LOCKTIME_VERIFY_SEQUENCE is set only when
+        DeploymentActiveAt(DEPLOYMENT_CSV) holds, and CSV is NEVER_ACTIVE on
+        the released node, so BIP68 is not among the rules it applies to
+        blocks at all. Its stricter threshold governs relay and nothing else.
 
         Node1's block template naturally picks the tx from its mempool — no
-        generateblock force-include is needed. Disconnecting node0 first
-        prevents auto-sync of the divergent block via P2P, so the chain-split
-        assertion is observable.
+        generateblock force-include is needed. node0 is disconnected first so
+        that its acceptance of the block is an observable event on reconnect
+        rather than something that happened during mining.
 
-        This phase is run LAST and intentionally leaves the chains divergent.
+        This phase is run LAST because it is the destructive one: it leaves a
+        transaction on the chain that node0 would never have relayed.
         """
         self.log.info("=== Phase D: v2 tx with unsatisfied lock — documented divergence ===")
         node0 = self.nodes[0]
@@ -439,44 +450,49 @@ class CompatTxVersionsTest(BitcoinTestFramework):
         assert_equal(node0.getbestblockhash(), common_tip)
         self.log.info("node0 (v4.22.9) still at common tip %s" % common_tip)
 
-        # Reconnect — expect node0 to reject the divergent block at consensus
-        self.log.info("Reconnecting nodes — node0 (v4.22.9) should reject the divergent block...")
+        # Reconnect. node0 has no BIP68 consensus rule to break, so it follows
+        # the chain rather than splitting from it.
+        self.log.info("Reconnecting nodes — node0 (v4.22.9) should accept the block...")
         set_node_times([node0, node1], node1.mocktime)
         self.connect_nodes(0, 1)
+        self.sync_blocks(timeout=60)
 
-        from test_framework.util import wait_until_helper
-        try:
-            wait_until_helper(
-                lambda: new_block_hash in [t["hash"] for t in node0.getchaintips()],
-                timeout=30,
-            )
-            tip = next(
-                (t for t in node0.getchaintips() if t["hash"] == new_block_hash),
-                None,
-            )
-            assert tip is not None
-            assert tip["status"] == "invalid", (
-                "Expected node0 to mark the block as invalid; got status=%s" % tip["status"]
-            )
-            self.log.info(
-                "node0 received the block and rejected it as invalid (status=%s)" % tip["status"]
-            )
-        except Exception:
-            self.log.info("node0 did not adopt the divergent block (rejected or not received)")
-
-        # Confirm chain-split persists — this is the test's documented outcome
-        assert_equal(node0.getbestblockhash(), common_tip)
+        # The chains converge. Block validation gates LOCKTIME_VERIFY_SEQUENCE on
+        # DeploymentActiveAt(DEPLOYMENT_CSV) (validation.cpp), and CSV is
+        # NEVER_ACTIVE on the released node, so BIP68 is simply not a consensus
+        # rule there. It cannot reject the block whatever its mempool thinks of
+        # the transaction.
+        assert_equal(node0.getbestblockhash(), new_block_hash)
         assert_equal(node1.getbestblockhash(), new_block_hash)
+
+        # Verbosity 1, not 2. Verbosity 2 makes TxToUniv compute a fee per
+        # transaction, and v4.22.9 asserts MoneyRange on it (core_write.cpp:268)
+        # without allowing for the negative fee a coinstake necessarily has. So
+        # getblock(hash, 2) fails on this node for any PoS block, which is every
+        # block past the PoW phase. develop guards that case; the released binary
+        # does not, and it is not this test's business to exercise it. Verbosity
+        # 1 gives the txid list with no fee computation.
+        node0_block_txids = node0.getblock(new_block_hash, 1)["tx"]
+        assert v2_txid in node0_block_txids, (
+            "node0 accepted the block but does not report the v2 unsat tx in it"
+        )
+        assert not self._csv_is_active(node0), (
+            "CSV became active on the old node; this phase assumes the released "
+            "node's NEVER_ACTIVE deployment state"
+        )
+
         self.log.info(
-            "Phase D PASSED: divergence confirmed. "
-            "node0 (v4.22.9) tip=%s ; node1 (v4.22.10) tip=%s."
-            % (common_tip, new_block_hash)
+            "Phase D passed: node0 (v4.22.9) accepted the block and both nodes are at %s"
+            % new_block_hash
         )
         self.log.warning(
-            "Known consensus divergence: post-CSV-activation, v4.22.10 accepts v2 unsatisfied-lock "
-            "txs in BOTH mempool and blocks (threshold >= 3 exempts v2 entirely); v4.22.9 rejects "
-            "in both layers (threshold >= 2 enforces v2). The split materialises whenever a "
-            "v4.22.10 node mines such a tx into a block. See RED-8 for mitigation."
+            "Known divergence (RED-8) is relay-only, not consensus. v4.22.10 accepts v2 "
+            "unsatisfied-lock txs into its mempool (threshold >= 3 exempts v2); v4.22.9 rejects "
+            "them (threshold >= 2 enforces v2), so it will neither hold nor forward such a tx. "
+            "It still accepts any block containing one, because CSV is NEVER_ACTIVE in every "
+            "release up to v4.22.9 and BIP68 is gated on that deployment. A v4.22.9 node cannot "
+            "be made to enforce BIP68 by network signalling, so activating CSV on mainnet does "
+            "not split these two versions apart. The cost is propagation, not consensus."
         )
 
     # ------------------------------------------------------------------

--- a/test/functional/feature_compat_tx_versions.py
+++ b/test/functional/feature_compat_tx_versions.py
@@ -53,7 +53,7 @@ the chains intentionally divergent):
 v1 transactions are not tested because Reddcoin wallets do not produce v1
 (PoSV requires nTime → every Reddcoin wallet tx is v2+ by design).
 
-Requires previous releases (v4.22.9 binary), see test/README.md.
+Requires previous releases (the v4.22.9.3 binary), see test/README.md.
 """
 
 import hashlib
@@ -88,7 +88,7 @@ RELATIVE_LOCK_10_BLOCKS = 10
 NOT_FINAL_ERROR = "non-BIP68-final"
 
 # Version numbers
-VERSION_OLD = 4220900  # v4.22.9
+VERSION_OLD = 4220903  # v4.22.9.3
 VERSION_NEW = None     # v4.22.10 (current build)
 
 

--- a/test/functional/feature_pos_coinstake_fees.py
+++ b/test/functional/feature_pos_coinstake_fees.py
@@ -73,7 +73,7 @@ class PosCoinstakeFeesTest(BitcoinTestFramework):
     def setup_network(self):
         if self.compat:
             self.add_nodes(self.num_nodes, extra_args=self.extra_args, versions=[
-                4220900,  # node0 — v4.22.9 follower
+                4220903,  # node0 - v4.22.9.3 follower
                 None,     # node1 — current build, lead staker
             ])
             self.start_nodes()

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1241,9 +1241,9 @@ class TaprootTest(BitcoinTestFramework):
         be connected during initial block generation — mocktime drift causes
         header rejection. Connect after syncing mocktime."""
         self.add_nodes(self.num_nodes, self.extra_args, versions=[
-            # ReddCoin: use the v4.22.9 previous release (encoded 4220900), not
+            # ReddCoin: use the v4.22.9.3 previous release (encoded 4220903), not
             # upstream's pre-Taproot v0.20.1 (200100) which ReddCoin doesn't ship.
-            4220900 if self.options.previous_release else None,
+            4220903 if self.options.previous_release else None,
             None,
         ])
         self.start_nodes()

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1234,6 +1234,15 @@ class TaprootTest(BitcoinTestFramework):
         # instead of treated as anyone-can-spend.
         self.extra_args[0].append("-vbparams=taproot:-2:0")
         if self.options.previous_release:
+            # ced15b87da gave the v4.22.9.3 build mainnet's deployment state, so
+            # SegWit is NEVER_ACTIVE on its regtest as well. Every block this test
+            # submits to node0 carries witness data, and ContextualCheckBlock
+            # rejects all of it as unexpected-witness while SegWit is inactive.
+            # Schedule SegWit explicitly and leave Taproot off: that pairing is
+            # what the inactive spenders are written against, and it matches the
+            # current build's regtest defaults (nStartTime=0, nTimeout=NO_TIMEOUT)
+            # so both binaries run node0 the same way.
+            self.extra_args[0].append("-vbparams=segwit:0:9223372036854775807")
             self.wallet_names = [None, self.default_wallet_name]
 
     def setup_network(self):

--- a/test/functional/mempool_compatibility.py
+++ b/test/functional/mempool_compatibility.py
@@ -36,7 +36,7 @@ class MempoolCompatibilityTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.add_nodes(self.num_nodes, extra_args=self.extra_args, versions=[
-            4220900,  # oldest version with getmempoolinfo.loaded (used to avoid intermittent issues)
+            4220903,  # oldest version with getmempoolinfo.loaded (used to avoid intermittent issues)
             None,
         ])
         self.start_nodes()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -211,12 +211,12 @@ BASE_SCRIPTS = [
     'example_test.py',
     'wallet_txn_doublespend.py --legacy-wallet',
     'wallet_txn_doublespend.py --descriptors',
-    # Group-A wallet-evolution tests are deferred: the v4.22.9 previous release is
-    # already at FEATURE_LATEST (169900) — identical to the current wallet version —
+    # Group-A wallet-evolution tests are deferred: the v4.22.9.3 previous release is
+    # already at FEATURE_LATEST (169900), identical to the current wallet version,
     # so there is no upgrade/cross-version delta to test yet. Re-enable and adapt them
-    # to use the v4.22.9 release (4220900) once FEATURE_LATEST is bumped past 169900
-    # (then v4.22.9 becomes a genuine old wallet). Until then they only fail (they
-    # request nonexistent Bitcoin Core v0.1x binaries).
+    # to use that release (4220903) once FEATURE_LATEST is bumped past 169900 (then
+    # it becomes a genuine old wallet). Until then they only fail (they request
+    # nonexistent Bitcoin Core v0.1x binaries).
     # 'feature_backwards_compatibility.py --legacy-wallet',
     # 'feature_backwards_compatibility.py --descriptors',
     'wallet_txn_clone.py --mineblock',
@@ -249,7 +249,7 @@ BASE_SCRIPTS = [
     'wallet_import_with_label.py --legacy-wallet',
     'wallet_importdescriptors.py --descriptors',
     # Deferred group-A wallet-evolution test (see note above); no cross-version
-    # delta until FEATURE_LATEST is bumped past v4.22.9's 169900.
+    # delta until FEATURE_LATEST is bumped past v4.22.9.3's 169900.
     # 'wallet_upgradewallet.py --legacy-wallet',
     'rpc_bind.py --ipv4',
     'rpc_bind.py --ipv6',
@@ -259,7 +259,10 @@ BASE_SCRIPTS = [
     'feature_pos_coinstake_fees.py',
     'feature_pos_sync.py',
     'feature_pos_tx_version_floor.py',
-    # v4.22.9 ↔ v4.22.10 compatibility tests (require releases/v4.22.9/bin/)
+    # Compatibility tests against the previous release (require
+    # releases/v4.22.9.3/bin/). That is v4.22.9 plus the commits that let it run
+    # regtest, which the released v4.22.9 cannot; the fourth version component
+    # is what distinguishes the two.
     'feature_compat_p2p_sync.py',
     'feature_compat_pos_blocks.py',
     'feature_pos_coinstake_fees.py --previous_release',


### PR DESCRIPTION
## Summary

Point the compatibility tests at the **v4.22.9.3** previous release instead of
v4.22.9, and adapt the two tests that its new baseline breaks.

`ced15b87da` on `v4.22.9-regtest` sets DEPLOYMENT_CSV, DEPLOYMENT_SEGWIT and
DEPLOYMENT_TAPROOT to `NEVER_ACTIVE` **on regtest**, so the compat binary now
carries mainnet's deployment state. That is the point of the change: before it,
both sides of these tests enforced the same rules and the upgrade path was never
exercised at all. The two tests below were written against the old baseline,
where all three activated at height 432, and have to move with it.

## Commits

1. **`test: point the compat tests at the v4.22.9.3 previous release`** switches
   `VERSION_OLD` to `4220903` across the compat suite and `feature_taproot`.
2. **`test: give feature_taproot's old node SegWit, which it no longer has`**
3. **`test: correct phase D of feature_compat_tx_versions to relay-only divergence`**

They are one logical change and cannot be split into separate PRs: commit 1 on
its own breaks both tests, and commit 3 on its own fails against the current
v4.22.9 binary, whose regtest activates CSV at height 432.

## feature_taproot

node0 was started with only `-vbparams=taproot:-2:0`, so with the new baseline
SegWit is `NEVER_ACTIVE` on it and every witness-bearing block the test submits
is rejected:

```
Failed to accept: inactive/scriptpath_valid (response: unexpected-witness)
```

Schedule SegWit explicitly and leave Taproot off. That pairing is what the
inactive spenders are written against, and it is what upstream had in the first
place: its node0 was v0.20.1, a post-SegWit pre-Taproot binary.

Note the P2P sync was never the problem. v4.22.9 gates NODE_WITNESS on
`DeploymentEnabled`, so with SegWit unscheduled it withheld the service bit,
asked for stripped blocks and accepted them. Only the blocks the test hands it
directly through `submitblock` carried witness data it would not take.

## feature_compat_tx_versions, phase D

Phase D asserted that the released node **rejects** a block carrying a v2
unsatisfied-lock transaction, leaving the chains split. That was only ever true
of the old regtest build, whose CSV activated at 432. It is not true of a real
v4.22.9, and the node is right where the test was wrong.

`LOCKTIME_VERIFY_SEQUENCE` is set only when
`DeploymentActiveAt(DEPLOYMENT_CSV)` holds (`validation.cpp:1937`), and CSV is
`NEVER_ACTIVE` in every release up to and including v4.22.9, so BIP68 is not
among the rules that node applies to blocks. Nothing the network signals can
change that: the deployment has no BIP9 window to move through.

**So the divergence RED-8 documents is real but confined to relay.** A v4.22.9
node will not hold or forward such a transaction, because its stricter v2
threshold still applies to the mempool, but it will follow any chain containing
one. **Activating CSV on mainnet does not split v4.22.9 from v4.22.10**, which
is the opposite of what this phase claimed. The phase, its docstring, the module
docstring and the warning text are all rewritten to say so.

This is worth a second opinion, since it reverses a claim about consensus
safety that feeds RED-37 risk assessment.

The block is also read back at verbosity 1 rather than 2. Verbosity 2 makes
`TxToUniv` compute a per-transaction fee, and v4.22.9 asserts `MoneyRange` on it
without allowing for the negative fee a coinstake necessarily has, so
`getblock` at verbosity 2 fails there for every block past the PoW phase.
develop guards that case (`7db79f7f98`); the released binary predates it.

## Testing

All eight previous-release tests pass against the v4.22.9.3 binary:
`feature_compat_p2p_sync`, `feature_compat_pos_blocks`,
`feature_compat_softfork_signaling`, `feature_compat_staking_interop`,
`feature_compat_tx_versions`, `feature_pos_coinstake_fees --previous_release`,
`feature_taproot --previous_release`, `mempool_compatibility`. Also verified
inside a full functional suite run.

## Note on fetching the binary

Tests that need a previous release call `skip_if_no_previous_releases()`, so
without one they skip rather than fail. But `test/get_previous_releases.py` on
develop still fetches **Bitcoin's** releases from bitcoincore.org, and
`ci/test/00_setup_env_native_qt5.sh` still lists Bitcoin versions, so it cannot
actually obtain v4.22.9.3. Until the RED-43 CI branch lands, running these tests
needs the archive placed by hand:

```
./releases/v4.22.9.3/bin/{reddcoind,reddcoin-cli}
```

from <https://download.reddcoin.com/bin/reddcoin-core-4.22.9.3/reddcoin-4.22.9.3-x86_64-linux-gnu.tar.gz>
