### PR TITLE
ci: move upload-artifact to v6 so nothing still targets Node.js 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       # announced.
       - name: Upload unit test logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: unit-test-logs-${{ matrix.name }}
           path: ci/scratch/build/*/src/**/*.cpp.log
@@ -246,7 +246,7 @@ jobs:
       # in a log file, so a hang leaves nothing on the console to read.
       - name: Upload unit test logs
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: unit-test-logs-macos-native
           path: ci/scratch/build/*/src/**/*.cpp.log


### PR DESCRIPTION
## Summary

Every CI run logs:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/upload-artifact@v4
```

Move the two `upload-artifact` call sites to v6, which is the first release that
runs on Node.js 24 by default.

## Why v6 rather than v5

The obvious bump is v4 to v5, and it would not have fixed the warning. From the
v5 release notes:

> v5 had preliminary support for Node.js 24, however this action was by default
> still running on Node.js 20

Its `action.yml` still declares `runs.using: 'node20'`. Each version's manifest
was checked directly rather than assumed:

| version | `runs.using` |
| --- | --- |
| v4 | node20, the current state |
| v5 | **node20**, would still warn |
| v6 | node24 |
| v7 | node24 |

## Why not v7

The inputs are identical between v4 and v6, and both call sites use only `name`,
`path`, `if-no-files-found` and `retention-days`, all of which still exist.

v7 moves the package to ESM and adds direct unzipped uploads via a new `archive`
input. Neither is wanted here, and this action runs in every job, so the smaller
change is the better one.

## Runner requirement

v6 requires Actions Runner 2.327.1 or newer. Every runner in this workflow is
GitHub-hosted (`ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-13`), so that is
already satisfied. It would only matter for self-hosted runners.

## Nothing else needed changing

Every action in the workflow was checked, not only the one named in the warning:

```
actions/checkout@v5         node24
actions/cache/restore@v5    node24
actions/cache/save@v5       node24
actions/upload-artifact@v6  node24   (this change)
```

which is consistent with the warning naming `upload-artifact@v4` alone.

## Testing

The change is two version strings, so there is nothing to run locally. The
warning either disappears from this PR's own run or it does not, and that is the
test.

Note the upload steps themselves are guarded by `if: failure() || cancelled()`,
so a green run does not exercise the upload path. If confirmation that uploads
still work is wanted, it needs a run with a failing job, which this repository
currently produces without any effort.
