### PR TITLE
util: include <cstdint> in semver.h

### DIFF
--- a/src/util/semver.h
+++ b/src/util/semver.h
@@ -25,6 +25,7 @@ SOFTWARE.
 #ifndef BITCOIN_UTIL_SEMVER_H
 #define BITCOIN_UTIL_SEMVER_H
 
+#include <cstdint>
 #include <ostream>
 #include <string>
 #include <regex>


### PR DESCRIPTION
## Summary

`src/util/semver.h` uses `uint64_t` without including `<cstdint>`. On Ubuntu
22.04 and later the build fails outright:

```
./util/semver.h:36:26: error: unknown type name 'uint64_t'
    using numeric_part = uint64_t;
                         ^
4 warnings and 17 errors generated.
make[2]: *** [Makefile:9661: node/libbitcoin_server_a-update_check.o] Error 1
```

This affects **every** build configuration, not just a sanitiser or fuzz build,
because `node/update_check.cpp` is part of `libbitcoin_server`.

## Cause

The header is vendored third-party code (MIT, Peter Csajtai's `semver.hpp`). It
includes `<ostream>`, `<string>`, `<regex>` and `<vector>`, then declares:

```cpp
using numeric_part = uint64_t;
```

Older libstdc++ pulled `<cstdint>` in transitively through one of those four, so
the omission was invisible. The GCC 13 headers shipped with Ubuntu 22.04 and
later no longer do.

The remaining sixteen errors are cascades: once `numeric_part` fails to resolve,
every later use of it reports as an unknown type. That makes the diagnostic
misleading if the first lines have scrolled away, since the visible errors all
point at lines 213 and beyond rather than at line 36.

CI does not currently catch this. The containers are `ubuntu:20.04`, whose
libstdc++ still leaks the include.

## Fix

Include `<cstdint>` directly rather than relying on a transitive include.

```cpp
+#include <cstdint>
 #include <ostream>
 #include <string>
 #include <regex>
 #include <vector>
```

## Testing

`node/libbitcoin_server_a-update_check.o` compiles clean, and a full build
completes, on clang 14 / libstdc++ 13 under Ubuntu 22.04 where it previously
failed.

## Note

Found while building the fuzz target for RED-54, but it is unrelated to that
work and is split out because it blocks all configurations on modern
distributions. The RED-54 branch does not carry this change, so on affected
systems this should merge first.
