### PR TITLE
test: don't step mocktime in sync_mempools while a block is in flight

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -709,9 +709,18 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                         r.syncwithvalidationinterfacequeue()
                 return
             # Check that each peer has at least one connection
-            assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
-            # Advance mocktime so outbound trickle relay timers can fire
-            if hasattr(rpc_connections[0], 'mocktime') and rpc_connections[0].mocktime:
+            peer_info = [x.getpeerinfo() for x in rpc_connections]
+            assert (all([len(info) for info in peer_info]))
+            # Advance mocktime so outbound trickle relay timers can fire, but never
+            # while a node is still waiting on a block. The block-download stall
+            # timer is measured against GetTime(), which honours mocktime, so a step
+            # taken here makes an in-flight download look like it has taken that long
+            # and the peer is dropped. The next sync_blocks then asserts on a node
+            # with no peers, which reads as an unrelated failure somewhere later in
+            # the test. Skipping the step costs nothing: the download completes on
+            # its own and the clock moves on the following iteration. See RED-58.
+            blocks_in_flight = any(peer.get('inflight') for info in peer_info for peer in info)
+            if not blocks_in_flight and hasattr(rpc_connections[0], 'mocktime') and rpc_connections[0].mocktime:
                 for node in rpc_connections:
                     node.mocktime += 5
                     node.setmocktime(node.mocktime)


### PR DESCRIPTION
## Summary

`sync_mempools` steps mocktime while waiting, which can make an in-flight block
download look stalled and get the peer dropped. Skip the step while any node is
still waiting on a block.

Fixes the `rpc_psbt.py` half of RED-58 properly. The earlier attempt, #462, did
not.

## Cause

`test_framework.py:713`:

```python
# Advance mocktime so outbound trickle relay timers can fire
if hasattr(rpc_connections[0], 'mocktime') and rpc_connections[0].mocktime:
    for node in rpc_connections:
        node.mocktime += 5
        node.setmocktime(node.mocktime)
time.sleep(wait)
```

Five seconds of mocktime per poll, on every node, for as long as convergence
takes. With `wait=1` that is roughly five times real time.

The block-download stall timer is measured against `GetTime()`, which honours
mocktime, so a step taken while a node is waiting on a block makes that download
look as though it has taken that long. The node drops the peer:

```
node2 [SendMessages] Timeout downloading block edf927f4... from peer=0, disconnecting
```

and the next `sync_blocks` fails its "every node has at least one connection"
assertion, which surfaces as a failure somewhere later in the test with no
obvious connection to the clock.

## Why the previous fix did not work

#462 added `self.sync_all()` before each mocktime jump in `rpc_psbt.py`, to
settle relay first. **`sync_all` calls `sync_mempools`**, so the settling is
itself a series of mocktime steps. The fix put a ratchet in front of every jump
in the file to protect against jumps.

It failed the same way, at the same line, on
[run 30864274992](https://github.com/reddcoin-project/reddcoin/actions/runs/30864274992):

```
rpc_psbt.py, line 334, in run_test
    self.sync_all()
  test_framework.py, line 685, in sync_blocks
    assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
```

Line 331, two lines above, is the `sync_all()` that PR added.

That is the argument for fixing this in the framework rather than at call sites:
the primitive a test reaches for to make a clock step safe is itself a clock
stepper.

## Fix

```python
peer_info = [x.getpeerinfo() for x in rpc_connections]
assert (all([len(info) for info in peer_info]))
blocks_in_flight = any(peer.get('inflight') for info in peer_info for peer in info)
if not blocks_in_flight and hasattr(...) and ...:
    ... step mocktime ...
```

Skipping costs nothing: the download completes on its own and the clock moves on
the following iteration. The peer info is already being fetched for the
connection assertion on the line above, so this adds no RPCs.

## Testing

**The `inflight` field was verified rather than assumed.** A guard keyed on a
field that is never populated would be a silent no-op, and this codebase has one
of those already: a coinstake key lookup that read an `address` field which does
not exist for P2PK, and so never once succeeded (RED-60). So a probe was written
first: disconnect a node, generate 120 blocks, reconnect, poll `getpeerinfo`.

```
INFLIGHT-PROBE polls=1 observations=1 synced=False
```

Non-empty `inflight` on the first poll. The condition is live.

Regression set, all passing: `rpc_psbt.py` under both `--descriptors` and
`--legacy-wallet`, `mempool_persist.py`, `mempool_unbroadcast.py`,
`mempool_reorg.py`, `p2p_feefilter.py`, `wallet_basic.py`, `rpc_blockchain.py`.
No slowdown; `rpc_psbt.py --descriptors` runs in 11.8s.

The guard was instrumented during those runs and fired zero times locally, which
is expected: regtest block downloads finish long before a mempool poll comes
round. It is a sanitiser-speed problem, so local runs confirm only that the
change is harmless.

## Scope

`sync_mempools` only. Two other places step the clock and want the same
treatment, left out to keep this reviewable:

- `advance_time_for_pos`, the explicit jump, used at 71 call sites.
- `BitcoinTestFramework.generate`, which steps 60 seconds per staking retry
  (`test_framework.py:793`).

RED-58 tracks the wider sweep.
