### PR TITLE
test: step mocktime until the wallet flush condition can be met

### DIFF
--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -5,6 +5,7 @@
 """Test the dumpwallet RPC."""
 import datetime
 import os
+import time
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
@@ -208,11 +209,23 @@ class WalletDumpTest(BitcoinTestFramework):
         assert result['ismine']
 
         self.log.info('Check that wallet is flushed')
+        # MaybeCompactWalletDB runs on a 500ms scheduler tick. The first tick that
+        # sees the write stamps nLastWalletUpdate with GetTime(), and a later tick
+        # flushes once GetTime() - nLastWalletUpdate >= 2. Both readings honour
+        # mocktime, so a single jump taken straight after the write is a race: if
+        # the tick lands after the jump then the stamp is the frozen post-jump time,
+        # the difference is pinned at 0, and no amount of waiting can satisfy it.
+        # Step the clock repeatedly instead. Once a tick has observed the write,
+        # nothing bumps the update counter again, so the stamp stops moving and the
+        # next step outruns it.
+        flush_time = dump_time
         with self.nodes[0].assert_debug_log(['Flushing wallet.dat'], timeout=20):
             w2.getnewaddress()
-            # Advance mocktime so periodic flush condition (2s since last update) triggers
-            self.nodes[0].setmocktime(dump_time + 10)
-            self.nodes[0].mocktime = dump_time + 10
+            for _ in range(3):
+                time.sleep(1)
+                flush_time += 10
+                self.nodes[0].setmocktime(flush_time)
+                self.nodes[0].mocktime = flush_time
 
         # Make sure that dumpwallet doesn't have a lock order issue when there is an unconfirmed tx and it is reloaded
         # See https://github.com/bitcoin/bitcoin/issues/22489


### PR DESCRIPTION
## Summary

`wallet_dump.py --legacy-wallet` can wait for a wallet flush that is not merely
late but impossible, and then burn the full assertion timeout before failing.
It failed the `previous releases, qt5, DEBUG` job in
[run 30735734992](https://github.com/reddcoin-project/reddcoin/actions/runs/30735734992)
after 803 seconds:

```
43/225 - wallet_dump.py --legacy-wallet failed, Duration: 803 s

File ".../test/functional/wallet_dump.py", line 215, in run_test
AssertionError: [node 0] Expected messages "['Flushing wallet.dat']" does not partially match log
```

Fixes RED-59.

## Cause

```python
with self.nodes[0].assert_debug_log(['Flushing wallet.dat'], timeout=20):
    w2.getnewaddress()
    # Advance mocktime so periodic flush condition (2s since last update) triggers
    self.nodes[0].setmocktime(dump_time + 10)
    self.nodes[0].mocktime = dump_time + 10
```

`MaybeCompactWalletDB` (`src/wallet/walletdb.cpp:1130`) runs on a 500 ms real-time
scheduler tick (`src/wallet/load.cpp:134`) and decides by comparing two
**mocktime** readings:

```cpp
if (dbh.nLastSeen != nUpdateCounter) {
    dbh.nLastSeen = nUpdateCounter;
    dbh.nLastWalletUpdate = GetTime();          // (1) stamp
}
if (dbh.nLastFlushed != nUpdateCounter && GetTime() - dbh.nLastWalletUpdate >= 2) {  // (2) trigger
```

`GetTime()` honours mocktime and the test freezes the clock, so the outcome turns
entirely on which side of the jump the stamping tick lands on:

- **Tick before `setmocktime`.** The stamp holds the pre-jump time, the jump makes
  (2) read 10 >= 2, and the next tick flushes. Passes in under a second.
- **Tick after `setmocktime`.** The stamp is the frozen post-jump time, so (2)
  reads **0 and stays 0**. Nothing advances mocktime again inside the `with`
  block, so no later tick can ever satisfy it.

The second branch is a deadlock, not slowness, and waiting cannot help. The 803
second duration confirms that is what happened: `ci/test/00_setup_env.sh:44` sets
`TEST_RUNNER_TIMEOUT_FACTOR=40`, and `assert_debug_log` multiplies its timeout by
that factor, so `timeout=20` is really 800 seconds. The only `Flushing wallet.dat`
lines after the jump appear 56 ms *after* the assertion fired, at node shutdown.

The window in which a tick can land "before the jump" is the few milliseconds
between `getnewaddress()` completing its write and `setmocktime` taking effect.
That is far too narrow to explain how often the test passes, and the reproduction
below shows what has actually been carrying it.

## Fix

Step the clock repeatedly rather than once. After a tick has observed the write
nothing bumps the update counter again, so the stamp stops moving and the next
step outruns it whichever side of the first jump the tick fell on.

```python
flush_time = dump_time
with self.nodes[0].assert_debug_log(['Flushing wallet.dat'], timeout=20):
    w2.getnewaddress()
    for _ in range(3):
        time.sleep(1)
        flush_time += 10
        self.nodes[0].setmocktime(flush_time)
        self.nodes[0].mocktime = flush_time
```

## Testing

Passing runs are weak evidence for a race, so the failure was reproduced
deterministically first.

Unloading every wallet except `w2` before the assertion, so that no other
database can satisfy it with a stamp taken before the jump, makes the current
code fail on every run with the exact CI error after exactly 20 seconds of
polling:

```
Check that wallet is flushed
(20.035s later)
AssertionError: [node 0] Expected messages "['Flushing wallet.dat']" does not partially match log
```

Under the same isolation the stepped form passes in 5.8 seconds.

That reproduction also makes a second point worth recording: **the assertion has
been passing on the strength of a different wallet's dirty database, not the one
the test writes to.** `w2` is not the only wallet loaded at that point, and
another one still holding an unflushed update stamped before the jump satisfies
the log check. Remove the others and the intended path is exposed as broken. So
the change is not only a deflake, it makes the test check what it claims to.

A control with the jump removed entirely fails, confirming the flush really is
driven by the mocktime step and not by unrelated log noise.

The unmodified test then passes four times in a row.

## Note

`timeout=20` becoming 800 seconds under `TEST_RUNNER_TIMEOUT_FACTOR=40` is worth
a second look on its own. The factor exists for slow CI hardware, but it also
applies to assertions that are logically instant, so one deadlocked debug-log
wait costs 13 minutes and, under `--failfast`, takes the rest of the suite with
it. Left out of this change deliberately. Tracked on RED-59.
