### PR TITLE
test: let sync_time skip a node whose RPC has gone away

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -757,7 +757,20 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         # Only sync if at least one node has mocktime set
         max_time = max(times)
         if max_time > 0:
-            set_node_times(rpc_connections, max_time)
+            for node in rpc_connections:
+                try:
+                    node.setmocktime(max_time)
+                    node.mocktime = max_time  # Track for the next sync_time()
+                except (JSONRPCException, ConnectionError, OSError) as e:
+                    # A node can be on its way down while we align clocks, and
+                    # feature_abortnode crashes one deliberately. Its HTTP server
+                    # then answers 503 or refuses the connection, while the flags
+                    # filtered on above still say it is up, because the framework
+                    # has not noticed yet. Alignment is best effort and is invoked
+                    # implicitly from every TestNode.generate, so it must not be the
+                    # thing that fails a test. set_node_times stays strict for the
+                    # tests that call it directly and do want to hear about this.
+                    self.log.debug("sync_time: skipping unreachable node %d: %s" % (node.index, e))
 
     def sync_all(self, nodes=None):
         self.sync_time(nodes)


### PR DESCRIPTION
## Summary

`sync_time` fails the test when it tries to align the clock of a node that is on
its way down. Skip nodes it cannot reach.

Fixes RED-66.

## The failure

`feature_abortnode.py` failed the `TSan, depends, no gui` job in
[run 30876653533](https://github.com/reddcoin-project/reddcoin/actions/runs/30876653533/job/91889406420)
at test 39 of 230, after 1 second:

```
feature_abortnode.py, line 43, in run_test
    self.nodes[1].generate(1)
  test_node.py, line 343, in generate
    self.time_sync_callback()
  test_framework.py, line 760, in sync_time
    set_node_times(rpc_connections, max_time)
  util.py, line 463, in set_node_times
    node.setmocktime(t)
JSONRPCException: non-JSON HTTP response with '503 Service Unavailable' from server (-342)
```

## Cause

That test crashes a node on purpose. It deletes an undo file so a reorg fails,
connects a node with more work, and generates a block on the second node while
the first one aborts:

```python
with self.nodes[0].assert_debug_log(["Failed to disconnect block"]):
    self.connect_nodes(0, 1)
    self.nodes[1].generate(1)          # line 43
    self.log.info("Waiting for crash")
    self.nodes[0].wait_until_stopped(timeout=200)
```

`TestNode.generate` calls `time_sync_callback` (`test_node.py:343`), which is
`sync_time`, and `sync_time` sets mocktime on every node it believes is up:

```python
rpc_connections = [n for n in rpc_connections if n.running and n.rpc_connected]
```

Those flags are the framework's own bookkeeping, not a question put to the node.
While node0 is aborting it is still flagged up, because the framework has not
noticed yet, and its HTTP server already answers 503. `set_node_times` has no
error handling, so the exception propagates and fails the test.

The window is between node0 beginning its abort and the framework observing that
it has stopped. Anything that slows shutdown widens it, which is why this
surfaced under TSan.

## Fix

Skip nodes that cannot be reached:

```python
for node in rpc_connections:
    try:
        node.setmocktime(max_time)
        node.mocktime = max_time
    except (JSONRPCException, ConnectionError, OSError) as e:
        self.log.debug("sync_time: skipping unreachable node %d: %s" % (node.index, e))
```

Clock alignment is best effort and happens behind the test's back, invoked from
every `TestNode.generate`, so it should never be what fails a test.

`set_node_times` itself is deliberately left strict. Tests call it directly, and
there a vanished node is worth hearing about.

## Testing

**Verified against the failure, not only against a green run.** A probe that makes
one node's `setmocktime` raise the same 503 fails on the current code:

```
JSONRPCException: non-JSON HTTP response with '503 Service Unavailable' from server
```

and passes with this change, with the reachable node still correctly aligned. So
the new branch is genuinely exercised rather than being a silent no-op.

Regression set, all passing: `feature_abortnode.py`, `rpc_psbt.py`,
`mempool_persist.py`, `wallet_basic.py`, `p2p_eviction.py`.

## Note on where this appeared

It surfaced on PR #470, which is unrelated to it. That branch does not touch
`feature_abortnode.py`, `sync_time`, `set_node_times` or `test_node.py`, and its
`validation.cpp` changes are confined to `GetInflationAdjustment` and
`GetInflation`, nowhere near `AbortNode`.

What it does is add five tests, 225 to 230, which changes the `-j4` parallel
schedule and so what else is running when this test does. That is enough to move
a timing window. The race is in the framework and predates it.
