### PR TITLE
test: screen BLOCK_FAILED_MASK in processnewblock_signals_ordering

### DIFF
--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -192,15 +192,22 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
             for (auto block : blocks) {
                 if (block->vtx.size() == 1) {
                     // Reddcoin: Check if block or its parent is already marked as failed before trying to process
-                    // During random processing, blocks may get marked invalid for various reasons
+                    // During random processing, blocks may get marked invalid for various reasons.
+                    // Screen on BLOCK_FAILED_MASK, matching the check below: the mask is
+                    // BLOCK_FAILED_VALID|BLOCK_FAILED_CHILD, and InvalidateBlock marks a whole
+                    // subtree by setting BLOCK_FAILED_CHILD on descendants. Invalidating an
+                    // ancestor above the parent therefore leaves both the parent and this block
+                    // carrying only BLOCK_FAILED_CHILD, so screening on BLOCK_FAILED_VALID alone
+                    // let such a block through to a check it could not pass. This chain is built
+                    // with forks on purpose, so multi-level invalid subtrees are expected. RED-80.
                     {
                         LOCK(cs_main);
                         auto* pindex = m_node.chainman->m_blockman.LookupBlockIndex(block->GetHash());
                         auto* pindexPrev = m_node.chainman->m_blockman.LookupBlockIndex(block->hashPrevBlock);
-                        if (pindex && (pindex->nStatus & BLOCK_FAILED_VALID)) {
+                        if (pindex && (pindex->nStatus & BLOCK_FAILED_MASK)) {
                             continue;
                         }
-                        if (pindexPrev && (pindexPrev->nStatus & BLOCK_FAILED_VALID)) {
+                        if (pindexPrev && (pindexPrev->nStatus & BLOCK_FAILED_MASK)) {
                             continue;
                         }
                     }
@@ -208,11 +215,17 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
                     Assert(m_node.chainman)->ProcessNewBlock(Params(), block, true, &ignored);
 
                     // Reddcoin: Check if block was accepted even if not connected to active chain
-                    // In a tree with forks, not all valid blocks will be on the active chain
+                    // In a tree with forks, not all valid blocks will be on the active chain.
+                    // Report nStatus on failure: the screen above and this check are separate
+                    // cs_main scopes with an unlocked ProcessNewBlock between them, and ten
+                    // threads run this loop, so a concurrent thread can still invalidate an
+                    // ancestor in that window. If that is what fires, the flag says which.
                     {
                         LOCK(cs_main);
                         auto* pindex = m_node.chainman->m_blockman.LookupBlockIndex(block->GetHash());
-                        BOOST_CHECK(pindex && !(pindex->nStatus & BLOCK_FAILED_MASK));
+                        BOOST_CHECK_MESSAGE(pindex && !(pindex->nStatus & BLOCK_FAILED_MASK),
+                                            "block " << block->GetHash().ToString() << " unexpectedly failed, nStatus="
+                                                     << (pindex ? pindex->nStatus : 0u));
                     }
                 }
             }


### PR DESCRIPTION

`validation_block_tests/processnewblock_signals_ordering` fails intermittently, taking the whole `make check` module with it:

```
test/validation_block_tests.cpp(215): error: in "validation_block_tests/processnewblock_signals_ordering":
  check pindex && !(pindex->nStatus & BLOCK_FAILED_MASK) has failed
*** 2 failures are detected in the test module "Reddcoin Core Test Suite"
make[2]: *** [Makefile:17296: check-am] Error 2
```

Tracked as RED-80.

## The guard is narrower than the thing it guards

The Reddcoin adaptation screens each block before processing it, then asserts afterwards:

```cpp
{
    LOCK(cs_main);
    auto* pindex     = ...LookupBlockIndex(block->GetHash());
    auto* pindexPrev = ...LookupBlockIndex(block->hashPrevBlock);
    if (pindex     && (pindex->nStatus     & BLOCK_FAILED_VALID)) continue;   // VALID only
    if (pindexPrev && (pindexPrev->nStatus & BLOCK_FAILED_VALID)) continue;   // VALID only
}

ProcessNewBlock(...);

{
    LOCK(cs_main);
    auto* pindex = ...LookupBlockIndex(block->GetHash());
    BOOST_CHECK(pindex && !(pindex->nStatus & BLOCK_FAILED_MASK));            // MASK
}
```

`BLOCK_FAILED_MASK` is `BLOCK_FAILED_VALID | BLOCK_FAILED_CHILD` (`chain.h:129-131`), so the screen tests a strictly narrower condition than the check.

**A block carrying only `BLOCK_FAILED_CHILD` passes the screen and fails the check, with no race required.** `InvalidateBlock` propagates failure down a subtree by setting `BLOCK_FAILED_CHILD` on descendants (`validation.cpp:2611`). Invalidate an ancestor above the immediate parent and both the parent and this block carry `BLOCK_FAILED_CHILD` and neither carries `BLOCK_FAILED_VALID`: both screen arms read false, the block is processed, and the check then sees the bit set.

The test builds a forked chain on purpose, `BuildChain(..., 80, 15, 10, 500, ...)` with a 15 percent invalid rate and 10 percent branch rate, so multi-level invalid subtrees are ordinary rather than exceptional.

## The change

Screen on the same mask the check uses. Blocks whose ancestry has been invalidated are skipped, which is what the screen was there for; asserting that such a block is not marked failed was never going to hold.

The assertion also now reports `nStatus` on failure. The screen and the check sit in separate `cs_main` scopes with an unlocked `ProcessNewBlock` between them, and ten threads run this loop, so a concurrent thread can still invalidate an ancestor inside that window. **That window is deliberately untouched here.** If it is what fires next, the flag value distinguishes it from the case fixed above instead of leaving the reader to infer which from a bare failed check, which is the position this was diagnosed from.

## Testing

- `validation_block_tests` run five times consecutively: clean, and the new diagnostic never fired.
- Full `make check`: 96 suite logs, all reporting `*** No errors detected`.
- CI [run 31259799476](https://github.com/reddink/reddcoin/actions/runs/31259799476): the ARM unit-test task, which failed on this test in the preceding run, passed.

**What that does and does not establish.** This test passed on CI run 31225009561 with the unfixed code and failed on 31242222096 with the same code, so passes have never been rare and none of the above isolates the fix. The basis for this change is the flag asymmetry, which is read directly from the source and holds without reference to any run.

## Sightings

| when | job | outcome |
| --- | --- | --- |
| 2026-08-07 | previous releases, qt5, DEBUG | failed after every functional and compatibility test had passed |
| 2026-08-08 | ARM, unit tests | failed |
| 2026-08-08 | ARM, unit tests, same code | passed |

Because it fails the whole `make check` module, any job running unit tests can go red on it regardless of what the branch under test changed.