### PR TITLE
test: clear the ten RPCs the --coverage gate reports (RED-51)

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -452,18 +452,21 @@ static RPCHelpMan getinflation()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             ChainstateManager& chainman = EnsureAnyChainman(request.context);
 
-            int height;
             LOCK(cs_main);
+            const CChain& active_chain = chainman.ActiveChain();
 
-            if (!request.params[1].isNull() && request.params[1].get_int() > 0) {
+            // A height of 0, the documented default, measures at the tip.
+            int height = active_chain.Height();
+            if (!request.params[0].isNull() && request.params[0].get_int() > 0) {
                 height = request.params[0].get_int();
-            } else {
-                height = chainman.ActiveChain().Height();
+                if (height > active_chain.Height()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Target block height %d after current tip %d", height, active_chain.Height()));
+                }
             }
 
             UniValue ret(UniValue::VOBJ);
-            ret.pushKV("height", chainman.ActiveChain().Height());
-            ret.pushKV("inflation", GetInflation(&chainman.ActiveChainstate(), Params().GetConsensus()));
+            ret.pushKV("height", height);
+            ret.pushKV("inflation", GetInflation(&chainman.ActiveChainstate(), Params().GetConsensus(), active_chain[height]));
             return ret;
         },
     };
@@ -487,19 +490,23 @@ static RPCHelpMan getinflationmultiplier()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
             ChainstateManager& chainman = EnsureAnyChainman(request.context);
 
-            int height;
             LOCK(cs_main);
+            const CChain& active_chain = chainman.ActiveChain();
 
-            if (!request.params[1].isNull() && request.params[1].get_int() > 0) {
+            // A height of 0, the documented default, measures at the tip.
+            int height = active_chain.Height();
+            if (!request.params[0].isNull() && request.params[0].get_int() > 0) {
                 height = request.params[0].get_int();
-            } else {
-                height = chainman.ActiveChain().Height();
+                if (height > active_chain.Height()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Target block height %d after current tip %d", height, active_chain.Height()));
+                }
             }
 
+            const CBlockIndex* pindex = active_chain[height];
             UniValue ret(UniValue::VOBJ);
-            ret.pushKV("height", chainman.ActiveChain().Height());
-            ret.pushKV("inflation", GetInflation(&chainman.ActiveChainstate(), Params().GetConsensus()));
-            ret.pushKV("multiplier", GetInflationAdjustment(&chainman.ActiveChainstate(), Params().GetConsensus()));
+            ret.pushKV("height", height);
+            ret.pushKV("inflation", GetInflation(&chainman.ActiveChainstate(), Params().GetConsensus(), pindex));
+            ret.pushKV("multiplier", GetInflationAdjustment(&chainman.ActiveChainstate(), Params().GetConsensus(), pindex));
             return ret;
         },
     };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5355,9 +5355,13 @@ void ChainstateManager::MaybeRebalanceCaches()
 
 // PoSV2 determine the inflation adjustment to apply
 // look back over the last month of rewards (365.2424 / 12)
-double GetInflationAdjustment(CChainState* active_chainstate, const Consensus::Params& consensusParams)
+double GetInflationAdjustment(CChainState* active_chainstate, const Consensus::Params& consensusParams, const CBlockIndex* pindex)
 {
-    CBlockIndex* pindex = active_chainstate->m_chain.Tip();
+    if (!pindex) pindex = active_chainstate->m_chain.Tip();
+
+    // Genesis has no predecessor to read a money supply from. See the header
+    // for why block validation never reaches this.
+    if (!pindex || !pindex->pprev) return 1;
 
     int64_t nStart = GetTimeMicros();
     float nInflationTarget = 0.05;
@@ -5380,7 +5384,9 @@ double GetInflationAdjustment(CChainState* active_chainstate, const Consensus::P
     }
 
     // get previous block interval
-    std::string strHash = active_chainstate->m_chain[pindex->nHeight - nBlocksPerMonth]->GetBlockHash().GetHex();
+    const CBlockIndex* pindexInterval = active_chainstate->m_chain[pindex->nHeight - nBlocksPerMonth];
+    if (!pindexInterval) return 1; // chain shorter than the measurement interval
+    std::string strHash = pindexInterval->GetBlockHash().GetHex();
     uint256 hash = uint256S(strHash);
 
     int64_t nMoneySupplyPrev;
@@ -5388,11 +5394,14 @@ double GetInflationAdjustment(CChainState* active_chainstate, const Consensus::P
 
     {
         LOCK(cs_main);
-        if (!active_chainstate->m_blockman.m_block_index.count(hash))
+        const auto it = active_chainstate->m_blockman.m_block_index.find(hash);
+        if (it == active_chainstate->m_blockman.m_block_index.end() || !it->second) {
             LogPrintf("- Hash block missing\n");
+            return 1;
+        }
 
-        nMoneySupplyPrev = active_chainstate->m_blockman.m_block_index[hash]->nMoneySupply;
-        nHeightPrev = active_chainstate->m_blockman.m_block_index[hash]->nHeight;
+        nMoneySupplyPrev = it->second->nMoneySupply;
+        nHeightPrev = it->second->nHeight;
     }
 
     nPoSVRewards = nMoneySupply - nMoneySupplyPrev;
@@ -5415,9 +5424,13 @@ double GetInflationAdjustment(CChainState* active_chainstate, const Consensus::P
 /**
  * PoSV2 determine the current inflation rate
  */
-double GetInflation(CChainState* active_chainstate, const Consensus::Params& consensusParams)
+double GetInflation(CChainState* active_chainstate, const Consensus::Params& consensusParams, const CBlockIndex* pindex)
 {
-    CBlockIndex* pindex = active_chainstate->m_chain.Tip();
+    if (!pindex) pindex = active_chainstate->m_chain.Tip();
+
+    // Genesis has no predecessor to read a money supply from. See the header
+    // for why block validation never reaches this.
+    if (!pindex || !pindex->pprev) return 0;
 
     int64_t nMoneySupply = pindex->pprev->nMoneySupply;
     int64_t nMoneySupplyPrev;
@@ -5437,15 +5450,20 @@ double GetInflation(CChainState* active_chainstate, const Consensus::Params& con
     }
 
     // get previous block interval
-    std::string strHash = active_chainstate->m_chain[pindex->nHeight - nBlocksPerMonth]->GetBlockHash().GetHex();
+    const CBlockIndex* pindexInterval = active_chainstate->m_chain[pindex->nHeight - nBlocksPerMonth];
+    if (!pindexInterval) return 0; // chain shorter than the measurement interval
+    std::string strHash = pindexInterval->GetBlockHash().GetHex();
     uint256 hash = uint256S(strHash);
 
     {
       LOCK(cs_main);
-      if (!active_chainstate->m_blockman.m_block_index.count(hash))
-	LogPrint(BCLog::STAKE, "%s: Hash block missing\n", __func__);
+      const auto it = active_chainstate->m_blockman.m_block_index.find(hash);
+      if (it == active_chainstate->m_blockman.m_block_index.end() || !it->second) {
+        LogPrint(BCLog::STAKE, "%s: Hash block missing\n", __func__);
+        return 0;
+      }
 
-      nMoneySupplyPrev = active_chainstate->m_blockman.m_block_index[hash]->nMoneySupply;
+      nMoneySupplyPrev = it->second->nMoneySupply;
     }
 
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -1068,8 +1068,18 @@ const AssumeutxoData* ExpectedAssumeutxo(const int height, const CChainParams& p
 CAmount GetProofOfWorkReward(unsigned int nBits);
 CAmount GetProofOfStakeReward(int64_t nCoinAge, const CAmount& nFees);
 CAmount GetProofOfStakeReward(int64_t nCoinAge, const CAmount& nFees, double fInflationAdjustment);
-double GetInflationAdjustment(CChainState* active_chainstate, const Consensus::Params& consensusParams);
-double GetInflation(CChainState* active_chainstate, const Consensus::Params& consensusParams);
+/**
+ * Inflation rate, and the reward multiplier derived from it, measured over the
+ * month of blocks ending at pindex. Passing nullptr measures at the tip.
+ *
+ * Both return a neutral value (no inflation, an unchanged multiplier) when the
+ * chain is too short to hold a full measurement interval. Block validation
+ * never sees that case: it consults the multiplier only for v5 blocks, which
+ * exist only above nLastPowHeight, where the interval is clamped to a height
+ * the chain is guaranteed to have.
+ */
+double GetInflationAdjustment(CChainState* active_chainstate, const Consensus::Params& consensusParams, const CBlockIndex* pindex = nullptr);
+double GetInflation(CChainState* active_chainstate, const Consensus::Params& consensusParams, const CBlockIndex* pindex = nullptr);
 bool VerifyHashTarget(CChainState* active_chainstate, CBlockIndex* pindexPrev, const CBlock& block, uint256& hashProof);
 
 #endif // BITCOIN_VALIDATION_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -860,9 +860,9 @@ static RPCHelpMan getunconfirmedbalance()
 static RPCHelpMan getinterest()
 {
     return RPCHelpMan{"getinterest",
-                "\nReturns the total available balance.\n"
-                "The available balance is what the wallet considers currently spendable, and is\n"
-                "thus affected by options which limit spendability such as -spendzeroconfchange.\n",
+                "\nReturns the total interest this wallet has earned from staking.\n"
+                "Interest is the amount each coinstake credited above what it spent, summed\n"
+                "over every coinstake in the wallet within the given time range.\n",
                 {
 					{"start", RPCArg::Type::NUM, RPCArg::Default{0}, "Start time (unixtime)."},
 					{"end", RPCArg::Type::NUM, RPCArg::Default{-1}, "End time (unixtime)."},
@@ -895,10 +895,12 @@ static RPCHelpMan getinterest()
     if (!request.params[0].isNull()) {
     	nTimeStart = (unsigned int)request.params[0].get_int();
     }
-    unsigned int nTimeEnd = -1;
+    // No end given means no upper bound. Spelled out rather than assigned from
+    // -1, whose implicit sign change UndefinedBehaviorSanitizer objects to.
+    unsigned int nTimeEnd = std::numeric_limits<unsigned int>::max();
     if (!request.params[1].isNull()) {
-        	nTimeStart = (unsigned int)request.params[1].get_int();
-	}
+        nTimeEnd = (unsigned int)request.params[1].get_int();
+    }
 
     isminefilter filter = ISMINE_SPENDABLE;
 

--- a/test/functional/rpc_checkupdates.py
+++ b/test/functional/rpc_checkupdates.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the checkupdates RPC.
+
+checkupdates asks api.github.com for the latest release and compares it against
+the running version, so unlike every other RPC in the suite its result depends
+on whether the machine running the test can reach the internet.
+
+That is exactly why it is worth a test that does not care. node::CheckForUpdates
+wraps the whole exchange in a try block with a bounded deadline and reports what
+went wrong in the errors field, so the RPC is contractually obliged to return
+the same fully-populated object either way. The assertions below hold offline,
+and tighten to check the version comparison only when a response actually
+arrived. A network failure must never propagate out as an RPC error, and must
+never take longer than the fetch deadline.
+"""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+# node::CheckForUpdates gives the whole exchange UPDATE_CHECK_TIMEOUT (10s),
+# with generous headroom here for a loaded CI machine.
+FETCH_DEADLINE = 60
+
+STR_FIELDS = [
+    "localversion",
+    "remoteversion",
+    "message",
+    "warning",
+    "officialDownloadLink",
+    "errors",
+]
+
+
+class CheckUpdatesTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("checkupdates answers whether or not the fetch succeeds")
+        start = time.time()
+        info = node.checkupdates()
+        elapsed = time.time() - start
+
+        assert elapsed < FETCH_DEADLINE, \
+            "checkupdates took {:.1f}s, past its own fetch deadline".format(elapsed)
+
+        self.log.info("Every documented field is present and correctly typed")
+        for field in STR_FIELDS:
+            assert field in info, "missing field {}".format(field)
+            assert isinstance(info[field], str), \
+                "{} is {}, expected str".format(field, type(info[field]).__name__)
+        assert isinstance(info["updateavailable"], bool)
+
+        if info["errors"]:
+            # No route to api.github.com, which is the normal case on an
+            # isolated CI runner. The contract is that it degrades quietly.
+            self.log.info("Fetch failed as %s; checking it degraded quietly", info["errors"])
+            assert_equal(info["localversion"], "")
+            assert_equal(info["remoteversion"], "")
+            assert_equal(info["updateavailable"], False)
+            assert_equal(info["officialDownloadLink"], "")
+        else:
+            self.log.info("Fetch succeeded; checking the version comparison")
+            assert info["localversion"], "no local version parsed from a successful fetch"
+            assert info["remoteversion"], "no remote version parsed from a successful fetch"
+            # updateavailable is set only when the remote version is strictly
+            # ahead, so it and an equal-version message cannot both hold.
+            if info["updateavailable"]:
+                assert info["localversion"] != info["remoteversion"]
+                assert info["officialDownloadLink"].startswith("https://download.reddcoin.com/")
+            if info["localversion"] == info["remoteversion"]:
+                assert_equal(info["updateavailable"], False)
+                assert info["message"], "no message for an up-to-date node"
+
+        self.log.info("A second call is consistent with the first")
+        # Nothing is cached between calls, so this also covers the fetch path
+        # running twice in one process.
+        again = node.checkupdates()
+        assert_equal(set(again), set(info))
+
+
+if __name__ == "__main__":
+    CheckUpdatesTest().main()

--- a/test/functional/rpc_inflation.py
+++ b/test/functional/rpc_inflation.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the PoSV inflation RPCs.
+
+- getinflation
+- getinflationmultiplier
+
+Both report the inflation measured over the month of blocks ending at a given
+height, and getinflationmultiplier additionally reports the reward multiplier
+derived from it.
+
+Two things had to be true for the measurement to be possible, and neither was
+checked. The measured block needs a predecessor to read a money supply from,
+which genesis does not have, and the block a month back has to exist, which it
+does not on a chain shorter than the interval. Either one dereferenced a null
+CBlockIndex and killed the node, so an ordinary unprivileged `getinflation`
+segfaulted a fresh regtest node, or a mainnet node still in early IBD below
+height 44541. Both now answer with a neutral measurement instead: no inflation,
+and a multiplier that scales the stake reward by one.
+
+The `height` argument was separately dead. Both RPCs tested request.params[1]
+while declaring a single parameter, so it read as null on every call and the tip
+was measured whatever the caller asked for, with the local height variable
+computed and then never used.
+
+Reddcoin regtest caps proof of work at nLastPowHeight (89) and every block above
+it must be staked, so this test stays at or below 89, where blocks are cheap to
+mine and, more to the point, where the short-chain paths are reachable at all.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+# Reddcoin regtest consensus.nLastPowHeight: the last height that may be mined.
+LAST_POW_HEIGHT = 89
+
+# GetInflationAdjustment clamps the multiplier to this range.
+MIN_MULTIPLIER = Decimal("0.5")
+MAX_MULTIPLIER = Decimal("5")
+
+
+class InflationTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        # Staking would extend the chain underneath the height assertions.
+        self.extra_args = [["-staking=0"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def assert_neutral(self, height):
+        """A chain too short to measure reports no inflation, and no adjustment.
+
+        Reaching either RPC at these heights used to be fatal, so the assertion
+        that matters most here is simply that the node is still answering.
+        """
+        node = self.nodes[0]
+
+        inflation = node.getinflation(height)
+        assert_equal(inflation["height"], height)
+        assert_equal(inflation["inflation"], 0)
+
+        multiplier = node.getinflationmultiplier(height)
+        assert_equal(multiplier["height"], height)
+        assert_equal(multiplier["inflation"], 0)
+        assert_equal(multiplier["multiplier"], 1)
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("Genesis has no predecessor to measure against")
+        assert_equal(node.getblockcount(), 0)
+        self.assert_neutral(0)
+
+        self.log.info("Neither does a chain shorter than the measurement interval")
+        self.generate(1)
+        self.assert_neutral(1)
+
+        self.generate(49)
+        assert_equal(node.getblockcount(), 50)
+        self.assert_neutral(50)
+
+        self.log.info("At nLastPowHeight the interval closes and the measurement runs")
+        self.generate(LAST_POW_HEIGHT - 50)
+        assert_equal(node.getblockcount(), LAST_POW_HEIGHT)
+
+        inflation = node.getinflation()
+        assert_equal(inflation["height"], LAST_POW_HEIGHT)
+        assert isinstance(inflation["inflation"], Decimal)
+
+        multiplier = node.getinflationmultiplier()
+        assert_equal(multiplier["height"], LAST_POW_HEIGHT)
+        assert_equal(multiplier["inflation"], inflation["inflation"])
+        # The multiplier feeds GetProofOfStakeReward, which is consensus, so the
+        # documented clamp is the part worth pinning down.
+        assert MIN_MULTIPLIER <= multiplier["multiplier"] <= MAX_MULTIPLIER, \
+            "multiplier {} outside the documented clamp".format(multiplier["multiplier"])
+
+        self.log.info("An explicit height is measured, not silently replaced by the tip")
+        # Before the params[1] fix every one of these came back as the tip, so
+        # the echoed height is the regression: asking for 50 answered for 89.
+        for height in [0, 1, 50, LAST_POW_HEIGHT]:
+            requested = node.getinflation(height)
+            expected = LAST_POW_HEIGHT if height == 0 else height
+            assert_equal(requested["height"], expected)
+            assert_equal(node.getinflationmultiplier(height)["height"], expected)
+
+        # A height of 0 is the documented default and means the tip, so the two
+        # spellings have to agree.
+        assert_equal(node.getinflation(0), node.getinflation())
+        assert_equal(node.getinflationmultiplier(0), node.getinflationmultiplier())
+
+        # ...and asking for a short chain still answers neutrally now that the
+        # height is honoured, which is the same path the crash used to take.
+        assert_equal(node.getinflation(1)["inflation"], 0)
+        assert_equal(node.getinflationmultiplier(1)["multiplier"], 1)
+
+        self.log.info("A height past the tip is rejected")
+        tip = node.getblockcount()
+        for height in [tip + 1, tip + 1000]:
+            assert_raises_rpc_error(
+                -8,
+                "Target block height {} after current tip {}".format(height, tip),
+                node.getinflation,
+                height,
+            )
+            assert_raises_rpc_error(
+                -8,
+                "Target block height {} after current tip {}".format(height, tip),
+                node.getinflationmultiplier,
+                height,
+            )
+
+        self.log.info("The node survived every one of those calls")
+        assert_equal(node.getblockcount(), LAST_POW_HEIGHT)
+
+
+if __name__ == "__main__":
+    InflationTest().main()

--- a/test/functional/rpc_staking.py
+++ b/test/functional/rpc_staking.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the staking control and status RPCs.
+
+- staking          (node-wide switch, mirrors the -staking argument)
+- setstaking       (per-wallet switch)
+- getstakinginfo   (staking status for the selected wallet)
+
+These are how an operator turns staking on and off and inspects what it is
+doing, and none of them had any functional coverage: grepping the suite for
+"staking" finds -staking=0 on the command line in dozens of tests, but nothing
+that calls the RPCs.
+
+The two switches are deliberately separate. `staking` sets the node-wide
+gArgs -staking flag and starts or stops the staking threads; `setstaking`
+records the intent on one wallet and adds or removes it from the staking set.
+A wallet only actually stakes when both are on, which is what the interaction
+at the end of this test pins down.
+
+Staking is left off at every point where the test asserts on chain height,
+since a staking thread that finds a kernel would move the tip underneath it.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+# Keys getstakinginfo always reports, per its RPCResult. currentblockweight and
+# currentblocktx are omitted until a block has been assembled, so they are not
+# required here.
+STAKINGINFO_KEYS = {
+    "enabled",
+    "staking",
+    "chain",
+    "blocks",
+    "difficulty",
+    "networkhashps",
+    "pooledtx",
+    "search-interval",
+    "averageweight",
+    "totalweight",
+    "netstakeweight",
+    "expectedtime",
+    "warnings",
+}
+
+
+class StakingRpcTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        # Start with staking off so the tip stays put; the switches are then
+        # exercised explicitly.
+        self.extra_args = [["-staking=0"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def staking_by_wallet(self, entries):
+        """setstaking and staking report a list of one-key {name: enabled} objects.
+
+        Not named wallet_names: the framework already owns that attribute, and
+        assigning the list of wallets to create silently replaces the method.
+        """
+        names = {}
+        for entry in entries:
+            assert_equal(len(entry), 1)
+            names.update(entry)
+        return names
+
+    def test_staking_switch(self):
+        node = self.nodes[0]
+        wallet = self.default_wallet_name
+
+        self.log.info("staking reports the node-wide switch")
+        status = node.staking()
+        assert_equal(status["enabled"], False)  # -staking=0
+        assert_equal(status["running"], False)
+        assert_equal(status["thread_count"], 0)
+        assert wallet in self.staking_by_wallet(status["enabled_wallet"])
+
+        self.log.info("staking with no argument does not change the switch")
+        assert_equal(node.staking()["enabled"], False)
+
+        self.log.info("staking(True) turns it on and starts the threads")
+        started = node.staking(True)
+        assert_equal(started["enabled"], True)
+        assert_equal(node.staking()["enabled"], True)
+
+        self.log.info("staking(False) turns it off again")
+        stopped = node.staking(False)
+        assert_equal(stopped["enabled"], False)
+        assert_equal(stopped["running"], False)
+        assert_equal(stopped["thread_count"], 0)
+        assert_equal(node.staking()["enabled"], False)
+
+    def test_setstaking_switch(self):
+        node = self.nodes[0]
+        wallet = self.default_wallet_name
+
+        self.log.info("setstaking with no argument lists every loaded wallet")
+        wallets = self.staking_by_wallet(node.setstaking())
+        assert wallet in wallets
+
+        self.log.info("setstaking(True) enables staking for the selected wallet")
+        enabled = node.setstaking(True)
+        assert_equal(enabled["enabled"], True)
+        assert_equal(enabled["warning"], "")
+        assert_equal(self.staking_by_wallet(node.setstaking())[wallet], True)
+
+        self.log.info("setstaking(False) disables it again")
+        disabled = node.setstaking(False)
+        assert_equal(disabled["enabled"], False)
+        assert_equal(self.staking_by_wallet(node.setstaking())[wallet], False)
+
+        self.log.info("The node-wide switch is left alone by the per-wallet one")
+        assert_equal(node.staking()["enabled"], False)
+
+    def test_getstakinginfo(self):
+        node = self.nodes[0]
+
+        self.log.info("getstakinginfo reports every documented field")
+        info = node.getstakinginfo()
+        missing = STAKINGINFO_KEYS - set(info)
+        assert_equal(missing, set())
+
+        assert_equal(info["chain"], self.chain)
+        assert_equal(info["blocks"], node.getblockcount())
+        assert_equal(info["pooledtx"], len(node.getrawmempool()))
+        assert_equal(info["enabled"], False)  # -staking=0
+        assert_equal(info["staking"], False)  # not searching, so not staking
+
+        # The wallet holds the cache's staked coins, so it has weight to report
+        # even while staking is switched off.
+        assert info["totalweight"] >= 0
+        assert info["netstakeweight"] >= 0
+        assert info["expectedtime"] >= 0
+
+        self.log.info("getstakinginfo follows the enabled flag")
+        node.staking(True)
+        assert_equal(node.getstakinginfo()["enabled"], True)
+        node.staking(False)
+        assert_equal(node.getstakinginfo()["enabled"], False)
+
+    def test_switches_are_independent(self):
+        node = self.nodes[0]
+        wallet = self.default_wallet_name
+
+        self.log.info("The node-wide and per-wallet switches do not shadow each other")
+        node.staking(False)
+        node.setstaking(True)
+        assert_equal(node.staking()["enabled"], False)
+        assert_equal(self.staking_by_wallet(node.setstaking())[wallet], True)
+        assert_equal(node.getstakinginfo()["enabled"], False)
+
+        node.staking(True)
+        node.setstaking(False)
+        assert_equal(node.staking()["enabled"], True)
+        assert_equal(self.staking_by_wallet(node.setstaking())[wallet], False)
+        assert_equal(node.getstakinginfo()["enabled"], True)
+
+        # Leave the node as the test found it.
+        node.staking(False)
+        assert_equal(node.staking()["enabled"], False)
+
+    def run_test(self):
+        self.test_staking_switch()
+        self.test_setstaking_switch()
+        self.test_getstakinginfo()
+        self.test_switches_are_independent()
+
+
+if __name__ == "__main__":
+    StakingRpcTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -272,11 +272,12 @@ BASE_SCRIPTS = [
     'wallet_descriptor_staking.py',
     'wallet_descriptor_staking_witness.py',
     'feature_descriptor_legacy_staking.py',
-    # Reddcoin-specific RPCs that the --coverage gate reported as untested.
+    # RPCs that the --coverage gate reported as untested.
     'rpc_staking.py',
     'wallet_interest.py',
     'rpc_inflation.py',
     'rpc_checkupdates.py',
+    'wallet_abortrescan.py',
     # 'feature_signet.py',  # TODO: signet chain type not yet supported in ReddCoin
     'wallet_bumpfee.py --legacy-wallet',
     'wallet_bumpfee.py --descriptors',
@@ -365,6 +366,23 @@ NON_SCRIPTS = [
     "feature_blockfilterindex_prune.py",   # prune mode incompatible with blockfilterindex
     "feature_pruning.py",                  # prune mode rejected in ReddCoin (txindex is always on)
 ]
+
+# RPCs the --coverage gate must not count against us, because no test in this
+# tree can exercise them. This is not a list of RPCs we have not got round to;
+# each entry is paired with the reason it is unreachable, and belongs here only
+# for as long as that reason holds.
+#
+# Keep it in step with NON_SCRIPTS above: both entries below are uncoverable
+# precisely because the test that would cover them is listed there, so a test
+# coming back is the signal to remove the matching line here.
+EXPECTED_UNCOVERED_RPCS = {
+    # feature_pruning.py cannot pass while DEFAULT_TXINDEX is true, since prune
+    # mode is rejected at startup. Nothing else calls this.
+    'pruneblockchain',
+    # wallet_upgradewallet.py is deferred until FEATURE_LATEST moves past
+    # v4.22.9's 169900, as there is no upgrade delta to test before then.
+    'upgradewallet',
+}
 
 def main():
     # Parse arguments and pass through unrecognised args
@@ -832,7 +850,10 @@ class RPCCoverage():
             with open(filename, 'r', encoding="utf8") as coverage_file:
                 covered_cmds.update([line.strip() for line in coverage_file.readlines()])
 
-        return all_cmds - covered_cmds
+        # covered_cmds is what the tests reached; EXPECTED_UNCOVERED_RPCS is what
+        # they cannot reach at all. Subtracting the latter separately keeps the
+        # two claims apart, so an exemption is never mistaken for coverage.
+        return all_cmds - covered_cmds - EXPECTED_UNCOVERED_RPCS
 
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -272,6 +272,11 @@ BASE_SCRIPTS = [
     'wallet_descriptor_staking.py',
     'wallet_descriptor_staking_witness.py',
     'feature_descriptor_legacy_staking.py',
+    # Reddcoin-specific RPCs that the --coverage gate reported as untested.
+    'rpc_staking.py',
+    'wallet_interest.py',
+    'rpc_inflation.py',
+    'rpc_checkupdates.py',
     # 'feature_signet.py',  # TODO: signet chain type not yet supported in ReddCoin
     'wallet_bumpfee.py --legacy-wallet',
     'wallet_bumpfee.py --descriptors',

--- a/test/functional/wallet_abortrescan.py
+++ b/test/functional/wallet_abortrescan.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the abortrescan wallet RPC.
+
+abortrescan stops a wallet rescan started by another RPC, such as
+importprivkey with rescan set. It is inherited from Bitcoin rather than
+Reddcoin's own, but nothing in the suite called it, so the coverage gate
+reported it alongside the Reddcoin RPCs that genuinely had no test.
+
+What is asserted here is the "nothing to abort" contract, which is the
+deterministic half: with no rescan in progress the RPC reports false rather
+than raising, and it does so whether or not a rescan has ever run.
+
+The true branch is not asserted. Reaching it needs a rescan still running when
+the call arrives, and a regtest chain is scanned in milliseconds, so there is
+no window to hit. Widening it would mean either an artificially large chain or
+racing a background thread against the scan, and a test that usually wins a
+race is worse than one that does not try: it passes for the wrong reason and
+fails for no reason. Upstream has no dedicated test for this RPC either.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class AbortRescanTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-staking=0"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("With no rescan running, abortrescan reports false")
+        assert_equal(node.abortrescan(), False)
+
+        self.log.info("The wallet is not left in a scanning state by the call")
+        assert_equal(node.getwalletinfo()["scanning"], False)
+
+        self.log.info("It still reports false after a rescan has run to completion")
+        # rescanblockchain returns once the scan is done, so by the time the
+        # next call is made there is again nothing in progress. This covers the
+        # IsScanning() check against a wallet that has scanned, not just a fresh
+        # one that never has.
+        node.rescanblockchain()
+        assert_equal(node.getwalletinfo()["scanning"], False)
+        assert_equal(node.abortrescan(), False)
+
+        self.log.info("Repeated calls stay false rather than becoming an error")
+        assert_equal(node.abortrescan(), False)
+        assert_equal(node.abortrescan(), False)
+
+        self.log.info("Without a loaded wallet it is refused, not answered")
+        # The test framework addresses the node through the wallet endpoint, so
+        # unloading makes the endpoint itself unresolvable rather than reaching
+        # the RPC and finding no wallet. Either way it is refused, which is the
+        # contract worth holding: this never answers false for a missing wallet.
+        wallet = self.default_wallet_name
+        node.unloadwallet(wallet)
+        assert_raises_rpc_error(-18, "Requested wallet does not exist or is not loaded", node.abortrescan)
+        node.loadwallet(wallet)
+        assert_equal(node.abortrescan(), False)
+
+
+if __name__ == "__main__":
+    AbortRescanTest().main()

--- a/test/functional/wallet_interest.py
+++ b/test/functional/wallet_interest.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the getinterest wallet RPC.
+
+getinterest sums what every coinstake in the wallet credited above what it
+spent, optionally restricted to a [start, end] window of transaction times. It
+is how a staker sees what staking has actually earned them, and it had no
+coverage at all.
+
+It also did not work. The end argument was read into nTimeStart rather than
+nTimeEnd, so passing an end silently moved the *start* instead and the window
+never gained an upper bound. Asking for interest earned up to some past moment
+returned everything earned since it, which is close to the exact opposite.
+
+The test pins that down with a partition: splitting the chain at an arbitrary
+time T, what was earned up to T plus what was earned after T has to add up to
+the total. Before the fix both halves ran to the end of time and the sum came
+out at roughly twice the total.
+
+The pre-mined cache stakes every block above nLastPowHeight with the default
+wallet, so the wallet arrives holding a spread of coinstakes to measure.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+)
+
+# Comfortably past every block time in the test chain, and still inside the
+# signed 32-bit range the RPC parses its arguments as.
+FAR_FUTURE = 2 ** 31 - 1
+
+# Before any block exists, so an end here excludes every coinstake.
+LONG_PAST = 1
+
+
+class WalletInterestTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        # Staking would add coinstakes underneath the totals being compared.
+        self.extra_args = [["-staking=0"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("The wallet holds the staked coins from the cached chain")
+        total = node.getinterest()
+        assert isinstance(total, Decimal)
+        assert_greater_than(total, 0)
+
+        self.log.info("An explicit start of 0 is the documented default")
+        assert_equal(node.getinterest(0), total)
+
+        self.log.info("A window covering the whole chain reports the whole total")
+        assert_equal(node.getinterest(0, FAR_FUTURE), total)
+
+        self.log.info("A start past every coinstake reports nothing")
+        assert_equal(node.getinterest(FAR_FUTURE), 0)
+
+        self.log.info("An end before every coinstake reports nothing")
+        # The regression: this used to move the start instead, so an end in the
+        # distant past selected everything rather than nothing.
+        assert_equal(node.getinterest(0, LONG_PAST), 0)
+
+        self.log.info("A window splits the total rather than doubling it")
+        # Any split point works; the middle of the chain keeps both halves
+        # non-trivial so the assertion has something to catch.
+        split_height = node.getblockcount() // 2
+        split_time = node.getblockheader(node.getblockhash(split_height))["time"]
+
+        up_to_split = node.getinterest(0, split_time)
+        after_split = node.getinterest(split_time + 1)
+        assert_equal(up_to_split + after_split, total)
+
+        # Both halves should hold some of it, or the split point was useless and
+        # the partition above would pass even with the window ignored entirely.
+        assert_greater_than(up_to_split, 0)
+        assert_greater_than(after_split, 0)
+
+        self.log.info("Widening the window can only include more")
+        # A coinstake exactly at split_time belongs to the first half, so moving
+        # the end one second later can only pull value in, never drop it.
+        assert node.getinterest(0, split_time + 1) >= up_to_split
+
+
+if __name__ == "__main__":
+    WalletInterestTest().main()


### PR DESCRIPTION

Closes RED-51.

The `previous releases, qt5, DEBUG` job runs the functional suite with
`--coverage` and folds the result into its exit status (`test_runner.py:598`),
so it fails on ten uncovered RPC commands even when every functional test
passes. This clears all ten, and fixes what covering them turned up.

Eight get tests: the seven Reddcoin RPCs, which have no upstream test to
inherit, plus `abortrescan`, which is inherited but simply had none. The other
two are not missing tests and do not get one; see the gate scoping below.

CI on an earlier revision of this branch confirmed the first half of that: the
full suite passed with zero failed tests and the uncovered list went from ten
to exactly the three addressed since.

## What the tests found

Writing the tests was the smaller half of this. Four of the seven RPCs did not
work, and one of them was fatal.

### getinflation and getinflationmultiplier segfault the node

Confirmed against a live regtest node, not inferred from reading:

```
Thread 21 "b-httpworker.2" received signal SIGSEGV, Segmentation fault.
0x000055555597eaf5 in GetInflation (...) at validation.cpp:5422
5422	    int64_t nMoneySupply = pindex->pprev->nMoneySupply;
#1  operator() (...) at rpc/blockchain.cpp:466
```

Both RPCs measure inflation over the month of blocks ending at the tip, and
neither checked that the two blocks it needs exist. The measured block's
predecessor supplies the money supply, which genesis does not have. The block a
month back is read straight out of the active chain, which returns null below
that height. Either one dereferences null and kills the node.

The measurement interval is 43829 blocks (`nBlocksPerYear / 12`), and the clamp
that would keep the chain index in range only applies above `nLastPowHeight`.
On regtest the fatal range is heights 0 to 88. **On mainnet it is heights 0 to
43828, so an ordinary unprivileged `getinflation` call kills a node that is
still in early IBD.**

This is not introduced here and it affects released binaries, so it is tracked
separately as RED-65 with a backport request. The fix below is self-contained
and a backport can take the guards without the `pindex` parameter that the
height fix needs.

Both now return a neutral measurement instead: no inflation, and a multiplier
that leaves the stake reward unchanged.

**This cannot move consensus.** `GetInflationAdjustment` feeds the v5 stake
reward in `ConnectBlock` (`validation.cpp:2093`), but v5 blocks exist only above
`nLastPowHeight`, where the interval is clamped to a height the chain is
guaranteed to hold. Block validation never reaches either guard. No height that
returns a value today returns a different one, which
`feature_pos_coinstake_fees.py` checks directly by asserting the exact coinstake
accounting identity.

### The documented height argument did nothing

Both RPCs tested `request.params[1]` while declaring a single parameter, so it
read as null on every call, the local `height` variable was computed and then
never used, and the tip was measured whatever the caller asked for. The reported
height was the tip too, so nothing in the response revealed the substitution.

`getinflation 50` answered for the tip and said so.

### getinterest inverted its own range

The `end` argument was read into `nTimeStart` rather than `nTimeEnd`
(`rpcwallet.cpp:900`), so passing an end silently moved the start instead and
the window never gained an upper bound. Asking what a wallet earned up to some
past moment returned everything it had earned since then.

Its help text also described `getbalance`, down to the note about
`-spendzeroconfchange`.

## The tests

| file | covers |
| --- | --- |
| `rpc_staking.py` | `staking`, `setstaking`, `getstakinginfo` |
| `rpc_inflation.py` | `getinflation`, `getinflationmultiplier` |
| `wallet_interest.py` | `getinterest` |
| `rpc_checkupdates.py` | `checkupdates` |
| `wallet_abortrescan.py` | `abortrescan` |

Notes on how they are built:

- **Coverage only counts a successful call.** `AuthServiceProxyWrapper.__call__`
  logs after delegating, so a call that raises propagates before `_log_call()`.
  A test made only of `assert_raises_rpc_error` would not satisfy the gate.
- `rpc_inflation.py` walks a clean chain up through `nLastPowHeight`, so it
  passes through the heights that used to segfault, and asserts the echoed
  height to pin down the argument that used to be ignored.
- `wallet_interest.py` partitions the chain at an arbitrary time: what was
  earned up to it plus what was earned after it has to equal the total. Before
  the `end` fix both halves ran to the end of time and the sum came out at
  roughly double.
- `rpc_checkupdates.py` is the one RPC whose result depends on the network. It
  asserts the object shape that holds either way and tightens to the version
  comparison only when a response actually arrived, so it passes on an isolated
  runner.
- **Trap for anyone extending `rpc_staking.py`:** grepping the suite for
  "staking" matches `-staking=0` on the command line in dozens of tests and no
  RPC call at all. Also, do not name a helper `wallet_names`; the framework owns
  that attribute and assigning the wallet list silently replaces the method.

## Scoping the gate for what cannot be tested

`pruneblockchain` and `upgradewallet` are not missing tests. The tests that
would cover them exist and are deliberately not run:

- `feature_pruning.py` cannot pass while `DEFAULT_TXINDEX` is true, since prune
  mode is rejected at startup. It is in `NON_SCRIPTS` for that reason, so
  nothing can ever exercise `pruneblockchain`.
- `wallet_upgradewallet.py` is deferred with the group A wallet-evolution tests
  until `FEATURE_LATEST` moves past v4.22.9's 169900, as there is no upgrade
  delta to test before then.

Counting either as an untested RPC reports something the tree cannot act on, so
`EXPECTED_UNCOVERED_RPCS` records them beside the `NON_SCRIPTS` entries that
make them unreachable. A test coming back is the signal to remove the matching
line.

It is subtracted separately rather than folded into `covered_cmds`, because
"cannot be tested here" and "tested but invisible to the harness", which is what
the existing `generate` entry means, are different claims and the report should
not blur them.

`abortrescan` was grouped with these two but does not belong with them: nothing
stopped a test being written, so it got one.

## What this does not do

The inflation arithmetic is left alone. At height 89 it reports a negative rate
because it compares `pprev`'s money supply against the tip's, but that number is
consensus, so correcting it is a separate decision and a separate issue.

- `wallet_abortrescan.py` asserts only the "nothing to abort" contract. The true
  branch needs a rescan still running when the call arrives, and a regtest chain
  is scanned in milliseconds, so there is no window to hit. Widening it would
  mean an artificially large chain or racing a thread against the scan, and a
  test that usually wins a race passes for the wrong reason and fails for no
  reason.

## Testing

- All five new tests pass, and all ten RPCs drop off the `--coverage`
  uncovered list.
- `test_reddcoin` unit suite: no errors detected.
- `feature_pos_basic`, `feature_pos_coinstake_fees`, `feature_pos_sync`,
  `mining_basic` all pass, confirming the guards did not shift any staking
  reward.
- lint-whitespace, lint-include-guards, lint-includes, lint-locale-dependence,
  lint-files and flake8 all clean.
