### PR TITLE
test: queue the unbroadcast relay before stepping mocktime

### DIFF
--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -174,14 +174,25 @@ class MempoolPersistTest(BitcoinTestFramework):
 
         # shutdown, then startup with wallet disabled
         self.stop_nodes()
-        # Use -mocktime so LoadMempool doesn't expire the tx (created at old
-        # mocktime). Then advance mocktime via RPC so SendMessages timing works.
-        self.start_node(0, extra_args=["-disablewallet", "-mocktime={}".format(mock_time)])
+        # Use -mocktime so LoadMempool doesn't expire the tx, which was created at
+        # the old mocktime.
+        #
+        # noban gives the peer below immediate tx relay. Without it the inv waits
+        # on the trickle deadline, which SendMessages takes from GetTime(); that
+        # honours mocktime, and mocktime is frozen here, so the deadline can only
+        # be reached by stepping the clock. Doing that is a race the test cannot
+        # win reliably: mockscheduler only bumps the scheduler and returns, so
+        # ReattemptInitialBroadcast runs asynchronously and may queue the txid
+        # after a SendMessages pass has already recomputed the deadline against
+        # the stepped time. The deadline then sits past a clock that never moves
+        # again and the inv is stranded until the test times out. Granting noban
+        # makes fSendTrickle unconditional, so the inv goes out on the first pass
+        # after the relay is queued, whenever that happens to be.
+        self.start_node(0, extra_args=["-disablewallet", "-mocktime={}".format(mock_time),
+                                       "-whitelist=noban@127.0.0.1"])
 
         # check that txn gets broadcast due to unbroadcast logic
         conn = node0.add_p2p_connection(P2PTxInvStore())
-        # Advance mocktime so SendMessages inv timing triggers
-        node0.setmocktime(mock_time + 16 * 60 + 60)
         node0.mockscheduler(16*60) # 15 min + 1 for buffer
         self.wait_until(lambda: len(conn.get_invs()) == 1)
 


### PR DESCRIPTION
## Summary

`mempool_persist.py` intermittently waits 2400 seconds for an inv the node has
been left unable to send. It failed the `ASan + LSan + UBSan + integer` job in
[run 30740161226](https://github.com/reddcoin-project/reddcoin/actions/runs/30740161226)
at test 224 of 225:

```
224/225 - mempool_persist.py failed, Duration: 2413 s

File ".../mempool_persist.py", line 186, in test_persist_unbroadcast
    self.wait_until(lambda: len(conn.get_invs()) == 1)
AssertionError: Predicate not true after 2400.0 seconds
```

Fixes RED-52.

## Cause

The transaction is fine throughout. The node's own logs show it loaded and still
flagged for initial broadcast at the restart, and still flagged forty minutes
later at shutdown:

```
LoadMempool: 1 succeeded, 0 failed, 0 expired, 0 already there, 1 waiting for initial broadcast
...
DumpMempool: Writing 1 unbroadcast transactions to disk.
```

So the re-announcement machinery is not the problem. `ReattemptInitialBroadcast`
(`src/net_processing.cpp:1164`) runs, finds the txid, and calls
`_RelayTransaction`. But that only puts the txid in the peer's inventory. The inv
goes out later, from `SendMessages`, and only once the trickle deadline has
passed (`src/net_processing.cpp:4908`):

```cpp
if (pto->m_tx_relay->nNextInvSend < current_time) {
    fSendTrickle = true;
    if (pto->IsInboundConn()) {
        pto->m_tx_relay->nNextInvSend = m_connman.PoissonNextSendInbound(current_time, INBOUND_INVENTORY_BROADCAST_INTERVAL);
    }
}
...
if (fSendTrickle) { /* drain the inventory into an INV */ }
```

`current_time` is `GetTime<std::chrono::microseconds>()`, which honours mocktime,
and this test runs the node under `-mocktime` so `LoadMempool` does not expire a
transaction created at the old clock. With the clock frozen the deadline can
never arrive on its own, so the test steps mocktime past it:

```python
conn = node0.add_p2p_connection(P2PTxInvStore())
node0.setmocktime(mock_time + 16 * 60 + 60)
node0.mockscheduler(16*60) # 15 min + 1 for buffer
self.wait_until(lambda: len(conn.get_invs()) == 1)
```

Doing that **before** the relay is queued is a race. `ThreadMessageHandler` runs
`SendMessages` at least every 100 ms, so it can land in the window between
`setmocktime` and `mockscheduler`. When it does:

1. it finds the old deadline expired and sets `fSendTrickle`,
2. it recomputes `nNextInvSend` to roughly five seconds past the **new** time,
3. it drains an inventory that is still empty, because `mockscheduler` has not
   run yet, and sends nothing.

`mockscheduler` then queues the txid, but the deadline now sits five seconds
beyond a clock that nothing advances again. The inv is stranded and the wait runs
to its full timeout. Under `TEST_RUNNER_TIMEOUT_FACTOR=40`
(`ci/test/00_setup_env.sh:44`) the 60 second `wait_until` becomes 2400 seconds, so
one lost race costs forty minutes of CI.

Upstream does not have this problem. Its version of the test runs the node on the
real clock here and has no `setmocktime` call at all, so the deadline arrives by
itself five seconds later. The freeze is ours, added so the transaction survives
the reload, and it converted a short wait into one that can never finish.

## Fix

Queue the relay first, then step the clock.

```python
conn = node0.add_p2p_connection(P2PTxInvStore())
node0.mockscheduler(16*60) # 15 min + 1 for buffer
node0.setmocktime(mock_time + 16 * 60 + 60)
self.wait_until(lambda: len(conn.get_invs()) == 1)
```

With the inventory already populated, the jump is guaranteed to find a deadline
that predates it, and the same `SendMessages` pass that sets `fSendTrickle`
drains the inventory. Every interleaving reaches that state: whether
`SendMessages` runs before the jump, after it, or not until the wait begins, the
deadline was computed at the old time and the new time is seventeen minutes
ahead of it.

## Testing

Passing runs prove little for a race this narrow, so the failure was made
deterministic first. Inserting a two second sleep between the two calls forces a
`SendMessages` pass into the window:

| order | result |
| --- | --- |
| `setmocktime` then `mockscheduler` (current) | **fails every run**, same assertion as CI |
| `mockscheduler` then `setmocktime` (this change) | passes every run |

The unmodified test then passes three times in a row.

## Note

This is the same failure mode as RED-59 in `wallet_dump.py`, on different
machinery: a node-side deadline derived from `GetTime()`, a test that freezes
mocktime for an unrelated reason, and a single jump used to make the deadline
arrive. Whether it works depends on which side of the jump the node happens to
sample the clock, and when it loses, the wait cannot finish rather than merely
taking longer. Both are worth remembering as a pattern rather than two unrelated
flakes, and RED-58 covers the wider mocktime sweep.
