### PR TITLE
ci: pin qa-assets and add the fuzz seed corpus

### DIFF
--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -68,5 +68,9 @@ export SDK_URL=${SDK_URL:-https://bitcoincore.org/depends-sources/sdks}
 export DOCKER_PACKAGES=${DOCKER_PACKAGES:-build-essential libtool autotools-dev automake pkg-config bsdmainutils curl ca-certificates ccache python3 rsync git procps bison}
 export GOAL=${GOAL:-install}
 export DIR_QA_ASSETS=${DIR_QA_ASSETS:-${BASE_SCRATCH_DIR}/qa-assets}
+# Pinned so a run is reproducible and an unrelated push to qa-assets cannot
+# silently change what CI tests. This governs the unit test vectors as well as
+# the fuzz seed corpus, so bump it deliberately.
+export QA_ASSETS_COMMIT=${QA_ASSETS_COMMIT:-bf5168493bbee26b28490cdbfc3e85ceb4832793}
 export PATH=${BASE_ROOT_DIR}/ci/retry:$PATH
 export CI_RETRY_EXE=${CI_RETRY_EXE:-"retry --"}

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -119,9 +119,22 @@ if [ "$RUN_FUZZ_TESTS" = "true" ] || [ "$RUN_UNIT_TESTS" = "true" ] || [ "$RUN_U
   if [ ! -d ${DIR_QA_ASSETS} ]; then
     # Reddcoin qa-assets: unit_test_data/script_assets_test.json is regenerated
     # for Reddcoin's nTime transaction format (the upstream Bitcoin vectors fail
-    # to deserialize). See the repo README for how it is produced.
-    DOCKER_EXEC git clone --depth=1 https://github.com/reddcoin-project/qa-assets ${DIR_QA_ASSETS}
+    # to deserialize), and fuzz_seed_corpus is minimised against the Reddcoin
+    # fuzz binary. See the repo README for how both are produced.
+    #
+    # Fetch the pinned commit rather than the branch tip. A shallow fetch of a
+    # single revision keeps this as cheap as the previous --depth=1 clone while
+    # making the run reproducible.
+    DOCKER_EXEC mkdir -p ${DIR_QA_ASSETS}
+    DOCKER_EXEC git -C ${DIR_QA_ASSETS} init -q
+    DOCKER_EXEC git -C ${DIR_QA_ASSETS} remote add origin https://github.com/reddcoin-project/qa-assets
+    DOCKER_EXEC git -C ${DIR_QA_ASSETS} fetch -q --depth=1 origin ${QA_ASSETS_COMMIT}
+    DOCKER_EXEC git -C ${DIR_QA_ASSETS} checkout -q FETCH_HEAD
   fi
+  # DOCKER_EXEC passes its arguments through "$*", which drops quoting, so a
+  # format string containing spaces would reach git as separate arguments.
+  DOCKER_EXEC echo "qa-assets pinned at:"
+  DOCKER_EXEC git -C ${DIR_QA_ASSETS} log -1 --format=%H
 
   export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
   export DIR_UNIT_TEST_DATA=${DIR_QA_ASSETS}/unit_test_data/

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -15,13 +15,22 @@ import sys
 
 
 def get_fuzz_env(*, target, source_dir):
-    return {
+    env = {
         'FUZZ': target,
         'UBSAN_OPTIONS':
         f'suppressions={source_dir}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1',
         'ASAN_OPTIONS':  # symbolizer disabled due to https://github.com/google/sanitizers/issues/1364#issuecomment-761072085
         'symbolize=0:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1',
     }
+    # Targets built on BasicTestingSetup create a datadir under the system
+    # temp directory, and libFuzzer writes its merge control file there too.
+    # Neither is small: a merge across the whole suite can leave several GB
+    # behind, which fills a modest /tmp and fails the run. This environment
+    # replaces the caller's wholesale, so TMPDIR has to be passed through
+    # explicitly for it to be honoured.
+    if 'TMPDIR' in os.environ:
+        env['TMPDIR'] = os.environ['TMPDIR']
+    return env
 
 
 def main():


### PR DESCRIPTION
## Summary

The fuzz job has never fuzzed anything. `ci/test/04_install.sh` points
`DIR_FUZZ_IN` at `${DIR_QA_ASSETS}/fuzz_seed_corpus/`, which did not exist in
`reddcoin-project/qa-assets`, and `test_runner.py:258` creates the per-target
directories on demand. Every target therefore ran two iterations of a single
trivial input:

```
INFO:        0 files found in .../fuzz_seed_corpus/prevector
INFO: A corpus is not provided, starting from an empty corpus
#2 INITED ... #2 DONE ... Done 2 runs in 0 second(s)
```

That is an initialisation smoke test, not fuzzing. It is also why RED-54 read as
a single defect when four were present: with no inputs, a target either
initialises or it does not.

The corpus now exists. `reddcoin-project/qa-assets` carries **122,893 seed
inputs** across the 179 targets, and this pins CI to that revision.

## Changes

**Pin the qa-assets revision.** The clone was `--depth=1` against the branch
tip, so a run picked up whatever the repository happened to point at. An
unrelated push silently changed what CI tested and a run could not be reproduced
afterwards. This governs `DIR_UNIT_TEST_DATA` as well as `DIR_FUZZ_IN`, so it
decided the unit test vectors too.

Replaced with a shallow fetch of a pinned commit. GitHub serves a single-revision
fetch, so this stays as cheap as the previous clone rather than pulling full
history, which now matters. The resolved commit is logged so a run records what
it used.

**Forward `TMPDIR` to the fuzz targets.** Targets built on `BasicTestingSetup`
create a datadir under the system temp directory, and libFuzzer writes its merge
control file there. Neither is small: building the corpus left roughly 26 GB of
per-process datadirs behind, about 17 MB each, which filled a 9.8 GB `/tmp` and
failed the run partway.

`get_fuzz_env` builds the target's environment from scratch and `subprocess.run`
replaces the caller's wholesale, so `TMPDIR` was discarded and the binary always
fell back to `/tmp`. Setting it in the calling shell had no effect. It is now
passed through when set.

## How the corpus was built

Against a fuzz binary configured the way CI configures it, in two stages.

Merging `bitcoin-core/qa-assets` seeded 132 targets. Their corpora now live under
`fuzz_corpora/`, renamed some time after the v22 base this fork tracks, and
libFuzzer's `-merge=1` keeps only inputs reaching new coverage under the Reddcoin
binary, so nothing meaningless to this fork is carried over. The other 47 targets
have no upstream counterpart: upstream has since consolidated the
`process_message_*` family into one target and renamed several `*_deserialize`
ones.

Generation then covered those 47 and extended the rest, contributing about 65,000
inputs.

Four targets stay empty. `script_bitcoin_consensus`, `spanparsing`,
`sub_net_deserialize` and `timedata` reach everything reachable from a trivial
input, so libFuzzer keeps nothing. Git does not track empty directories, so those
four are absent from the repository; `test_runner.py` creates them on demand.

## Testing

The whole corpus was replayed through all 179 targets with no crash, assertion or
sanitizer report.

The pinned fetch was exercised end to end exactly as `04_install.sh` performs it:
resolves to the pinned commit in 130 seconds and lands 4.1 GB. The runner reported
87 GB free in the failing run referenced by RED-54, so the footprint is
comfortable.

## Expect the job to take much longer

It ran in 6m35s against an empty corpus. It now replays 122,893 inputs, which
took on the order of an hour locally at comparable parallelism. That is the cost
of the job testing something, not a regression, and it is well inside the six hour
Actions limit. Worth knowing before the first run lands.

## blockfilter is capped at 64 KB per input, and that is a workaround

`blockfilter` behaves superlinearly on large inputs. A single 984 KB input takes
282 seconds, and libFuzzer's own slow unit detection escalated through 10, 46,
161, 245 and 317 seconds while replaying the untrimmed set. Left alone the target
needed over two and a half hours, so one of 179 targets would have dominated the
pipeline.

Dropping the 160 inputs above 64 KB leaves 474 and brings a replay to 40 seconds.
That is 25% of the target's inputs but 94% of its bytes.

This trims around the symptom. `addrman` and `block` carry far more large inputs
and replay without trouble, so the cost is specific to filter construction rather
than to input size in general. Whether it is inherited from upstream or specific
to this fork is not established. Block filters are built from untrusted network
data, so the underlying behaviour deserves its own investigation.

## Note

A green fuzz job still means every target initialises and survives its seed
inputs. It does not mean the targets are clean under sustained fuzzing, which is
a separate exercise this only makes possible.
