### PR TITLE
wallet: initialise bBip44 and WalletOptions

### DIFF
--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -218,9 +218,9 @@ enum walletType {
 };
 
 struct WalletOptions {
-    int walletType;
-    int bits;
-    bool importing;
+    int walletType = 0;  // bip32Wallet
+    int bits = 256;
+    bool importing = false;
     SecureString ssMnemonic;
     SecureString ssMnemonicPassphrase;
     SecureString ssMasterKey;

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1240,9 +1240,7 @@ CPubKey LegacyScriptPubKeyMan::GenerateNewBip39Seed(const WalletOptions& walleto
     // LogPrintf("%s:\nssMnemonic=%s\nssPassPhrase=%s\ntype: %d\n", __func__, seed0.c_str(), pass0.c_str(), walletoptions.walletType);
 
     CHDChain newHdChain;
-    if (walletoptions.walletType == walletType::bip44Wallet) {
-        newHdChain.SetBip44();
-    }
+    newHdChain.SetBip44(walletoptions.walletType == walletType::bip44Wallet);
     std::string strSeed = gArgs.GetArg("-hdseed", "not hex");
 
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -625,7 +625,10 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
     if (IsCrypted())
         return false;
 
-    WalletOptions walletoptions;
+    WalletOptions walletoptions{};
+    walletoptions.walletType = walletType::bip32Wallet;
+    walletoptions.bits = 256;
+    walletoptions.importing = false;
 
     CKeyingMaterial _vMasterKey;
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -138,6 +138,7 @@ public:
         nExternalChainCounter = 0;
         nInternalChainCounter = 0;
         seed_id.SetNull();
+        bBip44 = false;
     }
 
     bool operator==(const CHDChain& chain) const
@@ -147,7 +148,7 @@ public:
 
     bool IsNull() { return seed_id.IsNull();}
 
-    void SetBip44( bool b = true)   { bBip44 = b;}
+    void SetBip44(bool b)           { bBip44 = b;}
     bool IsBip44() const            { return bBip44 == true;}
 
     bool SetMnemonic(const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, SecureVector& vchSeed);


### PR DESCRIPTION

Backports two fixes from `develop` that were never released on the 4.22.9 line.
Both are uninitialised-read defects in wallet creation that reach the key
derivation path. Base is `v4.22.9-regtest` at `bf4c801c99`, the commit tagged
`v4.22.9.3`.

Fixes [RED-94](https://reddink.youtrack.cloud/issue/RED-94).

## The defects

`CHDChain::bBip44` (`src/wallet/walletdb.h`) is declared but never initialised.
Neither constructor assigns it and `SetNull()` omitted it, and
`GenerateNewBip39Seed()` wrote it only on the bip44 branch. `GenerateNewKey()`
then branches on `IsBip44()` to choose between `m/44'/coin'/0'/change/index`
and `m/account'/change'/index'`.

`struct WalletOptions` (`src/wallet/db.h`) has the same problem: `walletType`,
`bits` and `importing` have no initialisers, and `CWallet::EncryptWallet()`
constructs a bare local and passes it to `SetupGeneration()`, whose `default:`
case falls through to `GenerateNewBip39Seed()`.

Both values are serialized under `VERSION_HD_BIP39`, so the indeterminate
values are written into `wallet.dat` and survive restart.

## Impact is broader than seed import

This is not only a bip39-import problem. On the released binary, plain
`encryptwallet` on a BIP32 wallet moves it to a BIP44 tree and regenerates it
as BIP39, with no mnemonic import involved. Encryption already regenerates the
HD seed, so the user silently ends up on a derivation scheme they never asked
for.

No funds are at risk. The mnemonic is unchanged and only the derivation path
differs, so coins under an unintended path are recoverable by re-importing the
same mnemonic with the other wallet type.

## The behaviour is context-deterministic, not random

Worth stating because it changes how you reproduce this. The stack layout at a
given call site is identical on every call, so one binary always gives the same
answer on a given path. What varies is the build and the call path, not
repeated calls within a binary. Creating N wallets on one binary gives N
identical results, correct or incorrect.

## Verification

Regtest, 15 wallets per cell, each daemon run in isolation. The first two rows
are the same source commit `bf4c801c99`; only the compiler differs.

| build | `createwallet` | `createwallet` + passphrase | `encryptwallet` on existing |
|---|---|---|---|
| released v4.22.9.3 (guix) | bip32 `m/0'/0'/0'` | bip32 **`m/44'/1'/0'/0/0`** | **bip39** **`m/44'/1'/0'/0/0`** |
| unfixed (gcc, same commit) | bip32 `m/0'/0'/0'` | bip32 `m/0'/0'/0'` | **bip39** `m/0'/0'/0'` |
| this branch | bip32 `m/0'/0'/0'` | bip32 `m/0'/0'/0'` | bip32 `m/0'/0'/0'` |

Two compilers, one source tree, three different behaviours. This branch is
uniform across all three creation paths.

Observables used: `getaddressinfo <addr>.hdkeypath`, and whether a `dumpwallet`
file contains a `# mnemonic:` line (present means the BIP39 path ran).

## Backward compatibility

Wallets already created as BIP44 by the released v4.22.9.3 binary, then loaded
by this build:

* pre-existing addresses still report `ismine: true`
* their `hdkeypath` is unchanged
* new keys continue on `m/44'/1'/0'/0/...`

`bBip44` is read back out of the serialized `CHDChain`; the `SetNull()` default
only applies before load. No migration is needed and no existing wallet is
stranded.

## Deviation from upstream

`eee21091c7` keeps the conditional and changes only the call. This backport
writes the flag unconditionally instead:

```cpp
newHdChain.SetBip44(walletoptions.walletType == walletType::bip44Wallet);
```

Functionally identical once `SetNull()` zeroes the field, but it removes the
fix's dependence on `SetNull()` having run, so the correction is self-contained
within `GenerateNewBip39Seed()`.

`99b4f2db3d` (explicit bip39/bip44 cases in `SetupGeneration`, `default:`
returning false instead of falling through) is **not** backported. It is
hardening rather than a root-cause fix, and it changes behaviour on inputs that
the two commits here already make unreachable. Left out to keep the maintenance
branch close to the release. Easy to add if wanted.

## Out of scope

* A user advisory so 4.22.9.x users can audit `hd_type` on wallets they
  encrypted. Worth doing, but it is not a code change.
* `gethdwalletinfo` is broken on this branch for any non-BIP39 wallet: it
  returns `NullUniValue` when `GetHDChain().vchSeed` is empty (only BIP39
  populates `vchSeed`) while its `RPCResult` declares an OBJ, so
  `CHECK_NONFATAL` fires with `Internal bug detected`. `CHECK_NONFATAL` is
  unconditional, so release builds hit it too. Pre-existing and unrelated to
  these commits; tracked separately.
