### PR TITLE
pos: check coinstake maturity against the chainstate, not the wallet

### DIFF
--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -195,8 +195,31 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
     CBlockIndex* pindexTip = chainstate->m_chain.Tip();
     bool fSegwitActive = DeploymentActiveAfter(pindexTip, consensusParams, Consensus::DEPLOYMENT_SEGWIT);
 
+    // Height the coinstake being built would be spent at.
+    const int nSpendHeight = pindexTip->nHeight + 1;
+
     for (const auto& pcoin : setCoins)
     {
+        // Re-check maturity against the UTXO set rather than trusting the
+        // wallet's cached confirmation depth. BlockDisconnected reaches the
+        // wallet through the validation interface queue and nothing on the
+        // staking path drains it first, so for a short window after a reorg
+        // AvailableCoins still offers coinstake outputs that the rollback has
+        // made immature again: their cached depth predates the disconnect.
+        // Staking one produces a block that fails TestBlockValidity with
+        // bad-txns-premature-spend-of-coinbase/coinstake, which is the same
+        // rule CheckTxInputs applies. The chainstate is authoritative and
+        // current, so ask it instead.
+        //
+        // Background staking runs off its own thread, so draining the queue in
+        // the RPC path alone would not cover this.
+        const Coin& coin = chainstate->CoinsTip().AccessCoin(pcoin.outpoint);
+        if (coin.IsSpent())
+            continue;
+        if ((coin.IsCoinBase() || coin.IsCoinStake()) &&
+            nSpendHeight - coin.nHeight < consensusParams.GetCoinbaseMaturity())
+            continue;
+
         // Skip witness UTXOs if SegWit is not yet active — including them in a
         // coinstake would produce a block with witness data that gets rejected
         // with "unexpected witness data" during ContextualCheckBlock.


### PR DESCRIPTION
## Summary

A staking node can build a block whose own coinstake spends a coinstake output
that a reorg has just made immature again. The block fails its own validity
check before it is ever published:

```
CreateNewBlock: TestBlockValidity failed:
bad-txns-premature-spend-of-coinbase/coinstake
```

Affects real stakers, not only tests: any node staking across a reorg can reach
it, and background staking hits it without any RPC involved.

## Cause

`CreateCoinStake` takes its candidates from `AvailableCoins`, which drops
immature coinbase and coinstake outputs:

```cpp
if (wtx.IsImmatureCoinBase())
    continue;
```

That test uses the wallet's cached confirmation depth via
`GetDepthInMainChain()`, and the cache can be stale. `BlockDisconnected` reaches
the wallet through the validation interface queue
(`ENQUEUE_AND_LOG_EVENT`, validationinterface.cpp), and nothing on the staking
path drains that queue first. For a short window after a reorg the wallet still
reports pre-disconnect depths, so `AvailableCoins` offers coinstake outputs that
the rollback has made immature.

`CheckTxInputs` then enforces the maturity rule the wallet believed was met, and
`TestBlockValidity` rejects the block.

Everything else in the path is already correct, and was checked while diagnosing
this:

- `removeForReorg` handles coinstakes (#436), and its `GetSpendsCoinbase()` gate
  is set from `coin.IsCoinBase() || coin.IsCoinStake()`.
- `MaybeUpdateMempoolForReorg` excludes both when re-adding disconnected
  transactions.
- `CWalletTx::GetBlocksToMaturity` handles `IsCoinStake()`.

So the mempool is not involved. The offending transaction is the coinstake the
template builds for itself.

## Fix

Re-check each candidate against `CoinsTip()` before using it:

```cpp
const Coin& coin = chainstate->CoinsTip().AccessCoin(pcoin.outpoint);
if (coin.IsSpent())
    continue;
if ((coin.IsCoinBase() || coin.IsCoinStake()) &&
    nSpendHeight - coin.nHeight < consensusParams.GetCoinbaseMaturity())
    continue;
```

The UTXO set is authoritative and current, `CreateNewBlock` already holds
`cs_main` across this call, and the condition is the same one `CheckTxInputs`
and `removeForReorg` apply. Running it before the txindex lookup also avoids
work for coins that cannot be used.

**Why not drain the validation interface queue instead.** A
`SyncWithValidationInterfaceQueue()` on the RPC path would close the window for
`generate`, but background staking reaches `CreateCoinStake` from its own thread
with no RPC involved, so real stakers would stay exposed while the tests went
green. The check belongs at the point of use.

## How it showed up

CI, on `feature_bip68_sequence.py`, which invalidates a block and stakes a
replacement branch. The generate RPC arrives while the wallet is still draining
disconnect notifications:

```
12:33:57.588  test:  TestNode.generate() dispatches generate
12:33:57.589  node0: BlockDisconnected: ffbbe6...     <- still draining
12:33:57.591  node0: method=generatetoaddress         <- RPC arrives mid-flight
12:33:57.594  node0: BlockDisconnected: 2dd714...     <- still draining
12:33:57.596+ node0: AbandonOrphanedCoinstakes x12
```

## Testing

`feature_bip68_sequence.py` passes three consecutive runs where it previously
failed in CI.

Also passing: `feature_pos_coinstake_fees`, `feature_pos_coinage_source`,
`mining_basic`, `rpc_generate`, `wallet_orphanedreward`, `mempool_reorg`,
`feature_block`, `wallet_basic --legacy-wallet`, and the `pos_tests`,
`miner_tests`, `validation_block_tests` and `txvalidationcache_tests` unit
suites.

## Related

Third in a family of reorg-time PoS state bugs, each found only once the
previous one was fixed and execution reached further:

- #436 mempool kept immature-coinstake spends across a reorg
- #452 kernel modifier used a coin above the new tip
- this one, the wallet offering an immature coinstake to the staker

All three are state that still describes a branch which has been rolled back.
