### PR TITLE
pos: don't reserve a negative depth in GetKernelStakeModifier

### DIFF
--- a/src/pos/kernel.cpp
+++ b/src/pos/kernel.cpp
@@ -299,6 +299,20 @@ static bool GetKernelStakeModifier(CChainState* active_chainstate, CBlockIndex* 
     // pindexPrev - this is a block that is previous to PoS block that we are checking, you can think of it as tip of our chain
     std::vector<CBlockIndex*> tmpChain;
     int32_t nDepth = pindexPrev->nHeight - (pindexFrom->nHeight - 1); // -1 is used to also include pindexFrom
+    if (nDepth < 0) {
+        // pindexFrom is above the tip we are building on, so it cannot be an
+        // ancestor of pindexPrev and there is no chain between them to walk. A
+        // staking wallet reaches this after a reorg, while it still holds coins
+        // confirmed on the branch that was just disowned.
+        //
+        // nDepth is signed but reserve() takes an unsigned size_type, so a
+        // negative depth became an enormous allocation and threw
+        // std::length_error, surfacing to callers as "vector::reserve". The loop
+        // below already treats a non-positive depth as nothing to walk; only the
+        // reserve was unguarded.
+        return error("GetKernelStakeModifier() : block %s at height %d is above pindexPrev at height %d",
+                     hashBlockFrom.ToString(), pindexFrom->nHeight, pindexPrev->nHeight);
+    }
     tmpChain.reserve(nDepth);
     CBlockIndex* it = pindexPrev;
     for (int i = 1; i <= nDepth && !active_chainstate->m_chain.Contains(it); i++) {


### PR DESCRIPTION
## Summary

A staking node throws `std::length_error` out of `GetKernelStakeModifier` when
it tries to stake a coin confirmed on a branch it has just reorged away from. It
reaches RPC callers as

```
JSONRPCException: vector::reserve (-1)
```

and comes out of the staking thread as the same throw. This affects real
stakers, not only tests: any node that stakes across a reorg can reach it.

Fixes #452.

## Cause

`src/pos/kernel.cpp`:

```cpp
std::vector<CBlockIndex*> tmpChain;
int32_t nDepth = pindexPrev->nHeight - (pindexFrom->nHeight - 1); // -1 is used to also include pindexFrom
tmpChain.reserve(nDepth);
```

`nDepth` is a signed `int32_t`; `std::vector::reserve` takes an unsigned
`size_type`. `pindexFrom` is the block holding the coins the kernel is built
from, `pindexPrev` the tip being extended. When `pindexFrom` sits *above*
`pindexPrev` the subtraction is negative, converts to an enormous size, and
`reserve` throws.

A negative depth is a legitimate state rather than corruption: it means the coin
is not on the chain being extended. A staking wallet reaches it after a reorg,
while it still holds coins confirmed on the branch that was just disowned.

The loop immediately below already treats a non-positive depth as nothing to
walk:

```cpp
for (int i = 1; i <= nDepth && !active_chainstate->m_chain.Contains(it); i++) {
```

so only the `reserve` was unguarded.

## Fix

Return an error when `nDepth < 0`, which is what the function already does a few
lines above when the block is not indexed. `CheckStakeKernelHash` treats a false
return as "this coin cannot be used", logs it, and moves to the next candidate,
which is the correct outcome for a coin that is not on the chain being extended.

Clamping to zero was considered and rejected: it would silently compute a
modifier against an empty chain rather than declining a coin that genuinely
cannot produce one.

## How it showed up

CI, on `feature_bip68_sequence.py`, which invalidates a block and stakes a
replacement branch. node0 was rolling back while node1 ran ahead:

```
node0 UpdateTip heights: 343 342 341 340 339 338   (disconnecting)
node1 UpdateTip heights: 354 355 356 357 358 359
```

node0's wallet still held coins from blocks up to 343 while its tip was 338, so
`nDepth` came out negative on the next stake attempt.

Note the `-1` in `vector::reserve (-1)` is the JSON-RPC error code
(`RPC_MISC_ERROR`), not an argument. `TestNode.generate` loops with `nblocks=1`,
so a negative block count would never reach an RPC at all; the throw is from
inside the node.

## Testing

`feature_bip68_sequence.py` passes three consecutive runs where it previously
threw. `pos_tests`, `miner_tests` and `validation_block_tests` pass.

Confirmed in CI as well: with this change the throw is replaced by the graceful
path, with each unusable coin logged and skipped

```
ERROR: CheckStakeKernelHash() : unable to determine stakemodifier ...
```

and the node continues its search instead of failing the RPC.

## Related

Same family as #436 (mempool keeping immature-coinstake spends across reorgs):
state that still refers to a branch which has been rolled back. Note that with
this fix in place, `feature_bip68_sequence.py` in CI goes on to hit
`bad-txns-premature-spend-of-coinbase/coinstake` from `CreateNewBlock`, which is
#436's signature despite that fix being present and correct. That is a separate
problem, tracked apart from this one.
