### PR TITLE
test: bound the sync_mempools in-flight mocktime hold-off

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -47,6 +47,11 @@ TEST_EXIT_SKIPPED = 77
 
 TMPDIR_PREFIX = "reddcoin_func_test_"
 
+# How many consecutive sync_mempools polls may defer the mocktime step because a
+# block is in flight. Deferring lets a download in progress finish before the
+# clock moves under it; deferring without limit deadlocks. See sync_mempools.
+MAX_INFLIGHT_MOCKTIME_SKIPS = 10
+
 
 class SkipTest(Exception):
     """This exception is raised to skip a test"""
@@ -701,6 +706,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         rpc_connections = nodes or self.nodes
         timeout = int(timeout * self.options.timeout_factor)
         stop_time = time.time() + timeout
+        inflight_skips = 0
         while time.time() <= stop_time:
             pool = [set(r.getrawmempool()) for r in rpc_connections]
             if pool.count(pool[0]) == len(rpc_connections):
@@ -711,16 +717,34 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             # Check that each peer has at least one connection
             peer_info = [x.getpeerinfo() for x in rpc_connections]
             assert (all([len(info) for info in peer_info]))
-            # Advance mocktime so outbound trickle relay timers can fire, but never
-            # while a node is still waiting on a block. The block-download stall
+            # Advance mocktime so outbound trickle relay timers can fire, but hold
+            # off while a node is still waiting on a block. The block-download stall
             # timer is measured against GetTime(), which honours mocktime, so a step
             # taken here makes an in-flight download look like it has taken that long
             # and the peer is dropped. The next sync_blocks then asserts on a node
             # with no peers, which reads as an unrelated failure somewhere later in
-            # the test. Skipping the step costs nothing: the download completes on
-            # its own and the clock moves on the following iteration. See RED-58.
+            # the test. See RED-58.
+            #
+            # The hold-off is bounded, because waiting indefinitely deadlocks: a
+            # download that stalls keeps 'inflight' populated, which freezes the
+            # clock, which stops the node's own stall timeout from ever elapsing,
+            # so the peer is never dropped and 'inflight' never clears. Observed on
+            # develop as wallet_listreceivedby.py spinning for its full 2400s with
+            # mocktime unchanged across 477 polls. Past the bound, step anyway: a
+            # download that has not progressed in this many polls is exactly the
+            # stalled case the node's timeout exists to handle, and that timeout
+            # needs the clock to move.
             blocks_in_flight = any(peer.get('inflight') for info in peer_info for peer in info)
-            if not blocks_in_flight and hasattr(rpc_connections[0], 'mocktime') and rpc_connections[0].mocktime:
+            if not blocks_in_flight:
+                inflight_skips = 0
+            else:
+                inflight_skips += 1
+                if inflight_skips == MAX_INFLIGHT_MOCKTIME_SKIPS + 1:
+                    self.log.warning(
+                        "sync_mempools: a block has been in flight for %d polls; "
+                        "stepping mocktime anyway so the stall timeout can fire" % MAX_INFLIGHT_MOCKTIME_SKIPS)
+            deferring = blocks_in_flight and inflight_skips <= MAX_INFLIGHT_MOCKTIME_SKIPS
+            if not deferring and hasattr(rpc_connections[0], 'mocktime') and rpc_connections[0].mocktime:
                 for node in rpc_connections:
                     node.mocktime += 5
                     node.setmocktime(node.mocktime)


### PR DESCRIPTION

Fixes a deadlock introduced by #469. Tracked as RED-58.

## The problem

#469 made `sync_mempools` skip its mocktime step whenever any peer reports a block in flight. The reason was sound: the step is what lets outbound trickle relay timers fire, but the block-download stall timer is measured against `GetTime()`, which honours mocktime, so a step taken while a download is in flight makes that download look overdue and the peer gets dropped. The following `sync_blocks` then asserts on a node with no peers, which reads as an unrelated failure later in the test.

The hold-off had no limit, and that deadlocks:

1. A block download stalls, so `getpeerinfo` keeps reporting a non-empty `inflight`.
2. The hold-off sees it and skips the mocktime step.
3. The node's own block-download stall timeout is measured against `GetTime()`. With the clock frozen it can never elapse.
4. So the peer is never dropped and the download never abandoned, and `inflight` never clears.
5. Back to step 2.

The hold-off removes the one mechanism that would have ended the stall it is waiting on.

## Evidence

Observed on `develop` in the TSan task of [run 31150489227](https://github.com/reddcoin-project/reddcoin/actions/runs/31150489227/job/92778885115):

```
30/231 - wallet_listreceivedby.py --legacy-wallet failed, Duration: 2407 s

AssertionError: Mempool sync timed out after 2400s:
  {'ffd4547599c82811de3b28ba687559afab017aad1dcdc22fb10611d3cf334c64'}
  set()
```

node0 held the transaction, node1 never received it, and the sync burned its full budget. From the combined log:

- **3972 lines carry exactly one mocktime value**, `2022-01-19T09:05:22Z`, identical on both nodes and unchanged across the whole visible window.
- **Zero `setmocktime` calls.** The only RPCs present are 954 `getrawmempool`, 954 `getpeerinfo` and 2 `stop` - the `sync_mempools` loop spinning for 477 polls with its step skipped every time.

The step is gated on three conditions. Two of them hold here: `init_wallet` sets `n.mocktime = tip_time + 300` for every node, and the nodes are visibly running on mocktime rather than real time. So `not blocks_in_flight` is the only gate that can have been false 477 times consecutively.

Worth noting this run is the first time the TSan task got this far. It previously died at exit 137 around test 65 (RED-57); lowering that task's functional concurrency to `-j2` cleared the SIGKILL, so this is a failure that was always present and simply never reached.

## Two aggravating properties

**It couples subsystems that are otherwise independent.** The gate reads *block* download state but throttles the ratchet that drives *transaction* trickle relay. Here a transaction stalled behind a block that never arrived.

**It traded a fast failure for a slow one.** `wallet_listreceivedby` was already a known casualty of this issue, failing with the `sync_blocks` peer assertion - immediate and legible. It now spins for 40 minutes instead. With `--failfast` and `TEST_RUNNER_TIMEOUT_FACTOR=40`, one wedged download costs the whole job.

## The change

Cap consecutive skips at `MAX_INFLIGHT_MOCKTIME_SKIPS = 10` and step the clock once the cap is passed. A download that has not progressed in that many polls is exactly the stalled case the node's own timeout exists to handle, and that timeout needs the clock to move.

Two details:

- The counter resets on any poll that finds nothing in flight, so a later download gets the full hold-off rather than inheriting an earlier stall's budget.
- Crossing the cap logs a warning once, so a recurrence is visible directly instead of having to be reconstructed from mocktime values after the fact.

## Testing

The gap in #469 was that its guard fired zero times in local testing, so the skip path shipped unexercised. That is closed here with a probe that wraps `getpeerinfo` to report `inflight` permanently, making the hold-off unable to clear on its own:

| | result |
| --- | --- |
| without this change | `AssertionError: Mempool sync timed out after 60s`, one node holding the transaction and the other empty |
| with this change | warning at exactly 10 polls, mocktime advanced on both nodes, mempools converged, passed |

The failing case reproduces the CI signature exactly, including the `{txid}` versus `set()` shape, so the comparison is against the real defect rather than a proxy for it. Both directions were re-confirmed against a current build.

The state machine was checked against five in-flight patterns:

| pattern | behaviour |
| --- | --- |
| never in flight | steps every poll, identical to pre-#469 |
| clears after 3 polls | defers 3, then steps - hold-off preserved |
| stalls forever | defers 10, then steps every poll |
| stalls, clears, stalls again | defers 10, steps, then re-arms on the clear |
| intermittent | defers on in-flight polls only, never reaches the cap |

Regression set from #469, all passing, in both wallet variants where they exist:

```
mempool_persist.py                       | Passed |  43 s
mempool_reorg.py                         | Passed |  28 s
mempool_unbroadcast.py                   | Passed |  59 s
p2p_feefilter.py                         | Passed |  47 s
rpc_blockchain.py                        | Passed |  55 s
rpc_psbt.py --descriptors                | Passed |  17 s
rpc_psbt.py --legacy-wallet              | Passed |  76 s
wallet_basic.py --descriptors            | Passed |  46 s
wallet_basic.py --legacy-wallet          | Passed | 120 s
wallet_listreceivedby.py --descriptors   | Passed |   9 s
wallet_listreceivedby.py --legacy-wallet | Passed |  25 s
```

`test/lint/lint-python.sh` clean.

## CI on this branch

[Run 31159607840](https://github.com/reddink/reddcoin/actions/runs/31159607840). The TSan task passed the **entire** functional suite, 231 tests, 6990 s accumulated, where on `develop` it died at test 30 of 231:

```
wallet_listreceivedby.py --legacy-wallet | Passed | 10 s     (2407 s timeout on develop)
wallet_listreceivedby.py --descriptors   | Passed |  9 s
ALL                                      | Passed | 6990 s (accumulated)
```

**The bound did not fire in that run.** The warning appears zero times, so no poll ever observed a stalled download and `sync_mempools` behaved exactly as it does without this change. That makes the green TSan run a no-regression result across 231 tests under a sanitiser, not a demonstration that the fix engaged. The demonstration is the probe above. It also shows the original failure is intermittent rather than deterministic, so the warning is the signal to watch for a recurrence.

One unrelated failure in the run: `multiprocess, DEBUG` at `mempool_unbroadcast.py` line 53 with `txn-mempool-conflict (-26)`, which is RED-74, a known flake at roughly one run in three and nothing to do with `sync_mempools`.

## What this does not do

It bounds the damage; it does not fix the stalled download underneath. That a block sat in flight long enough to matter is still unexplained, and under TSan it may be slowness rather than a defect. The new warning now distinguishes those cases directly in future runs.

Two other mocktime steppers named on RED-58 remain unguarded and are deliberately out of scope here: `advance_time_for_pos`, with 71 call sites, and `BitcoinTestFramework.generate`, which steps 60 seconds per staking retry. Both want the bounded form rather than the unbounded one, given what this one turned into.