### PR TITLE
pos: sync the wallet to the tip before building a stake block

### DIFF
--- a/src/interfaces/staking.h
+++ b/src/interfaces/staking.h
@@ -98,6 +98,20 @@ public:
 
     //! Block until the wallet has processed the current chain tip, so a staking
     //! readout reflects blocks the caller could already have seen.
+    //!
+    //! Every caller that is about to build a proof-of-stake block must take this
+    //! first. createCoinStake() draws its kernel candidates from the wallet's
+    //! coin view, which measures confirmation depth against the last block the
+    //! wallet processed, and blocks reach the wallet asynchronously through the
+    //! validation interface queue. Building straight off a tip the wallet has
+    //! not caught up with hides coins that have just reached maturity, so a
+    //! different UTXO wins the kernel search and, since the PoSV reward follows
+    //! coin age, the block pays a different amount. The maturity re-check inside
+    //! createCoinStake() already reads the chainstate and treats the tip as
+    //! authoritative; this makes the candidate set agree with it.
+    //!
+    //! Must be called before cs_main or the wallet lock is taken: draining the
+    //! queue needs both.
     virtual void blockUntilSyncedToCurrentChain() = 0;
 
     //! How far the last kernel search advanced, for getstakinginfo.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -673,6 +673,13 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
             //
             // Create new block
             //
+            // Take the tip and the wallet's coin view from the same point in
+            // time. A block that arrived while this thread was sleeping reaches
+            // the wallet asynchronously, and staking off the newer tip with the
+            // older coin view drops coins that have just matured. See
+            // StakingWallet. No lock is held here, which is what this needs.
+            staking_wallet.blockUntilSyncedToCurrentChain();
+
             CBlockIndex* pindexPrev = chainman->ActiveChain().Tip();
             bool fPoSCancel = false;
             CScript scriptPubKey = GetScriptForDestination(dest);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -185,6 +185,10 @@ static UniValue generateBlocks(ChainstateManager& chainman, const CTxMemPool& me
         CBlockIndex* pindexPrev = nullptr;
 
         if (needPoS) {
+            // Let the wallet catch up with the block this loop just connected
+            // before picking coins for the next one. See StakingWallet.
+            staking_wallet->blockUntilSyncedToCurrentChain();
+
             // Create PoS block with wallet - follow miner.cpp PoSMiner() process exactly
             // Get pindexPrev BEFORE CreateNewBlock, without lock (matching miner.cpp line 650)
             pindexPrev = chainman.ActiveChain().Tip();
@@ -630,6 +634,10 @@ static RPCHelpMan generateblock()
             throw JSONRPCError(RPC_METHOD_NOT_FOUND,
                 "Wallet required for PoS block generation. Load a wallet first.");
         }
+
+        // Pick coins against the tip, not against whatever the wallet has
+        // processed so far. See StakingWallet.
+        staking_wallet->blockUntilSyncedToCurrentChain();
 
         CTxDestination dest;
         std::string dest_error;
@@ -1160,6 +1168,10 @@ static RPCHelpMan getblocktemplate()
                     ENTER_CRITICAL_SECTION(cs_main);
                     throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Wallet not found for PoS block creation");
                 }
+
+                // Safe here only because cs_main is released for this block; a
+                // queue drain needs it. See StakingWallet.
+                staking_wallet->blockUntilSyncedToCurrentChain();
 
                 CTxDestination dest;
                 std::string strError;


### PR DESCRIPTION
## The problem

`CreateCoinStake` draws its kernel candidates from the wallet's coin view, which measures confirmation depth against the last block the wallet processed. Blocks reach the wallet asynchronously through the validation interface queue, and no block creation path drained that queue first, so staking could run against a coin view behind the tip that the same function then validates against.

A coin that has just reached maturity is what this hides. Regtest matures at 60, so an output first becomes selectable at depth 61, and a single block of lag drops it from the candidate set. A different UTXO then wins the kernel search, and because the PoSV reward follows coin age, the block pays a different amount and the chain carries a different money supply.

In the 200 block chain `rpc_blockchain.py` builds, 63 of the 111 stake blocks consume a coin at depth exactly 61, so the selection sits on that boundary for most of the chain. That is what makes the test fail intermittently on loaded machines. In the run that prompted this, two blocks staked different coins: an old deep UTXO was consumed three blocks earlier than it should have been, carried 1.99% less coin age, and the money supply came out 0.26489255 RDD short of the value the test pins.

## The fix

The barrier already existed and was reached only by `getstakinginfo`. It cannot live inside `CreateNewBlock`, which runs under `cs_main`, the mempool lock and the wallet lock, because draining the queue needs all three. So each of the four paths that can build a stake block takes it first: `generateBlocks`, `generateblock`, `getblocktemplate` and the staker thread.

In `getblocktemplate` the call sits inside the window where `cs_main` is deliberately released, and the comment there records that so the call is not moved later.

The requirement is written up on `StakingWallet::blockUntilSyncedToCurrentChain()` itself, so the next caller that builds a stake block finds it at the declaration rather than by hitting the same intermittent failure.

## Impact

Nothing changes when the wallet is already caught up, which is the ordinary case, since `waitForNotificationsIfTipChanged` returns without waiting when the tip hash already matches. The chain `rpc_blockchain.py` builds is unchanged, tip hash and every pinned total included.

This is a node-side fix, not a test-side one: a real staker whose wallet lags the tip skips coins that have just matured and stakes a lower-value block, so the same defect costs rewards outside the test harness.

## Review notes

`rpc_blockchain.py` is the reproducer. It only fails under the load of `previous releases, qt5, DEBUG`, which is the one job running the functional suite with `--extended --coverage --previous-releases`, so a green run elsewhere neither confirms nor denies the fix.

Three lines of the diff are the call, the rest is the reasoning behind each placement.
