### PR TITLE
test: settle relay before rpc_psbt jumps mocktime

### DIFF
--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -92,6 +92,19 @@ class PSBTTest(BitcoinTestFramework):
         assert_equal(decoded_psbt["tx"]["vout"][changepos]["scriptPubKey"]["type"], expected_type)
 
     def run_test(self):
+        # This test advances mocktime by 600 seconds before each generate, to
+        # age coins for staking. Each of those jumps is preceded by sync_all().
+        #
+        # That is not tidiness: a block still in flight when the clock jumps
+        # makes the next stall check see ten minutes of elapsed download time,
+        # so the peer is dropped with "Timeout downloading block ...
+        # disconnecting" although no real time has passed. The sync_all after
+        # the generate then asserts, because a node has no peers left. Settling
+        # relay first means nothing is in flight when the clock moves.
+        #
+        # Seen in CI under TSan, whose slowdown widens the window; the race is
+        # not specific to it.
+
         # Create and fund a raw tx for sending 10 BTC
         psbtx1 = self.nodes[0].walletcreatefundedpsbt([], {self.nodes[2].getnewaddress():10})['psbt']
 
@@ -152,6 +165,7 @@ class PSBTTest(BitcoinTestFramework):
         txid = self.nodes[0].sendrawtransaction(signed_tx)
         # Unlock any locked UTXOs before generating (locked UTXOs can't be staked)
         self.nodes[0].lockunspent(True)
+        self.sync_all()  # settle relay first, see note at the top of run_test
         advance_time_for_pos(self.nodes, seconds=600)
         self.nodes[0].generate(6)
         self.sync_all()
@@ -314,6 +328,7 @@ class PSBTTest(BitcoinTestFramework):
         node2_addr = self.nodes[2].getnewaddress()
         txid1 = self.nodes[0].sendtoaddress(node1_addr, 13)
         txid2 = self.nodes[0].sendtoaddress(node2_addr, 13)
+        self.sync_all()  # settle relay first, see note at the top of run_test
         advance_time_for_pos(self.nodes, seconds=600)
         blockhash = self.nodes[0].generate(6)[0]
         self.sync_all()
@@ -343,6 +358,7 @@ class PSBTTest(BitcoinTestFramework):
         combined = self.nodes[0].combinepsbt([psbt1, psbt2])
         finalized = self.nodes[0].finalizepsbt(combined)['hex']
         self.nodes[0].sendrawtransaction(finalized)
+        self.sync_all()  # settle relay first, see note at the top of run_test
         advance_time_for_pos(self.nodes, seconds=600)
         self.nodes[0].generate(6)
         self.sync_all()
@@ -550,6 +566,7 @@ class PSBTTest(BitcoinTestFramework):
         addr4 = self.nodes[1].getnewaddress("", "p2sh-segwit")
         txid4 = self.nodes[0].sendtoaddress(addr4, 5)
         vout4 = find_output(self.nodes[0], txid4, 5)
+        self.sync_all()  # settle relay first, see note at the top of run_test
         advance_time_for_pos(self.nodes, seconds=600)
         self.nodes[0].generate(6)
         self.sync_all()
@@ -575,6 +592,7 @@ class PSBTTest(BitcoinTestFramework):
         addr = self.nodes[1].getnewaddress("", "p2sh-segwit")
         txid = self.nodes[0].sendtoaddress(addr, 7)
         addrinfo = self.nodes[1].getaddressinfo(addr)
+        self.sync_all()  # settle relay first, see note at the top of run_test
         advance_time_for_pos(self.nodes, seconds=600)
         blockhash = self.nodes[0].generate(6)[0]
         self.sync_all()


### PR DESCRIPTION
## Summary

`rpc_psbt.py` intermittently fails when a mocktime jump lands while a block is
still in flight: the block-download stall timer fires, the peer is dropped, and
the `sync_all()` that follows asserts on a node with no peers. It failed the
`TSan, depends, no gui` job in
[run 30689751930](https://github.com/reddcoin-project/reddcoin/actions/runs/30689751930):

```
rpc_psbt.py, line 319, in run_test
    self.sync_all()
  ...
  File ".../test_framework.py", line 685, in sync_blocks
    assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
AssertionError
```

Fixes #459 for this test. The wider pattern is left open there, see below.

## Cause

```python
txid1 = self.nodes[0].sendtoaddress(node1_addr, 13)
txid2 = self.nodes[0].sendtoaddress(node2_addr, 13)
advance_time_for_pos(self.nodes, seconds=600)
blockhash = self.nodes[0].generate(6)[0]
self.sync_all()
```

`advance_time_for_pos` issues `setmocktime` on every node in one step. In the
failing run node0's clock went from `09:09:07Z` to `09:19:07Z` in a single jump,
and 70ms later two of the three P2P links tore down:

```
node2  SendMessages] Timeout downloading block 6d87342c... from peer=0, disconnecting
node2  CloseSocketDisconnect] disconnecting peer=0
node1  SocketHandler] socket closed for peer=1
```

The stall timer compares `GetTime()`, which honours mocktime, against the time
recorded when the download started. A block was mid-flight when the jump landed,
so the next check saw ten minutes of elapsed download time and disconnected at
once, although no real time had passed. Reddcoin's stall timeout works out at
roughly two minutes, so a 600 second step clears it comfortably.

Same mechanism as the mocktime problem fixed in `feature_minchainwork`: a large
mocktime step taken while the node still has work timed against that clock.

Timing-dependent, not deterministic. It needs a block-relay round trip still in
flight at the instant `setmocktime` lands. TSan's slowdown widens that window by
delaying the compact-block exchange relative to the `setmocktime` that follows,
but nothing about the race is specific to TSan.

## Fix

Call `sync_all()` before each jump, so nothing is in flight when the clock moves.

**All five jumps in the file get it, not only the one that failed.** They are
the same construct and any of them can lose the race; fixing only the observed
one would leave four loaded guns and invite the same investigation again.

A comment at the top of `run_test` explains why the syncs are there, so they are
not mistaken for redundant tidying and removed later.

## Testing

Passes twice under `--descriptors` and twice under `--legacy-wallet`.

Note that passing runs are weak evidence for a race this narrow; the argument
for the fix is the mechanism, not the run count.

## Scope

This PR fixes `rpc_psbt.py` only. The pattern is much wider: across
`test/functional/`, 53 files call `advance_time_for_pos`, 71 call sites are
immediately followed by a `generate`, and 63 of the jumps are 600 seconds. Every
one is the same shape and can trip the same timeout.

Patching call sites individually as they flake will not converge. #459 proposes
a framework-level fix so that settling relay before stepping the clock is the
default rather than something each test must remember. That is deliberately not
attempted here, to keep this change small and reviewable against a demonstrated
failure.
