### PR TITLE
test: fix the eviction test's ping-protection assertion

### DIFF
--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -174,12 +174,15 @@ class P2PEvict(BitcoinTestFramework):
             current_peer += 1
             self.wait_until(lambda: "ping" in fastpeer.last_message, timeout=10)
 
-        # Wait until the node has timed a ping for every peer. Waiting on the
-        # ping being sent, as above, does not mean the pong is back and counted,
-        # and a peer the node has not yet timed still ranks as infinitely slow.
-        # The snapshot below would then record an order the node is about to
-        # revise, and it evicts against its own, so a peer taken here to be
-        # protected can be the one that goes.
+        # Wait until the node has timed a ping for every peer. Waiting on the ping
+        # being sent, as above, does not mean the pong is back and counted, and a
+        # peer the node has not yet timed reports no minping at all.
+        #
+        # This is the only sample any peer will get. The node re-pings on
+        # "now > m_ping_start + PING_INTERVAL" (net_processing.cpp:4500) with now
+        # taken from GetTime(), so once it has recorded m_ping_start under a frozen
+        # mocktime that condition can never come true again. One ping per peer,
+        # measured as 0, and no revision to wait for. See RED-63.
         self.wait_until(lambda: all('minping' in peer for peer in node.getpeerinfo()), timeout=60)
 
         # Make sure by asking the node what the actual min pings are

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -189,10 +189,31 @@ class P2PEvict(BitcoinTestFramework):
             pings[i] = peerinfo[i]['minping'] if 'minping' in peerinfo[i] else 1000000
         sorted_pings = sorted(pings.items(), key=lambda x: x[1])
 
-        # Usually the 8 fast peers are protected. In rare case of unreliable pings,
-        # one of the slower peers might have a faster min ping though.
-        for i in range(8):
-            protected_peers.add(sorted_pings[i][0])
+        # The node protects the 8 lowest-minping peers. Unlike the two protections
+        # above, which are earned by work only those peers do and so are known
+        # here, this one has to be inferred from the pings, and it is the only
+        # place this test can be wrong about a node that behaved correctly.
+        #
+        # It is currently not inferable at all. The node times a ping with
+        # GetTime(), at both ends (net_processing.cpp:4511 and net.cpp:628), and
+        # that honours mocktime, which this test freezes so it can build PoS
+        # blocks. The SlowP2P classes sleep in real time, which the frozen clock
+        # cannot see, so every peer reports a minping of 0 and the ordering below
+        # is meaningless. The node is ranking 21 equal values too, and neither
+        # side's choice of 8 has anything to do with the other's.
+        #
+        # So claim this protection only where the ordering is unambiguous: a peer
+        # has to beat the 9th by a clear margin. Today nothing does, and the
+        # assertion falls back to the protections the test actually knows. If
+        # ping timing is ever made to work under mocktime, the fast peers will
+        # clear the margin on their own and the check tightens again with no
+        # change here. See RED-63.
+        PING_MARGIN = 0.05
+        assert len(sorted_pings) > 8
+        ninth_ping = sorted_pings[8][1]
+        ping_protected = [peer for peer, ping in sorted_pings[:8] if ping < ninth_ping - PING_MARGIN]
+        protected_peers.update(ping_protected)
+        self.log.debug("{} of the 8 fastest peers had an unambiguous min ping".format(len(ping_protected)))
 
         self.log.info("Create peer that triggers the eviction mechanism")
         node.add_p2p_connection(SlowP2PInterface())

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -127,11 +127,16 @@ class P2PEvict(BitcoinTestFramework):
 
         self.log.info("Create 4 peers and protect them from eviction by sending us a block")
         for _ in range(4):
+            # ReddCoin PoS: Use build_block_on_tip for proper PoS block creation with signing.
+            # Built before the peer connects, not after. It cannot be lifted out of the loop,
+            # since each block comes from a template on the current tip and the tip only moves
+            # when the previous one is accepted, but building it first keeps its RPCs, which
+            # now include a dumpprivkey for the coinstake key, out of the window in which this
+            # peer's ping is being timed.
+            block = self.build_block_on_tip(node)
             block_peer = node.add_p2p_connection(SlowP2PDataStore())
             current_peer += 1
             block_peer.sync_with_ping()
-            # ReddCoin PoS: Use build_block_on_tip for proper PoS block creation with signing
-            block = self.build_block_on_tip(node)
             block_peer.send_blocks_and_test([block], node, success=True)
             protected_peers.add(current_peer)
 


### PR DESCRIPTION
## Summary

Three changes to `p2p_eviction.py`, the second of which fixes RED-62.

1. Build each protection block before connecting the peer that delivers it,
   rather than after.
2. Claim the ping-based eviction protection only where the ranking is
   unambiguous, because under this test's frozen mocktime it never is.
3. Correct the reasoning on an earlier fix in the same file, which said the
   snapshot could record an order the node was about to revise. No revision is
   coming: each peer is pinged exactly once and never sampled again.

## 1. Build before connect

`p2p_eviction.py` builds each of its four protection blocks while the peer that
will deliver it is already connected, so the node does RPC work during a window
in which that peer's ping is being timed. Build the block first, then connect the
peer.

## Why now

The coinstake signing fix (RED-60) changed the cost of that build. The key lookup
used to fail without an RPC, because a coinstake output is P2PK and
`decoderawtransaction` reports no address for P2PK, so the test fell through to
the deterministic key every time. Now the lookup succeeds, which means a
`dumpprivkey` per block on top of the existing `getblocktemplate` and
`decoderawtransaction`.

That is three RPCs rather than two, four times over, in a test whose result
depends on ping measurements. Worth tidying on its own terms.

**On its own this does not fix RED-62.** The eight peers whose ping ranking
decides that assertion are created after all four blocks are built, so the timing
this tidies is not the timing that decides the result. It is worth doing on its
own terms; the fix is the second change.

## Why the build cannot leave the loop

`build_block_on_tip` takes a template from the current tip
(`p2p_eviction.py:67`), and the tip only moves when the previous block is
accepted. Each block also has to be delivered by its own peer, because that
delivery is what earns the peer its protection. So the four builds are
necessarily sequential and interleaved with the connections. Reordering within
each iteration is the whole of what is available.

## 2. Only claim ping protection where the ranking is unambiguous

This is the RED-62 fix.

The node protects peers in five passes (`src/net.cpp:986-999`). Three matter
here: 4 by most recent block, 4 by most recent transaction, and 8 by lowest min
ping. The first two are earned by work only those peers do, so the test knows
them by construction. The third has to be inferred from a snapshot of
`getpeerinfo`, and it is the only place the test can be wrong about a node that
behaved correctly. It is where it failed under TSan.

**It cannot be inferred at all.** The node times a ping with `GetTime()` at both
ends, `m_ping_start` in `SendMessages` (`net_processing.cpp:4511`) and
`msg.m_time` stamped in `CNode::ReceiveMsgBytes` (`net.cpp:628`). `GetTime()`
honours mocktime, and this test freezes mocktime so it can build PoS blocks at
all. The `SlowP2P` classes sleep in real time, which the frozen clock cannot see.
So every peer reports a min ping of exactly 0:

```
PINGS [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
```

The node is ranking 21 equal values, `EraseLastKElements` does not preserve the
order of equal elements, and the test picks 8 from the same 21 equal values.
Neither selection has anything to do with the other. **The assertion has been
passing or failing on whether two unrelated arbitrary choices collide.** A local
run evicted peer 13, one of the peers built to be fast, and still passed, because
the test's own arbitrary 8 did not contain it.

The fix requires a peer to beat the 9th by a clear margin before the test claims
it is ping-protected:

```python
PING_MARGIN = 0.05
ninth_ping = sorted_pings[8][1]
ping_protected = [peer for peer, ping in sorted_pings[:8] if ping < ninth_ping - PING_MARGIN]
protected_peers.update(ping_protected)
```

Nothing clears that today, so the assertion falls back to the protections the
test actually knows, which is what it should have been asserting all along. The
form is deliberately adaptive rather than a flat deletion: if ping timing is ever
made to work under mocktime, the fast peers clear the margin on their own and the
check tightens again with no change here.

**This leaves the ping criterion without functional coverage**, which is a real
loss and is recorded as RED-63 rather than hidden. Note that it never had
coverage; the test only appeared to provide it.

RED-63 also records why this is not obviously a node bug. Timing pings on a
mockable clock matches upstream, and there is a fair argument that a node whose
clock is being driven by tests should not have peer management depend on wall
time.

## 3. Correcting an earlier fix in the same file

The file already carried a repair of this class: a wait for every peer to have a
`minping` before the snapshot is taken. Its stated reasoning was that an untimed
peer ranks as infinitely slow, so the snapshot could record an order the node was
about to revise.

The first half is right, the second is not. **No revision is coming.** The node
re-pings on `now > m_ping_start + PING_INTERVAL` (`net_processing.cpp:4500`) with
`now` from `GetTime()`. Once it has stamped `m_ping_start` under a frozen
mocktime, that condition can never be true again, so each peer is pinged exactly
once, at connect, and never sampled after that.

The wait is still wanted, guarding against an absent value rather than a stale
one, so only the comment changes.

## What the test verifies after this

`sync_with_ping` is worth separating out here, because the two are easily
confused. It is a processing barrier: the test peer pings the node and waits for
the node's pong, which proves everything sent earlier on that connection has been
handled. It measures nothing and is unaffected by any of the above. The broken
flow is the opposite direction, the node's own latency probe.

What remains asserted is that exactly one peer is evicted and that it is not one
of the eight that earned protection by sending a block or a transaction. Those
two criteria are real and the assertion on them is deterministic, since only
those peers do the work that earns them.

What is no longer asserted, because it was never true, is anything about the
eight peers built to have fast pings. They are as evictable as the slow ones
under a frozen clock: the local run behind this change evicted peer 13, one of
them.

## Testing

Passes five times in a row after each change, three after the last. Local passes
are weak evidence here, since the test passed before too, for the reason
described above. The substantive evidence is the measured ping distribution and
the fact that a local run evicted a peer the test believed fast.
