### PR TITLE
wallet: lock cs_db in BerkeleyEnvironment::Open

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -126,6 +126,24 @@ BerkeleyEnvironment::~BerkeleyEnvironment()
 
 bool BerkeleyEnvironment::Open(bilingual_str& err)
 {
+    // Take cs_db here rather than relying on callers, because they disagree.
+    // BerkeleyDatabase::Open() and ReloadDbEnv() both hold it across their call,
+    // but BerkeleyDatabase::Verify() does not: MakeBerkeleyDatabase() releases
+    // cs_db before calling Verify(), so the loadwallet RPC reaches this function
+    // unlocked while a concurrent load can be inside it holding the lock.
+    //
+    // Guarding only some of the paths leaves fDbEnvInit, dbenv and the error
+    // file racing, and lets two threads run dbenv->open() with DB_RECOVER on the
+    // same environment at once. The environment is shared per directory, so two
+    // loads of *different* wallets in one walletdir reach it together; the
+    // g_loading_wallet_set guard in LoadWallet() is keyed on wallet name and
+    // does not cover that.
+    //
+    // cs_db is recursive, so the callers that already hold it re-enter here
+    // harmlessly, and this adds no new lock order: those callers already hold
+    // cs_db across the LockDirectory() call below.
+    LOCK(cs_db);
+
     if (fDbEnvInit) {
         return true;
     }


### PR DESCRIPTION

`BerkeleyEnvironment::Open()` is reachable both with and without `cs_db` held, so two threads loading wallets in the same wallet directory can run it concurrently. Reachable from the `loadwallet` RPC, so this is a node bug rather than a test artifact.

## The inconsistent locking

Three callers of `BerkeleyEnvironment::Open()` in `src/wallet/bdb.cpp`:

| line | caller | holds `cs_db`? |
| --- | --- | --- |
| 285 | `BerkeleyDatabase::Verify()` | **no** |
| 348 | `BerkeleyDatabase::Open()` | yes |
| 465 | `BerkeleyEnvironment::ReloadDbEnv()` | yes |

The unlocked one is the RPC path. `MakeBerkeleyDatabase()` closes its `cs_db` scope before calling `Verify()`, which its own comment explains: the lock was only ever there to guard `env.m_databases` until the `BerkeleyDatabase` constructor inserts.

```cpp
{
    LOCK(cs_db); // Lock env.m_databases until insert in BerkeleyDatabase constructor
    ...
    db = std::make_unique<BerkeleyDatabase>(std::move(env), std::move(data_filename));
}                                             // lock released here

if (options.verify && !db->Verify(error)) {   // Verify() -> env->Open(), unlocked
```

Guarding some paths and not others buys nothing: the lock held on one side does not exclude a thread arriving on the other.

## Why the existing guards do not cover it

**`LoadWallet()` is keyed on wallet name.** `g_loading_wallet_set.insert(name)` rejects a second concurrent load of the *same* name, which is what the `wallet_multiwallet.py` concurrent-loading section asserts on. But `g_dbenvs` is keyed on **directory**, via `GetBerkeleyEnv(data_file.parent_path())`, and in a multiwallet setup every wallet shares one directory. Two loads of *different* names both clear the name guard and meet on the same `BerkeleyEnvironment`.

**`LockDirectory()` is a cross-process guard.** It returns early when this process already holds the directory lock, so a second thread in the same process walks straight through. It protects against another instance of the daemon, not against another thread.

## What races

```cpp
if (fDbEnvInit) return true;                                // unsynchronised read
...
dbenv->set_errfile(fsbridge::fopen(pathErrorFile, "a"));    // both fopen, one FILE* leaks
int ret = dbenv->open(strPath.c_str(), ... DB_RECOVER ...); // same DbEnv, concurrently
...
fDbEnvInit = true;                                          // unsynchronised write
```

Both threads observe `fDbEnvInit == false` and proceed. `DB_RECOVER` then makes Berkeley DB walk the log directory, which is where this surfaces.

## Evidence

Under ThreadSanitizer the TSan task dies inside TSan's own fd-lifetime interceptor while reporting a race on a descriptor closed by `__os_dirlist`. Run [30986476232](https://github.com/reddcoin-project/reddcoin/actions/runs/30986476232/job/92436402447) produced two CHECK failures in the same run, one on each side of the lock:

```
tid 31657:  FdClose <- closedir <- __os_dirlist <- __log_find <- __log_recover
            <- __log_open <- __env_open <- BerkeleyEnvironment::Open bdb.cpp:160
            <- BerkeleyDatabase::Verify bdb.cpp:267      <- UNLOCKED path

tid 29668:  FdClose <- closedir <- __os_dirlist <- __log_find <- __logc_get
            <- __db_apprec <- __env_open <- BerkeleyEnvironment::Open bdb.cpp:160
            <- BerkeleyDatabase::Open bdb.cpp:330        <- LOCKED path
```

That is the race pair reported simultaneously, one thread on each side. It recurred on `develop` in run [31176315253](https://github.com/reddcoin-project/reddcoin/actions/runs/31176315253/job/92858984200) with the `Verify` stack alone.

The CHECK failure is ThreadSanitizer crashing while *formatting* a report, not a false positive. It found a real descriptor race and died in `AddLocation` building the output for it, which is why the failure has looked diagnostic-free until now.

## The change

Take `cs_db` at the top of `Open()`, so the guarantee lives in the function rather than depending on every caller getting it right.

- `cs_db` is a `RecursiveMutex`, so the two callers that already hold it re-enter harmlessly.
- No new lock order appears: those callers already hold `cs_db` across the `LockDirectory()` call inside `Open()`, and `cs_dir_locks` is confined to `util/system.cpp` and never acquires `cs_db`.
- `ReloadDbEnv()`'s `m_db_in_use.wait()` releases `cs_db` while waiting, and its `AssertLockNotHeld(cs_db)` applies to its caller, so neither is affected.

## Provenance

Inherited from Bitcoin Core rather than introduced here.

| Core branch | `bdb.cpp` | `LOCK(cs_db)` in `Open()` |
| --- | --- | --- |
| 28.x | present | no |
| 29.x | present | no |
| 30.x, 31.x, master | removed | n/a |

Never fixed upstream; it is absent from 30.x only because `bdb.cpp` was removed with the legacy wallet. Reddcoin still ships BDB, so it still carries the bug.

## Testing

The existing `wallet_multiwallet.py` concurrent-loading section is the trigger, and it only fails visibly under ThreadSanitizer, which widens the window. No new test is added, because reproducing the race deterministically without a sanitiser would need injected delays inside `Open()`.

The TSan task builds with `-DDEBUG_LOCKORDER`, so a lock-order mistake in this change would be caught at runtime there.

## CI on this branch

[Run 31225009561](https://github.com/reddcoin-project/reddcoin/actions/runs/31225009561). The TSan task passed the full functional suite in 63 minutes:

```
wallet_multiwallet.py --usecli        | Passed | 22 s     (failed at 67/231 on develop)
wallet_multiwallet.py --legacy-wallet | Passed | 46 s
wallet_multiwallet.py --descriptors   | Passed | 42 s
ALL                                   | Passed | 6065 s (accumulated)
```

Zero ThreadSanitizer CHECK failures and zero race reports of any kind, where the `sanitizer_common.h:494` abort had been killing this task repeatedly.

**How much that proves, stated honestly:** the race is intermittent, and run 31159607840 passed the same suite on `develop` without this change. So a single green run is consistent with the fix working and equally consistent with the race not firing. The argument for this change rests on the code analysis above, which stands independently; the green run corroborates rather than demonstrates.

Locally, `wallet_multiwallet.py` passes in all three variants (`--legacy-wallet` 108 s, `--usecli` 85 s, `--descriptors` 67 s). The meaningful signal there is the absence of a deadlock: `LOCK(cs_db)` now wraps `dbenv->open()` on every wallet load, and both `BerkeleyDatabase::Open()` and `ReloadDbEnv()` re-enter `Open()` while already holding the lock, so a mistake in the recursion reasoning would hang rather than fail.
