### PR TITLE
test: fix the fuzz targets for ReddCoin's PoW cutoff, subsidy and RPCs

### DIFF
--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -12,6 +12,7 @@
 #include <scheduler.h>
 #include <script/script.h>
 #include <streams.h>
+#include <sync.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -20,6 +21,7 @@
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
 #include <txorphanage.h>
+#include <validation.h>
 #include <validationinterface.h>
 #include <version.h>
 
@@ -79,7 +81,13 @@ void fuzz_target(FuzzBufferType buffer, const std::string& LIMIT_TO_MESSAGE_TYPE
 
     ConnmanTestMsg& connman = *static_cast<ConnmanTestMsg*>(g_setup->m_node.connman.get());
     TestChainState& chainstate = *static_cast<TestChainState*>(&g_setup->m_node.chainman->ActiveChainstate());
-    SetMockTime(1610000000); // any time to successfully reset ibd
+    // ResetIbd() asserts that we are back in IBD, which requires the tip to look
+    // stale, i.e. tip time < mocktime - nMaxTipAge. Upstream hardcodes 1610000000,
+    // but ReddCoin's regtest genesis is 1642570147 - newer than that constant - so
+    // the tip never looks stale and the assert fires. Derive the mocktime from the
+    // tip instead, which stays correct if either value moves.
+    const int64_t tip_time{WITH_LOCK(::cs_main, return chainstate.m_chain.Tip()->GetBlockTime())};
+    SetMockTime(tip_time + nMaxTipAge + 1);
     chainstate.ResetIbd();
 
     const std::string random_message_type{fuzzed_data_provider.ConsumeBytesAsString(CMessageHeader::COMMAND_SIZE).c_str()};

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -23,6 +23,7 @@
 #include <validationinterface.h>
 #include <version.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -58,9 +59,15 @@ void initialize_process_message()
     Assert(GetNumMsgTypes() == getAllNetMessageTypes().size()); // If this fails, add or remove the message type below
 
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
-    const int COINBASE_MATURITY = Params().GetConsensus().GetCoinbaseMaturity();
+    const Consensus::Params& consensus = Params().GetConsensus();
+    const int COINBASE_MATURITY = consensus.GetCoinbaseMaturity();
     g_setup = testing_setup.get();
-    for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
+    // ReddCoin: PoW ends at nLastPowHeight (89 on regtest). Above that height
+    // CreateNewBlock's TestBlockValidity rejects the PoW template with "pow-ended"
+    // and MineBlock throws, so cap the mined count. Chains where PoW does not end
+    // early (nLastPowHeight is large) still mine the full 2 * COINBASE_MATURITY.
+    const int num_blocks{std::min(2 * COINBASE_MATURITY, consensus.nLastPowHeight - 1)};
+    for (int i = 0; i < num_blocks; i++) {
         MineBlock(g_setup->m_node, CScript() << OP_TRUE);
     }
     SyncWithValidationInterfaceQueue();

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -7,6 +7,7 @@
 #include <net.h>
 #include <net_processing.h>
 #include <protocol.h>
+#include <sync.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -47,7 +48,13 @@ FUZZ_TARGET_INIT(process_messages, initialize_process_messages)
 
     ConnmanTestMsg& connman = *static_cast<ConnmanTestMsg*>(g_setup->m_node.connman.get());
     TestChainState& chainstate = *static_cast<TestChainState*>(&g_setup->m_node.chainman->ActiveChainstate());
-    SetMockTime(1610000000); // any time to successfully reset ibd
+    // ResetIbd() asserts that we are back in IBD, which requires the tip to look
+    // stale, i.e. tip time < mocktime - nMaxTipAge. Upstream hardcodes 1610000000,
+    // but ReddCoin's regtest genesis is 1642570147 - newer than that constant - so
+    // the tip never looks stale and the assert fires. Derive the mocktime from the
+    // tip instead, which stays correct if either value moves.
+    const int64_t tip_time{WITH_LOCK(::cs_main, return chainstate.m_chain.Tip()->GetBlockTime())};
+    SetMockTime(tip_time + nMaxTipAge + 1);
     chainstate.ResetIbd();
 
     std::vector<CNode*> peers;

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -18,6 +18,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+#include <algorithm>
+
 namespace {
 const TestingSetup* g_setup;
 } // namespace
@@ -25,9 +27,15 @@ const TestingSetup* g_setup;
 void initialize_process_messages()
 {
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
-    const int COINBASE_MATURITY = Params().GetConsensus().GetCoinbaseMaturity();
+    const Consensus::Params& consensus = Params().GetConsensus();
+    const int COINBASE_MATURITY = consensus.GetCoinbaseMaturity();
     g_setup = testing_setup.get();
-    for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
+    // ReddCoin: PoW ends at nLastPowHeight (89 on regtest). Above that height
+    // CreateNewBlock's TestBlockValidity rejects the PoW template with "pow-ended"
+    // and MineBlock throws, so cap the mined count. Chains where PoW does not end
+    // early (nLastPowHeight is large) still mine the full 2 * COINBASE_MATURITY.
+    const int num_blocks{std::min(2 * COINBASE_MATURITY, consensus.nLastPowHeight - 1)};
+    for (int i = 0; i < num_blocks; i++) {
         MineBlock(g_setup->m_node, CScript() << OP_TRUE);
     }
     SyncWithValidationInterfaceQueue();

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -67,17 +67,22 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "addnode",        // avoid DNS lookups
     "addpeeraddress", // avoid DNS lookups
     "analyzepsbt",    // avoid signed integer overflow in CFeeRate::GetFee(unsigned long) (https://github.com/bitcoin/bitcoin/issues/20607)
+    "checkupdates",   // avoid outbound network access (queries the release feed over TLS)
     "dumptxoutset",   // avoid writing to disk
     "dumpwallet", // avoid writing to disk
     "echoipc",              // avoid assertion failure (Assertion `"EnsureAnyNodeContext(request.context).init" && check' failed.)
+    "enumeratesigners",     // avoid running external signer commands
     "generatetoaddress",    // avoid prohibitively slow execution (when `num_blocks` is large)
     "generatetodescriptor", // avoid prohibitively slow execution (when `nblocks` is large)
+    "getstakinginfo",       // avoid disk access (stake weight walks the UTXO set via the tx index)
     "gettxoutproof",        // avoid prohibitively slow execution
     "importwallet", // avoid reading from disk
     "loadwallet",   // avoid reading from disk
     "prioritisetransaction", // avoid signed integer overflow in CTxMemPool::PrioritiseTransaction(uint256 const&, long const&) (https://github.com/bitcoin/bitcoin/issues/20626)
     "savemempool",           // disabled as a precautionary measure: may take a file path argument in the future
     "setban",                // avoid DNS lookups
+    "setstaking",            // avoid mutating node staking state
+    "staking",               // avoid mutating node staking state
     "stop",                  // avoid shutdown state
 };
 
@@ -118,6 +123,8 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getdescriptorinfo",
     "getdifficulty",
     "getindexinfo",
+    "getinflation",
+    "getinflationmultiplier",
     "getmemoryinfo",
     "getmempoolancestors",
     "getmempooldescendants",

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -15,11 +15,17 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+#include <algorithm>
+
 namespace {
 
 const TestingSetup* g_setup;
 std::vector<COutPoint> g_outpoints_coinbase_init_mature;
 std::vector<COutPoint> g_outpoints_coinbase_init_immature;
+// Summed value of the mature coinbases above. ReddCoin's block subsidy varies with
+// height (premine, then descending bonus tiers), so it cannot be derived from a flat
+// per-block reward the way it can upstream.
+CAmount g_supply_total_mature{0};
 
 struct MockedTxPool : public CTxMemPool {
     void RollingFeeUpdate() EXCLUSIVE_LOCKS_REQUIRED(!cs)
@@ -33,15 +39,32 @@ struct MockedTxPool : public CTxMemPool {
 void initialize_tx_pool()
 {
     static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>();
-    const int COINBASE_MATURITY = Params().GetConsensus().GetCoinbaseMaturity();
+    const Consensus::Params& consensus = Params().GetConsensus();
+    const int COINBASE_MATURITY = consensus.GetCoinbaseMaturity();
     g_setup = testing_setup.get();
 
-    for (int i = 0; i < 2 * COINBASE_MATURITY; ++i) {
+    // ReddCoin: PoW ends at nLastPowHeight (89 on regtest). Above that height
+    // CreateNewBlock's TestBlockValidity rejects the PoW template with "pow-ended"
+    // and MineBlock throws, so cap the mined count. Chains where PoW does not end
+    // early (nLastPowHeight is large) still mine the full 2 * COINBASE_MATURITY.
+    const int num_blocks{std::min(2 * COINBASE_MATURITY, consensus.nLastPowHeight - 1)};
+    // A coinbase is only spendable once COINBASE_MATURITY blocks are buried on top of
+    // it, so of the num_blocks mined only the first (num_blocks - COINBASE_MATURITY)
+    // have matured. Upstream mines exactly 2 * COINBASE_MATURITY, which makes that
+    // count COINBASE_MATURITY; deriving it keeps the split correct once capped.
+    const int num_mature{num_blocks - COINBASE_MATURITY};
+    Assert(num_mature > 0);
+
+    for (int i = 0; i < num_blocks; ++i) {
         CTxIn in = MineBlock(g_setup->m_node, P2WSH_OP_TRUE);
         // Remember the txids to avoid expensive disk access later on
-        auto& outpoints = i < COINBASE_MATURITY ?
+        const bool is_mature{i < num_mature};
+        auto& outpoints = is_mature ?
                               g_outpoints_coinbase_init_mature :
                               g_outpoints_coinbase_init_immature;
+        if (is_mature) {
+            g_supply_total_mature += GetBlockSubsidy(i + 1, consensus);
+        }
         outpoints.push_back(in.prevout);
     }
     SyncWithValidationInterfaceQueue();
@@ -117,7 +140,6 @@ FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const auto& node = g_setup->m_node;
     auto& chainstate = node.chainman->ActiveChainstate();
-    const int COINBASE_MATURITY = Params().GetConsensus().GetCoinbaseMaturity();
 
     MockTime(fuzzed_data_provider, chainstate);
     SetMempoolConstraints(*node.args, fuzzed_data_provider);
@@ -131,8 +153,9 @@ FUZZ_TARGET_INIT(tx_pool_standard, initialize_tx_pool)
     }
     outpoints_rbf = outpoints_supply;
 
-    // The sum of the values of all spendable outpoints
-    const CAmount SUPPLY_TOTAL{COINBASE_MATURITY * 50 * COIN};
+    // The sum of the values of all spendable outpoints. ReddCoin pays a height-dependent
+    // subsidy rather than a flat 50 per block, so this is accumulated while mining.
+    const CAmount SUPPLY_TOTAL{g_supply_total_mature};
 
     CTxMemPool tx_pool_{/* estimator */ nullptr, /* check_ratio */ 1};
     MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(&tx_pool_);

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -273,12 +273,17 @@ def run_once(*, fuzz_pool, corpus, test_list, src_dir, build_dir, use_valgrind):
                 universal_newlines=True,
             )
             output += result.stderr
-            return output, result
+            return t, output, result
 
         jobs.append(fuzz_pool.submit(job, t, args))
 
+    # Collect every failure rather than exiting on the first one. All jobs are
+    # submitted to the pool up front, so bailing out early still paid the cost of
+    # running the remaining targets while discarding their results, which hid every
+    # failure but one behind whichever target happened to finish first.
+    failures = []
     for future in as_completed(jobs):
-        output, result = future.result()
+        target, output, result = future.result()
         logging.debug(output)
         try:
             result.check_returncode()
@@ -288,7 +293,13 @@ def run_once(*, fuzz_pool, corpus, test_list, src_dir, build_dir, use_valgrind):
             if e.stderr:
                 logging.info(e.stderr)
             logging.info("Target \"{}\" failed with exit code {}".format(" ".join(result.args), e.returncode))
-            sys.exit(1)
+            failures.append((target, e.returncode))
+
+    if failures:
+        logging.error("{} of {} target(s) failed:".format(len(failures), len(jobs)))
+        for target, returncode in sorted(failures):
+            logging.error("  {} (exit code {})".format(target, returncode))
+        sys.exit(1)
 
 
 def parse_test_list(*, fuzz_bin):


### PR DESCRIPTION
## Summary

The `fuzzer, address, undefined, integer, no depends` job has never passed. In
[run 30740161226](https://github.com/reddcoin-project/reddcoin/actions/runs/30740161226/job/91476008153)
it aborted on:

```
Run process_message_addrv2 with args [.../fuzz, -runs=1, .../process_message_addrv2]
terminate called after throwing an instance of 'std::runtime_error'
  what():  CreateNewBlock: TestBlockValidity failed: pow-ended
Target "... process_message_addrv2" failed with exit code -6
```

That single line was hiding four separate defects. The suite has 179 targets;
after these changes all 179 pass.

Fixes RED-54.

## Cause

**The runner reports one failure and discards the rest.** `run_once`
(`test/fuzz/test_runner.py:254`) submits every target to a `ThreadPoolExecutor`
up front, then harvests futures with `as_completed` and calls `sys.exit(1)` on
the first non-zero result. Because the executor drains its queue on scope exit,
the remaining targets **still ran**; only their results were thrown away. In the
CI run above, 95 of 179 results were examined and 84 were discarded, which is
the unexplained 31 seconds between the abort and the job ending. Locally the
same suite had 72 failures.

**`pow-ended`.** `initialize_process_message`, `initialize_process_messages` and
`initialize_tx_pool` each mine `2 * COINBASE_MATURITY` blocks through
`MineBlock`, which is PoW only (`src/test/util/mining.cpp:59`). Regtest sets
`nCoinbaseMaturity = 60` and `nLastPowHeight = 89`, so the loops asked for 120
blocks where 89 are legal. The template for height 90 is rejected at
`src/validation.cpp:1794`, `CreateNewBlock` throws at `src/miner.cpp:280`, and
the throw leaves the initialize function uncaught, aborting the target before it
reads a single input. Same defect as RED-47 in the `AssembleBlock` benchmark.

**`tx_pool` supply.** Capping alone is not sufficient here. `SUPPLY_TOTAL` was
`COINBASE_MATURITY * 50 * COIN`, Bitcoin's flat reward. ReddCoin pays by height
(`src/validation.cpp:1189`): 545,000,000 for the premine at heights 1 to 10,
then 300,000 through 9,999. The 28 mature coinbases are worth 5,455,400,000
rather than 3,000, so `Assert(supply_now == SUPPLY_TOTAL)` could never hold. The
mature/immature split was also hardcoded at `COINBASE_MATURITY`, correct only
when exactly twice that many blocks exist.

**`ResetIbd`.** Only reachable once the targets initialise, so it was masked
until the cap landed:

```
test/util/validation.cpp:14: TestChainState::ResetIbd():
  Assertion `IsInitialBlockDownload()' failed
```

The assert holds only while the tip looks stale, `tip time < mocktime -
nMaxTipAge`. The mocktime is hardcoded to `1610000000` (January 2021), inherited
from upstream where the regtest genesis predates it by a decade. ReddCoin's
regtest genesis is `1642570147` (January 2022, `src/chainparams.cpp:706`), so the
tip is always newer than the threshold. ReddCoin also lowers
`DEFAULT_MAX_TIP_AGE` from 24 hours to 8, narrowing the window further.

**Unclassified RPCs.** The `rpc` target requires every registered command to
appear in one of its two lists and calls `std::terminate` on the first it cannot
find. Six were missing, five of them ReddCoin additions.

## Fix

Five commits, one per defect plus the runner change.

1. **Cap the `process_message` mine loops** at
   `min(2 * COINBASE_MATURITY, nLastPowHeight - 1)`, matching RED-47. The minus
   one matters because the code under test assembles a further block on the tip.
   Chains where PoW does not end early still mine the full count.

2. **Fix the `tx_pool` setup.** Kept as one commit because its three parts are
   mutually dependent: the cap, the split derived as
   `num_blocks - COINBASE_MATURITY`, and `SUPPLY_TOTAL` accumulated from
   `GetBlockSubsidy()` while mining. The derived split reduces to the old
   constant when uncapped.

3. **Derive the mocktime from the chain tip**,
   `tip->GetBlockTime() + nMaxTipAge + 1`, rather than substituting another
   constant, so the targets survive a future change to either value. The tip is
   deterministic, so the targets stay reproducible.

4. **Classify the six RPCs.** `getinflation` and `getinflationmultiplier` are
   safe, both read only. `checkupdates` (outbound TLS), `enumeratesigners`
   (external commands), `getstakinginfo` (stake weight walks the UTXO set
   through the transaction index and reaches disk), `setstaking` and `staking`
   (both mutate node staking state) are not.

5. **Report every failing target.** Collect failures and print them sorted
   before exiting. The exit status is unchanged, so CI still fails the job.

## Testing

| | failures |
| --- | --- |
| CI run 30740161226 | 1 reported, 84 results discarded |
| local serial run, before | 72 of 179 |
| local serial run, after | **0 of 179** |

Run as `test/fuzz/test_runner.py --par 1`, build configured to match CI:
`--enable-fuzz --disable-wallet --with-sanitizers=fuzzer,address,undefined,integer`
under clang. `--disable-wallet` reproduces CI, whose container has neither BDB
nor sqlite and so reports `with wallet = no`.

## Notes

**A green run here means the targets initialise, not that they are fuzz clean.**
`reddcoin-project/qa-assets` tracks only `README.md` and `unit_test_data/`; there
is no `fuzz_seed_corpus/`. `ci/test/04_install.sh:126` points `DIR_FUZZ_IN` at
that missing path and `test_runner.py:258` creates the directories on the fly, so
every target runs two iterations against an empty corpus. The job is an
initialisation smoke test. Populating a corpus is separate work.

**The corpus clone is unpinned.** `ci/test/04_install.sh:123` clones with
`--depth=1` and no commit, so the job is not reproducible across time. Worth
pinning once there is content to pin.

**Capping costs coverage.** `tx_pool` now has 28 spendable outpoints rather than
60. That follows from `MineBlock` being PoW only and cannot be widened without
teaching the harness to stake.

**`getstakinginfo` is a judgement call.** It is read only from the caller's point
of view, but the stake weight computation reaches disk, so it is excluded on the
same grounds as `gettxoutproof`. Easy to flip if reviewers prefer it fuzzed.

**Commits 1 and 3 both touch `process_message.cpp`.** All five compile, but the
suite is only green at the tip, since the `ResetIbd` defect was invisible until
the cap fixed initialisation. They are kept separate because they are unrelated
root causes.

**Building this branch on Ubuntu 22.04 or later also needs the `<cstdint>` fix**
in `src/util/semver.h`, sent separately as it blocks all configurations. CI's
`ubuntu:20.04` containers are unaffected, so this branch passes CI on its own.
