### PR TITLE
wallet: abandon orphaned coinstakes on block disconnect, not on every block template

### DIFF
--- a/src/interfaces/staking.h
+++ b/src/interfaces/staking.h
@@ -57,9 +57,9 @@ public:
     //!
     //! The node holds cs_wallet across whole operations that call back into the
     //! wallet several times (most importantly BlockAssembler::CreateNewBlock,
-    //! which invokes abandonOrphanedCoinstakes, createCoinStake,
-    //! setLastCoinStakeSearchInterval and finalizeCoinStakeReward in turn), so
-    //! per-method locking inside the implementation cannot reproduce the span.
+    //! which invokes createCoinStake, setLastCoinStakeSearchInterval and
+    //! finalizeCoinStakeReward in turn), so per-method locking inside the
+    //! implementation cannot reproduce the span.
     //! Callers keep the original scope by holding one of these.
     //!
     //! Lock order: cs_wallet is acquired *before* cs_main on the staking path.
@@ -112,9 +112,6 @@ public:
 
     //! Keep the destination reserved by reserveDestination().
     virtual void keepDestination() = 0;
-
-    //! Abandon coinstakes left behind by a reorg.
-    virtual void abandonOrphanedCoinstakes() = 0;
 
     //! Record how far the last kernel search advanced, for getstakinginfo.
     virtual void setLastCoinStakeSearchInterval(int64_t interval) = 0;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -178,9 +178,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     if (staking_wallet)
     {
-        // flush orphaned coinstakes
-        staking_wallet->abandonOrphanedCoinstakes();
-
         // attempt to find a coinstake
         *pfPoSCancel = true;
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());

--- a/src/wallet/staking.cpp
+++ b/src/wallet/staking.cpp
@@ -657,7 +657,6 @@ public:
     }
 
     void notifyStakingStatusChanged() override { m_wallet->NotifyWalletStakingStatusChanged(); }
-    void abandonOrphanedCoinstakes() override { m_wallet->AbandonOrphanedCoinstakes(); }
 
     void setLastCoinStakeSearchInterval(int64_t interval) override
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1146,6 +1146,12 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
     LOCK(cs_wallet);
 
     WalletBatch batch(GetDatabase());
+    return AbandonTransaction(batch, hashTx);
+}
+
+bool CWallet::AbandonTransaction(WalletBatch& batch, const uint256& hashTx)
+{
+    AssertLockHeld(cs_wallet);
 
     std::set<uint256> todo;
     std::set<uint256> done;
@@ -1331,11 +1337,56 @@ void CWallet::blockDisconnected(const CBlock& block, int height)
     for (const CTransactionRef& ptx : block.vtx) {
         SyncTransaction(ptx, {CWalletTx::Status::UNCONFIRMED, /* block height */ 0, /* block hash */ {}, /* index */ 0});
     }
+
+    // A coinstake of ours in a block that just left the chain is orphaned for
+    // good: coinstakes are never accepted into the mempool, so nothing will
+    // reconfirm it on this chain and it would sit UNCONFIRMED forever. While it
+    // does, CWallet::IsSpent still counts it as spending its input, keeping that
+    // coin out of AvailableCoins and so out of reach of the staker. Abandon it
+    // here to return the input to the wallet.
+    //
+    // This is the only way a coinstake becomes orphaned while we are running, so
+    // it replaces the full mapWallet sweep that used to run before every block
+    // template. If a deeper reorg later remines the coinstake, AddToWallet
+    // overwrites the abandoned status when the confirmation arrives.
+    std::vector<uint256> orphaned;
+    for (const CTransactionRef& ptx : block.vtx) {
+        if (!ptx->IsCoinStake()) continue;
+        auto it = mapWallet.find(ptx->GetHash());
+        if (it == mapWallet.end()) continue;
+        const CWalletTx& wtx = it->second;
+        if (wtx.GetDepthInMainChain() != 0 || wtx.isAbandoned()) continue;
+        orphaned.push_back(ptx->GetHash());
+    }
+    if (!orphaned.empty()) {
+        // One database transaction for the whole block, not one per coinstake.
+        WalletBatch batch(GetDatabase());
+        for (const uint256& wtxid : orphaned) {
+            LogPrint(BCLog::STAKE, "Abandoning coinstake wtx %s orphaned by disconnect of block %s\n",
+                     wtxid.ToString(), block.GetHash().ToString());
+            if (!AbandonTransaction(batch, wtxid)) {
+                LogPrint(BCLog::STAKE, "Failed to abandon coinstake tx %s\n", wtxid.ToString());
+            }
+        }
+    }
 }
 
 void CWallet::updatedBlockTip()
 {
     m_best_block_time = GetTime();
+
+    // postInitProcess() skips the orphaned-coinstake sweep while the node is in
+    // initial block download, because a coinstake that looks unconfirmed there
+    // may simply be confirmed in a block we have not processed yet. Run it once
+    // when IBD ends, so a wallet that started up behind the chain does not leave
+    // those coins locked out of staking until its next restart.
+    //
+    // Costs one relaxed atomic load per tip update once it has run.
+    if (!m_orphaned_coinstakes_swept.load(std::memory_order_relaxed) &&
+        !chain().isInitialBlockDownload() &&
+        !m_orphaned_coinstakes_swept.exchange(true)) {
+        AbandonOrphanedCoinstakes();
+    }
 }
 
 
@@ -1767,6 +1818,7 @@ void CWallet::ReacceptWalletTransactions()
     if (!fBroadcastTransactions)
         return;
     std::map<int64_t, CWalletTx*> mapSorted;
+    std::vector<uint256> to_abandon;
 
     // Check if we're still in initial block download
     const bool fIBD = chain().isInitialBlockDownload();
@@ -1785,11 +1837,20 @@ void CWallet::ReacceptWalletTransactions()
                 // They may be confirmed in blocks we haven't processed yet.
                 // blockConnected() will properly handle them as sync progresses.
                 if (!fIBD) {
-                    LogPrintf("Abandoning wtx %s\n", wtx.GetHash().ToString());
-                    AbandonTransaction(wtxid);
+                    to_abandon.push_back(wtxid);
                 }
             } else
                 mapSorted.insert(std::make_pair(wtx.nOrderPos, &wtx));
+        }
+    }
+
+    // Abandon under a single batch: one database transaction for the whole set
+    // rather than one per transaction.
+    if (!to_abandon.empty()) {
+        WalletBatch batch(GetDatabase());
+        for (const uint256& wtxid : to_abandon) {
+            LogPrintf("Abandoning wtx %s\n", wtxid.ToString());
+            AbandonTransaction(batch, wtxid);
         }
     }
 
@@ -1804,15 +1865,26 @@ void CWallet::ReacceptWalletTransactions()
 void CWallet::AbandonOrphanedCoinstakes()
 {
     LOCK(cs_wallet);
-    for (std::pair<const uint256, CWalletTx>& item : mapWallet) {
+
+    // Collect first, then abandon, so the whole sweep costs one database
+    // transaction rather than one per orphan. AbandonTransaction also mutates
+    // mapWallet entries, which is not safe to do while iterating it.
+    std::vector<uint256> orphaned;
+    for (const std::pair<const uint256, CWalletTx>& item : mapWallet) {
         const uint256& wtxid = item.first;
-        CWalletTx& wtx = item.second;
+        const CWalletTx& wtx = item.second;
         assert(wtx.GetHash() == wtxid);
         if (wtx.GetDepthInMainChain() == 0 && !wtx.isAbandoned() && wtx.IsCoinStake()) {
-            LogPrint(BCLog::STAKE, "Abandoning coinstake wtx %s\n", wtx.GetHash().ToString());
-            if (!AbandonTransaction(wtxid)) {
-                LogPrint(BCLog::STAKE, "Failed to abandon coinstake tx %s\n", wtx.GetHash().ToString());
-            }
+            orphaned.push_back(wtxid);
+        }
+    }
+    if (orphaned.empty()) return;
+
+    WalletBatch batch(GetDatabase());
+    for (const uint256& wtxid : orphaned) {
+        LogPrint(BCLog::STAKE, "Abandoning coinstake wtx %s\n", wtxid.ToString());
+        if (!AbandonTransaction(batch, wtxid)) {
+            LogPrint(BCLog::STAKE, "Failed to abandon coinstake tx %s\n", wtxid.ToString());
         }
     }
 }
@@ -2996,6 +3068,19 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
 void CWallet::postInitProcess()
 {
     LOCK(cs_wallet);
+
+    // Return the inputs of any coinstake this wallet loaded already orphaned, so
+    // the staker can spend them again. While we are running, blockDisconnected()
+    // abandons them as the disconnect arrives; this covers a wallet that was
+    // offline across the reorg that orphaned them.
+    //
+    // Skipped during IBD for the same reason ReacceptWalletTransactions() skips
+    // it: a coinstake that looks unconfirmed may simply be confirmed in a block
+    // we have not processed yet, and blockConnected() will pick it up as sync
+    // progresses. updatedBlockTip() then runs the sweep once IBD ends.
+    if (!chain().isInitialBlockDownload() && !m_orphaned_coinstakes_swept.exchange(true)) {
+        AbandonOrphanedCoinstakes();
+    }
 
     // Add wallet transactions that aren't already in a block to mempool
     // Do this here as mempool requires genesis block to be loaded

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -253,6 +253,10 @@ private:
     bool fBroadcastTransactions = false;
     // Local time that the tip block was received. Used to schedule wallet rebroadcasts.
     std::atomic<int64_t> m_best_block_time {0};
+    /** Whether the startup sweep for orphaned coinstakes has run. postInitProcess()
+     * skips it during initial block download, in which case updatedBlockTip()
+     * runs it once IBD ends. See AbandonOrphanedCoinstakes(). */
+    std::atomic<bool> m_orphaned_coinstakes_swept{false};
     /** optional setting to unlock wallet for staking only
      * serves to disable the trivial sendmoney when OS account compromised
      * provides no real security */
@@ -818,6 +822,12 @@ public:
     /* Mark a transaction (and it in-wallet descendants) as abandoned so its inputs may be respent. */
     bool AbandonTransaction(const uint256& hashTx);
 
+    /* As above, but writing through a caller-supplied batch so several
+     * transactions can be abandoned in a single database transaction. Abandoning
+     * N transactions one at a time costs N commits, and on BDB each commit can
+     * involve a log write and flush. */
+    bool AbandonTransaction(WalletBatch& batch, const uint256& hashTx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     /** Mark a transaction as replaced by another transaction (e.g., BIP 125). */
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
@@ -844,7 +854,10 @@ public:
     /* Returns true if the wallet can give out new addresses. This means it has keys in the keypool or can generate new keys */
     bool CanGetAddresses(bool internal = false) const;
 
-    /* Function that will remove potentially abandoned coinstakes, returning the input to the wallet. */
+    /* Sweep the whole wallet for orphaned coinstakes, returning their inputs to
+     * the wallet. Coinstakes left behind by a reorg are normally abandoned as
+     * the disconnect arrives, in blockDisconnected(); this covers the ones a
+     * wallet loads already orphaned, having been offline across the reorg. */
     void AbandonOrphanedCoinstakes();
 
     /**

--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -8,6 +8,18 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
+
+def is_abandoned(node, txid):
+    """Whether every spend recorded for txid is marked abandoned.
+
+    gettransaction reports "abandoned" on the "send" side of a transaction, which
+    for a coinstake is the coin it staked.
+    """
+    details = [d for d in node.gettransaction(txid)["details"] if "abandoned" in d]
+    assert details, f"gettransaction {txid} reported no spend details to check"
+    return all(d["abandoned"] for d in details)
+
+
 class OrphanedBlockRewardTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = False
@@ -57,23 +69,26 @@ class OrphanedBlockRewardTest(BitcoinTestFramework):
         self.nodes[1].setmocktime(self.nodes[0].mocktime)
         self.sync_all()
 
-        # Without the following abandontransaction call, the coins are
-        # not considered available yet.
-        balances_before = self.nodes[1].getbalances()["mine"]
-        assert_equal(balances_before["trusted"], 0)
-        assert_equal(balances_before["untrusted_pending"], 0)
-        assert_equal(balances_before["immature"], 0)
+        # A coinstake orphaned by a disconnect is abandoned by the wallet as the
+        # disconnect arrives, in blockDisconnected(). Until it is, IsSpent still
+        # counts it as spending its input, holding that coin out of the wallet.
+        #
+        # This used to be done by a full mapWallet sweep run before every block
+        # template, so it only took effect once this node next tried to stake,
+        # and the test had to call abandontransaction by hand to get there.
+        assert is_abandoned(self.nodes[1], coinstake_txid), \
+            "orphaned coinstake should have been abandoned by the disconnect"
 
-        # The following abandontransaction calls are necessary to make the
-        # later lines succeed, and probably should not be needed; see
-        # https://github.com/bitcoin/bitcoin/issues/14148.
-        # In PoS, we must also abandon the coinstake from the orphaned block
-        # to free the UTXO it consumed.
-        self.nodes[1].abandontransaction(coinstake_txid)
-        self.nodes[1].abandontransaction(txid)
+        # AbandonTransaction also abandons the in-wallet descendants of what it
+        # abandons, so the spend of the coinstake output goes with it. No manual
+        # abandontransaction call is needed for either; see
+        # https://github.com/bitcoin/bitcoin/issues/14148 for why one used to be.
+        assert is_abandoned(self.nodes[1], txid), \
+            "spend of the orphaned coinstake should have been abandoned with it"
+
         balances_after = self.nodes[1].getbalances()["mine"]
-        # After orphaning the staked block and abandoning the send tx,
-        # the wallet should recover the pre-staking balance.
+        # With the coinstake and its spend abandoned, the staked input is back
+        # in the wallet and the pre-staking balance is recovered.
         assert_equal(balances_after["trusted"], pre_stake_balance)
         assert_equal(balances_after["untrusted_pending"], 0)
         assert_equal(balances_after["immature"], 0)


### PR DESCRIPTION

`CWallet::AbandonOrphanedCoinstakes` was called unconditionally from `BlockAssembler::CreateNewBlock`, so it ran before every proof-of-stake block template: on the staker thread, and on every `generatetoaddress`, `generateblock` and `getblocktemplate` call. Each call scanned all of `mapWallet` under `cs_wallet`, and abandoned each orphan through a separate `AbandonTransaction` call, which opens its own `WalletBatch` and therefore its own database write transaction.

Measured on a loaded machine, one such sweep took 28 seconds and blew the functional test framework's 30 second RPC timeout on `generatetoaddress`. From a `p2p_sendheaders.py` node log, the RPC is dispatched, clears everything else in under a millisecond, then sits in the sweep:

```
00:29:39.010587  httpworker.1  ThreadRPCServer method=generatetoaddress
00:29:39.233649  httpworker.1  Abandoning coinstake wtx ...
00:29:39.333197  httpworker.1  Abandoning coinstake wtx ...        +0.10s
00:29:42.587756  httpworker.1  Abandoning coinstake wtx ...        +3.00s
00:29:50.979379  httpworker.1  Abandoning coinstake wtx ...        +8.39s
00:29:56.886783  httpworker.1  Abandoning coinstake wtx ...        +5.91s
00:30:00.962266  httpworker.1  Abandoning coinstake wtx ...        +4.08s
00:30:07.240638  httpworker.1  [modifiercache] hits 65 / miss 19   <- sweep done, 28.0s later
```

Eight orphans, 28 seconds, one BDB write transaction each. Because it delayed every PoS block template, this is a plausible source of timeout-shaped flakes across the functional suite.

## The sweep is load-bearing, not cleanup

Worth stating up front, because it constrains the fix: `CWallet::IsSpent` counts a depth zero unabandoned spend as spending its input. An orphaned coinstake therefore holds its own staked input out of `AvailableCoins`, and abandoning it is what returns that coin to the staker after a reorg. It could not simply be deleted.

The chainstate re-check in `CreateCoinStake` does not subsume it either. That check only *filters* coins `AvailableCoins` already offered; it cannot restore ones the wallet withheld. The two are complementary: the re-check drops coins a reorg made immature, the sweep adds back coins a reorg freed.

## Approach

Coinstakes are never accepted into the mempool and only enter the wallet through `blockConnected`, so the only way one becomes orphaned while the node is running is a block disconnect. The abandonment moves to `CWallet::blockDisconnected`, where it is:

- **targeted** at the coinstakes of the block that just left the chain, `O(block)` rather than `O(mapWallet)`;
- **batched**, one database transaction per block rather than one per orphan;
- **off the caller's path**, running on the validation interface thread rather than between an RPC and its block template.

`AbandonTransaction` gains an overload taking a `WalletBatch&`, with the existing signature delegating to it.

The full sweep is kept for a wallet that loads with coinstakes already orphaned, having been offline across the reorg, and is called once from `postInitProcess`. That is gated on `!isInitialBlockDownload()` for the same reason `ReacceptWalletTransactions` gates it: a coinstake that looks unconfirmed during IBD may just be confirmed in a block not yet processed. Because that gate would otherwise leave a node that starts behind the chain worse off than before (the old `CreateNewBlock` sweep was unconditional), `updatedBlockTip` runs the sweep once when IBD ends, through a `std::atomic<bool>` one-shot shared with `postInitProcess`. Steady state cost is one relaxed atomic load per tip update.

## Also batched

`ReacceptWalletTransactions` had the identical one-commit-per-transaction cost, abandoning any depth zero coinbase or coinstake. It runs from `postInitProcess` and four `rpcdump` import paths, so it is batched here too rather than leaving the same defect fixed in only one place.

## Interface change

`abandonOrphanedCoinstakes()` existed on `interfaces::StakingWallet` solely to serve the `CreateNewBlock` call site, and is removed along with it. `libbitcoin_server` no longer reaches into the wallet for this at all.

## Correctness notes

- **Abandoning is reversible.** `AddToWallet` overwrites `ABANDONED` with `CONFIRMED` when a re-confirmation arrives, so a deeper reorg that remines the coinstake restores it.
- **Startup ordering is safe.** `client->start()` -> `StartWallets` -> `postInitProcess` runs in init.cpp Step 13; the staker starts in Step 14. The load time sweep always precedes the first stake attempt.
- **`AbandonTransaction`'s `assert(currentconfirm <= 0)` holds on the new path.** Disconnects fire tip first, so any wallet transaction spending a coinstake output has already had its own higher block disconnected by the time the coinstake's disconnect is processed.

## Testing

Unit: 490/490 pass.

Functional: 21/21 pass, chosen to cover the reorg paths (`rpc_invalidateblock`, `wallet_txn_doublespend` x3, `wallet_txn_clone` x2), abandonment (`wallet_abandonconflict` x2, `wallet_listtransactions` x2), the `ReacceptWalletTransactions` paths (`wallet_resendwallettransactions` x2, `wallet_import_rescan`, `wallet_importmulti`), staking (`rpc_staking`, `wallet_descriptor_staking`, `feature_descriptor_legacy_staking`), plus `wallet_basic` x2 and `feature_reindex`.

`wallet_orphanedreward.py` is the regression test. It previously called `abandontransaction` by hand on the orphaned coinstake, because nothing else abandoned it: the sweep ran only from `CreateNewBlock`, and the node holding that coinstake never builds a template after the `invalidateblock`. Its staking flag is off by default, so its staker thread returns immediately, and the other node does the generating from there on. The test now asserts the wallet has already abandoned it. Since `AbandonTransaction` also abandons in-wallet descendants, the spend of the coinstake output goes with it and neither manual call is needed.

Confirmed at runtime from a `--nocleanup` run:

```
[scheduler] [wallet/wallet.cpp:1365] [blockDisconnected] Abandoning coinstake wtx 82c0bff8...
                                                          orphaned by disconnect of block 66e90ec9...
```

`[scheduler]`, not `[httpworker]`: the abandonment no longer sits between an RPC and its block template.

## Not addressed

Nothing known. An earlier revision of this description claimed that a reorg happening while the wallet is unloaded was left unhandled. That was wrong, and is corrected here so the merged record does not mislead: `CWallet::LoadToWallet` (wallet.cpp:1050-1065) already resolves each recorded block against the active chain as the wallet is read off disk and resets anything no longer on it to `UNCONFIRMED`. `m_confirm.block_height` is not serialized, so that lookup happens at load regardless, and it carries the chain membership check with it.

It runs before `AttachChain`, so the reset is in place by the time anything else looks: `m_chain` is set in the constructor (wallet.h:398), `CWallet::Create` calls `LoadWallet()` at wallet.cpp:2700 reaching `LoadToWallet` via walletdb.cpp:463, and `AttachChain` only follows at 2909.

That case is therefore handled, and handled by the mechanism this change depends on: `LoadToWallet` produces the depth zero state that `AbandonOrphanedCoinstakes` acts on from `postInitProcess`. Covered end to end by `test/functional/wallet_reorg_stale_coinstake.py`. RED-78, filed for the supposed gap, is closed as invalid.
