### PR TITLE
test: derive the coinstake signing key from the P2PK pubkey

### DIFF
--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -9,6 +9,7 @@ ReddCoin uses BIP9 for CLTV (bit 1), activating at height 433 on regtest
 (window=144, 75% threshold, 3 periods from genesis).
 """
 
+from test_framework.address import key_to_p2pkh
 from test_framework.blocktools import (
     create_block,
     NORMAL_GBT_REQUEST_PARAMS,
@@ -168,6 +169,13 @@ class BIP65Test(BitcoinTestFramework):
                 addresses = script_pubkey.get('addresses', [])
                 if addresses:
                     addr = addresses[0]
+            if not addr and script_pubkey.get('type') == 'pubkey':
+                # A coinstake output is P2PK, and decoderawtransaction reports no
+                # address for it, so derive the P2PKH address from the pubkey.
+                asm = script_pubkey.get('asm', '')
+                parts = asm.split()
+                if len(parts) >= 1 and parts[0] != 'OP_CHECKSIG':
+                    addr = key_to_p2pkh(parts[0], main=False)
             if addr:
                 signing_key = node.dumpprivkey(addr)
         except Exception as e:

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -8,6 +8,7 @@ Test that the DERSIG soft-fork activates at (regtest) block height 500.
 ReddCoin uses BIP66Height=500 as a buried deployment.
 """
 
+from test_framework.address import key_to_p2pkh
 from test_framework.blocktools import (
     create_block,
     NORMAL_GBT_REQUEST_PARAMS,
@@ -82,6 +83,13 @@ class BIP66Test(BitcoinTestFramework):
                 addresses = script_pubkey.get('addresses', [])
                 if addresses:
                     addr = addresses[0]
+            if not addr and script_pubkey.get('type') == 'pubkey':
+                # A coinstake output is P2PK, and decoderawtransaction reports no
+                # address for it, so derive the P2PKH address from the pubkey.
+                asm = script_pubkey.get('asm', '')
+                parts = asm.split()
+                if len(parts) >= 1 and parts[0] != 'OP_CHECKSIG':
+                    addr = key_to_p2pkh(parts[0], main=False)
             if addr:
                 signing_key = node.dumpprivkey(addr)
         except Exception as e:

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -13,6 +13,7 @@ Generate COINBASE_MATURITY (CB) more blocks to ensure the coinbases are mature.
 [Policy/Consensus] Check that the new NULLDUMMY rules are enforced on block CB + 5.
 """
 
+from test_framework.address import key_to_p2pkh
 from test_framework.blocktools import (
     COINBASE_MATURITY,
     NORMAL_GBT_REQUEST_PARAMS,
@@ -158,11 +159,21 @@ class NULLDUMMYTest(BitcoinTestFramework):
                 addresses = script_pubkey.get('addresses', [])
                 if addresses:
                     addr = addresses[0]
+            if not addr and script_pubkey.get('type') == 'pubkey':
+                # A coinstake output is P2PK, and decoderawtransaction reports no
+                # address for it, so derive the P2PKH address from the pubkey.
+                asm = script_pubkey.get('asm', '')
+                parts = asm.split()
+                if len(parts) >= 1 and parts[0] != 'OP_CHECKSIG':
+                    addr = key_to_p2pkh(parts[0], main=False)
             if addr:
                 signing_key = node.dumpprivkey(addr)
         except Exception as e:
             self.log.debug("coinstake key lookup failed: %s" % e)
         if not signing_key:
+            # Only correct when the coinstake happens to be staked by the
+            # deterministic key; the block is rejected bad-blk-sign otherwise.
+            self.log.warning("coinstake key not found, falling back to the deterministic key")
             signing_key = node.get_deterministic_priv_key().key
         sign_block(block, signing_key)
 

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -15,6 +15,7 @@ Therefore, this test is limited to the remaining protection criteria.
 
 import time
 
+from test_framework.address import key_to_p2pkh
 from test_framework.blocktools import (
     add_witness_commitment,
     COINBASE_MATURITY,
@@ -86,13 +87,29 @@ class P2PEvict(BitcoinTestFramework):
             coinstake_hex = coinstake.serialize().hex()
             decoded_tx = node.decoderawtransaction(coinstake_hex)
 
+            signing_key = None
             try:
-                coinstake_addresses = decoded_tx['vout'][1]['scriptPubKey'].get('addresses', [])
-                if coinstake_addresses:
-                    signing_key = node.dumpprivkey(coinstake_addresses[0])
-                else:
-                    signing_key = node.get_deterministic_priv_key().key
-            except:
+                script_pubkey = decoded_tx['vout'][1]['scriptPubKey']
+                addr = script_pubkey.get('address')
+                if not addr:
+                    addresses = script_pubkey.get('addresses', [])
+                    if addresses:
+                        addr = addresses[0]
+                if not addr and script_pubkey.get('type') == 'pubkey':
+                    # A coinstake output is P2PK, and decoderawtransaction reports no
+                    # address for it, so derive the P2PKH address from the pubkey.
+                    asm = script_pubkey.get('asm', '')
+                    parts = asm.split()
+                    if len(parts) >= 1 and parts[0] != 'OP_CHECKSIG':
+                        addr = key_to_p2pkh(parts[0], main=False)
+                if addr:
+                    signing_key = node.dumpprivkey(addr)
+            except Exception as e:
+                self.log.debug("coinstake key lookup failed: %s" % e)
+            if not signing_key:
+                # Only correct when the coinstake happens to be staked by the
+                # deterministic key; the block is rejected bad-blk-sign otherwise.
+                self.log.warning("coinstake key not found, falling back to the deterministic key")
                 signing_key = node.get_deterministic_priv_key().key
 
             sign_block(block, signing_key)

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -19,6 +19,7 @@ ReddCoin adaptation notes:
 """
 import copy
 
+from test_framework.address import key_to_p2pkh
 from test_framework.blocktools import (
     create_block,
     NORMAL_GBT_REQUEST_PARAMS,
@@ -89,6 +90,13 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
                 addresses = script_pubkey.get('addresses', [])
                 if addresses:
                     coinstake_address = addresses[0]
+            if not coinstake_address and script_pubkey.get('type') == 'pubkey':
+                # A coinstake output is P2PK, and decoderawtransaction reports no
+                # address for it, so derive the P2PKH address from the pubkey.
+                asm = script_pubkey.get('asm', '')
+                parts = asm.split()
+                if len(parts) >= 1 and parts[0] != 'OP_CHECKSIG':
+                    coinstake_address = key_to_p2pkh(parts[0], main=False)
             if coinstake_address:
                 signing_key = node.dumpprivkey(coinstake_address)
         except Exception as e:


### PR DESCRIPTION
## Summary

`feature_nulldummy.py --legacy-wallet` failed the `32-bit + dash, gui [CentOS 9]`
job in
[run 30788623713](https://github.com/reddcoin-project/reddcoin/actions/runs/30788623713):

```
137/225 - feature_nulldummy.py --legacy-wallet failed, Duration: 7 s

File ".../feature_nulldummy.py", line 187, in block_submit
    assert_equal(None if accept else 'block-validation-failed', node.submitblock(...))
AssertionError: not(None == bad-blk-sign)
```

The block was expected to be accepted and was rejected for a bad block signature.

Fixes RED-60.

## Cause

The test signs the PoS blocks it builds, and looks the key up like this:

```python
script_pubkey = decoded['vout'][1]['scriptPubKey']
addr = script_pubkey.get('address')
if not addr:
    addresses = script_pubkey.get('addresses', [])
    if addresses:
        addr = addresses[0]
if addr:
    signing_key = node.dumpprivkey(addr)
...
if not signing_key:
    signing_key = node.get_deterministic_priv_key().key
```

A coinstake output is **P2PK**, and `decoderawtransaction` reports no `address`
for P2PK. So `addr` is always `None`, `dumpprivkey` is never called, and the
fallback is taken on **every block**. Instrumenting the helper shows it directly:

```
SIGN-DEBUG vout1=pubkey addr=None got_key=False nvout=4
SIGN-DEBUG vout1=pubkey addr=None got_key=False nvout=4
...
```

The test passes anyway almost all of the time, because the fallback usually
happens to be right: the wallet normally stakes a coin belonging to the
deterministic key, so the signature verifies. It fails when a coin belonging to
some other key wins the stake. Then the signature cannot match the pubkey in
`vout[1]`, and `CheckBlockSignature` (`src/pos/signer.cpp:19`) rejects the block:

```cpp
const CTxOut& txout = block.IsProofOfStake() ? block.vtx[1]->vout[1] : block.vtx[0]->vout[0];
TxoutType whichType = Solver(txout.scriptPubKey, vSolutions);
...
if (whichType != TxoutType::PUBKEY) return false;
```

That is why the failure is rare, why it took the second of the two block
submissions in the run rather than the first, and why it had not been seen
before. Nothing about it is specific to 32-bit; that is where the dice fell.

## Fix

Derive the P2PKH address from the pubkey in the output script when no address is
reported, which is exactly what `feature_csv_activation.py:269` already does:

```python
if not addr and script_pubkey.get('type') == 'pubkey':
    asm = script_pubkey.get('asm', '')
    parts = asm.split()
    if len(parts) >= 1 and parts[0] != 'OP_CHECKSIG':
        addr = key_to_p2pkh(parts[0], main=False)
```

The fallback stays, since it is still needed for outputs that are not P2PK, but
it now logs a warning instead of silently signing with a key that cannot work.
The silent fallback is what turned a lookup that never worked into a rare flake
and hid it for months.

## Scope

**Five tests share the defect**, so all five are fixed here rather than only the
one that failed: `feature_nulldummy.py`, `feature_cltv.py`, `feature_dersig.py`,
`p2p_eviction.py` and `p2p_invalid_block.py`. They are the same code with
different variable names, and each is a loaded gun that will fire on its own
schedule.

All thirteen tests that sign PoS blocks were audited. The other eight already
derive the pubkey themselves. Four of them (`feature_taproot.py`,
`interface_zmq.py`, `feature_pos_tx_version_floor.py`, `p2p_compactblocks.py`)
do it by hashing the raw script bytes rather than parsing the asm, which is
arguably the sturdier form since it does not depend on RPC field naming at all.

## Testing

All five pass, and none of them takes the fallback any more:

```
feature_nulldummy.py --legacy-wallet   Tests successful  fallbacks=0
feature_cltv.py                        Tests successful  fallbacks=0
feature_dersig.py                      Tests successful  fallbacks=0
p2p_invalid_block.py                   Tests successful  fallbacks=0
p2p_eviction.py                        Tests successful  fallbacks=0
```

Before the change every block in every one of them reported `addr=None` and fell
back. That count going to zero is the actual evidence, more so than the passes,
since these tests passed before too.

## Follow-up worth considering

This logic now exists in thirteen copies across the functional suite, in three
different spellings, and five of them were wrong. A single helper in
`test_framework` would remove the class of bug rather than this instance of it.
Deliberately not attempted here, to keep the change reviewable against a
demonstrated failure.
