### PR TITLE
test: assert the shape of getblock verbosity 1, not a substring of the txid

### DIFF
--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -458,7 +458,13 @@ class BlockchainTest(BitcoinTestFramework):
         block = node.getblock(blockhash, 1)
         # Find the wallet tx in the block by txid
         tx_idx = block['tx'].index(txid)
-        assert 'fee' not in block['tx'][tx_idx]
+        # Verbosity 1 lists each transaction as a plain txid string, so there is
+        # no fee field to find. Assert that shape rather than writing
+        # `'fee' not in block['tx'][tx_idx]`: against a string that is a
+        # substring test, and about 1.5% of txids contain "fee" as hex, so it
+        # fails at random. One did in CI:
+        # a4d5f4b2265d81b6bfbb3b8221af7e1ad01665fee5a6e431fa5a84451d6f834e
+        assert isinstance(block['tx'][tx_idx], str)
 
         self.log.info('Test that getblock with verbosity 2 includes expected fee')
         block = node.getblock(blockhash, 2)


### PR DESCRIPTION
## Summary

`rpc_blockchain.py` fails at random, roughly once every 67 runs. It failed the
`ASan + LSan + UBSan + integer` job in
[run 30689751930](https://github.com/reddcoin-project/reddcoin/actions/runs/30689751930):

```
rpc_blockchain.py, line 461, in _test_getblock
    assert 'fee' not in block['tx'][tx_idx]
AssertionError
```

Fixes #458.

## Cause

```python
self.log.info("Test that getblock with verbosity 1 doesn't include fee")
block = node.getblock(blockhash, 1)
tx_idx = block['tx'].index(txid)
assert 'fee' not in block['tx'][tx_idx]
```

At verbosity 1, `blockToJSON` pushes `tx->GetHash().GetHex()`
(`src/rpc/blockchain.cpp:206`), so that element is a **plain txid string**, not
an object. Against a string, `not in` is a **substring** test rather than a key
test.

`fee` is three valid hex digits, so any txid containing that sequence fails. The
one CI drew was:

```
a4d5f4b2265d81b6bfbb3b8221af7e1ad01665fee5a6e431fa5a84451d6f834e
                              ^^^
```

Measured over 200000 random 64-character hex strings, **1.50%** contain `fee`.

So the assertion has never tested anything. It passes because most txids happen
not to contain the substring, not because verbosity 1 omits a fee field. It
would go on passing, and occasionally failing, whatever the RPC did.

## Fix

Assert the shape that "doesn't include fee" actually means at this verbosity:

```python
assert isinstance(block['tx'][tx_idx], str)
```

A string entry cannot carry a fee, so this is the real invariant, and it cannot
be satisfied or broken by coincidence.

The verbosity 2 check immediately below is untouched and was always correct:
there the element really is an object, so `in` really is a key test.

## Testing

Four consecutive passes of `rpc_blockchain.py`.

## Note

Inherited verbatim from Bitcoin Core, which carries the identical
`'fee' not in block['tx'][1]` idiom, so the same latent flake exists upstream.
Worth reporting there separately; this PR only fixes it here.
