### PR TITLE
test: settle block relay before stepping mocktime for PoS

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -478,6 +478,45 @@ STAKE_MODIFIER_SELECTION_INTERVAL = sum(
     60 * 63 // (63 + (63 - section) * (3 - 1)) for section in range(64))
 
 
+# How many consecutive polls advance_time_for_pos waits for an in-flight block
+# download before stepping the clock regardless. See _settle_block_relay.
+MAX_INFLIGHT_ADVANCE_POLLS = 10
+INFLIGHT_ADVANCE_POLL_INTERVAL = 0.2
+
+
+def _settle_block_relay(nodes):
+    """Let in-flight block downloads land before the caller steps mocktime.
+
+    The block-download stall timer compares GetTime(), which honours mocktime,
+    against the moment the download started (net_processing.cpp:5053):
+
+        current_time > m_downloading_since
+            + nPowTargetSpacing * (1 + 0.5 * other_peers_downloading)
+
+    On regtest nPowTargetSpacing is 600, so with a single downloading peer the
+    budget is exactly 600 seconds. A step of that size therefore trips the
+    timeout outright rather than merely eating into it: the peer is dropped and
+    the next sync_blocks asserts on a node with no peers, which reads as an
+    unrelated failure later in the test. Letting the download land first is what
+    actually makes a step safe, at any step size.
+
+    Bounded, for the same reason the sync_mempools hold-off is bounded: a
+    download that never completes must not stop the clock forever. Past the
+    bound the caller steps anyway and the node's own timeout is free to fire,
+    which is the right outcome for a genuinely stalled download. See RED-58.
+    """
+    for _ in range(MAX_INFLIGHT_ADVANCE_POLLS):
+        try:
+            if not any(peer.get('inflight') for node in nodes for peer in node.getpeerinfo()):
+                return
+        except Exception:
+            # A node that is stopped, crashed, or has no RPC has nothing to
+            # settle, and several tests do step time across such a node on
+            # purpose. Never let this helper be the thing that fails them.
+            return
+        time.sleep(INFLIGHT_ADVANCE_POLL_INTERVAL)
+
+
 def advance_time_for_pos(nodes, seconds=60):
     """Advance mock time on all nodes to age coins for PoS staking.
 
@@ -493,6 +532,8 @@ def advance_time_for_pos(nodes, seconds=60):
     """
     if not isinstance(nodes, list):
         nodes = [nodes]
+
+    _settle_block_relay(nodes)
 
     # Get current time - use tracked mocktime if set, otherwise block header time
     # This allows multiple calls to advance_time_for_pos without generating blocks


### PR DESCRIPTION

`advance_time_for_pos` steps every node's clock at once. The block-download stall timer compares `GetTime()`, which honours mocktime, against the moment a download started, so a step taken while a block is in flight makes that download look overdue and the peer is dropped. The next `sync_blocks` then asserts on a node with no peers, which reads as an unrelated failure later in the test.

Part of RED-58.

## The step size is not incidental

The budget is computed in `net_processing.cpp:5053`:

```cpp
current_time > state.m_downloading_since
    + std::chrono::seconds{consensusParams.nPowTargetSpacing}
      * (BLOCK_DOWNLOAD_TIMEOUT_BASE + BLOCK_DOWNLOAD_TIMEOUT_PER_PEER * nOtherPeersWithValidatedDownloads)
```

On regtest `nPowTargetSpacing` is 600 and `BLOCK_DOWNLOAD_TIMEOUT_BASE` is 1, so with a single downloading peer the budget is **exactly 600 seconds** - and 63 of the call sites step by precisely that. Those steps do not eat into the budget, they exhaust it outright.

This corrects the figure recorded on RED-58, which describes the timeout as "roughly two minutes" and says a 600 second step "clears it comfortably". The conclusion was right but the margin was not: the step lands exactly on the limit, which is why it trips so reliably.

## Lowering the step does not work

The obvious response is to bring the jumps in line with the 60 second block spacing, which is also this function's own default and 6x the regtest `nStakeMinAge` of 10 seconds. That was tried across all 63 sites and it breaks staking:

```
feature_pos_sync.py
  JSONRPCException: Could not create PoS block at height 101:
    no valid coinstake found (wallet may need more age) (-1)
```

The same jump that endangers relay is what ages coins for the kernel search. Coinage and relay pull in opposite directions, so no single step size satisfies both. `feature_csv_activation.py` also failed under that sweep. Both pass with the jumps left at 600.

## What this does instead

Wait for in-flight downloads to land before stepping. The timeout only applies to a download that is *in flight*, so once relay has settled the step is safe at any size and every existing call site can stay as it is.

The wait is bounded at ten polls, for the same reason the `sync_mempools` hold-off is bounded: a download that never completes must not stop the clock forever, and past the bound the node's own timeout should be free to fire. RPC errors are swallowed, because several tests step time across a deliberately stopped or crashed node and this helper must never be the thing that fails them.

No call sites change; the helper already receives the node list, so RED-58's note about needing framework access turned out not to apply.

## Testing

Eight tests on this change, covering staking, relay and the original failure:

```
feature_block.py              | Passed | 1327 s
feature_csv_activation.py     | Passed |  280 s
feature_pos_basic.py          | Passed |    7 s
feature_pos_coinstake_fees.py | Passed |   13 s
feature_pos_sync.py           | Passed |   50 s
p2p_compactblocks.py          | Passed |  472 s
rpc_psbt.py --descriptors     | Passed |   19 s
rpc_psbt.py --legacy-wallet   | Passed |  193 s
```

**CI:** the ASan task passes on this branch ([run 31242222096](https://github.com/reddink/reddcoin/actions/runs/31242222096)). That is the task that failed at `rpc_psbt.py` 76/231 with this exact disconnect, and it is the meaningful signal here: the failure is sanitiser-only, because the widened timing is what opens the window, so local runs can show absence of regression but cannot exercise the bug. TSan also passes.

Stated plainly: the failure is intermittent, so one green ASan run supports the change without proving it. The argument rests on the timing arithmetic above, which is independent of any run.

One unrelated failure in that run, the ARM unit-test task on `validation_block_tests/processnewblock_signals_ordering`, tracked separately as RED-80. It runs no functional tests and passed on the previous run of the same code.

Wall-clock was not measured cleanly. Comparing against the sweep run is confounded, since those two differ in both jump size and the guard, and the numbers move in both directions.

## Still open on RED-58

`BitcoinTestFramework.generate` steps 60 seconds per staking retry while earlier blocks from the same call are still propagating, and is not guarded here.