### PR TITLE
rpc: return HD info for bip32 wallets instead of throwing

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -716,10 +716,12 @@ RPCHelpMan gethdwalletinfo()
                 RPCResult{
                     RPCResult::Type::OBJ, "", "",
                     {
-                        {RPCResult::Type::STR, "hdseed", "The HD seed (bip32, in hex)"},
-                        {RPCResult::Type::STR, "mnemonic", "The mnemonic for this HD wallet (bip39, english words)"},
-                        {RPCResult::Type::STR, "mnemonicpassphrase", "The mnemonic passphrase for this HD wallet (bip39)"},
+                        {RPCResult::Type::STR, "hdseed", "The HD seed, in hex. For a bip39/bip44 wallet this is the binary seed derived from the mnemonic; for a plain bip32 wallet it is the seed key held in the keystore"},
+                        {RPCResult::Type::STR, "mnemonic", /* optional */ true, "The mnemonic for this HD wallet (bip39/bip44 wallets only)"},
+                        {RPCResult::Type::STR, "mnemonicpassphrase", /* optional */ true, "The mnemonic passphrase for this HD wallet (bip39/bip44 wallets only)"},
                         {RPCResult::Type::STR, "rootprivkey", "The bip32 root private key"},
+                        {RPCResult::Type::STR, "accountextendedprivkey", /* optional */ true, "The extended private key at m/44'/coin_type'/account' (bip44 wallets only)"},
+                        {RPCResult::Type::STR, "accountextendedpubkey", /* optional */ true, "The extended public key at m/44'/coin_type'/account' (bip44 wallets only)"},
                         {RPCResult::Type::STR, "extendedprivkey", "The bip32 extended private key"},
                         {RPCResult::Type::STR, "extendedpubkey", "The bip32 extended public key"}
                     }
@@ -732,7 +734,6 @@ RPCHelpMan gethdwalletinfo()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return NullUniValue;
 
     CWallet& wallet = *pwallet;
     LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(wallet);
@@ -743,69 +744,80 @@ RPCHelpMan gethdwalletinfo()
 
     LOCK(spk_man.cs_KeyStore);
 
-    SecureVector vchSeed = spk_man.GetHDChain().vchSeed;
+    const CHDChain& hd_chain = spk_man.GetHDChain();
 
-    if (spk_man.GetHDChain().vchSeed.size() > 0) {
-        UniValue result(UniValue::VOBJ);
-        CExtKey masterKey;
-        CExtKey purposeKey;
-        CExtKey coinTypeKey;
-        CExtKey accountKey;
-        CExtKey chainKey;
-
-        masterKey.SetSeed(spk_man.GetHDChain().vchSeed.data(), spk_man.GetHDChain().vchSeed.size());
-
-        int nAccountIndex = 0;
-        bool internal = false;
-
-        if (spk_man.GetHDChain().vchMnemonic.size() > 0) {
-            SecureString ssMnemonic(spk_man.GetHDChain().vchMnemonic.begin(), spk_man.GetHDChain().vchMnemonic.end());
-            SecureString ssMnemonicPassphrase(spk_man.GetHDChain().vchMnemonicPassphrase.begin(), spk_man.GetHDChain().vchMnemonicPassphrase.end());
-
-            result.pushKV("mnemonic", ssMnemonic.c_str());
-            result.pushKV("mnemonicpassphrase", ssMnemonicPassphrase.c_str());
-        }
-
-        result.pushKV("hdseed", HexStr(spk_man.GetHDChain().vchSeed));
-        result.pushKV("rootprivkey", EncodeExtKey(masterKey));
-
-        if (!spk_man.GetHDChain().IsBip44()) {
-            // Derive new account keys
-            masterKey.Derive(accountKey, 0x80000000);
-
-            // Derive new chain keys
-            accountKey.Derive(chainKey, 0x80000000);
-
-        } else {
-            // derive m/purpose'
-            // use hardened derivation (child keys >= 0x80000000 are hardened after bip32)
-            masterKey.Derive(purposeKey, 44 | 0x80000000);
-
-            // derive m/purpose'/coin_type'
-            purposeKey.Derive(coinTypeKey, Params().ExtCoinType() | 0x80000000);
-
-            // derive m/purpose'/coin_type'/account'
-            coinTypeKey.Derive(accountKey, nAccountIndex | 0x80000000);
-
-            CExtPubKey accountpubKey = accountKey.Neuter();
-
-            result.pushKV("accountextendedprivkey", EncodeExtKey(accountKey));
-            result.pushKV("accountextendedpubkey", EncodeExtPubKey(accountpubKey));
-
-            // Derive new chain keys
-            accountKey.Derive(chainKey, (internal ? 1 : 0));
-        }
-
-
-        CExtPubKey chainpubKey = chainKey.Neuter();
-
-        result.pushKV("extendedprivkey", EncodeExtKey(chainKey));
-        result.pushKV("extendedpubkey", EncodeExtPubKey(chainpubKey));
-
-        return result;
+    if (!spk_man.IsHDEnabled()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet has no HD seed");
     }
 
-    return NullUniValue;
+    UniValue result(UniValue::VOBJ);
+    CExtKey masterKey;
+    CExtKey purposeKey;
+    CExtKey coinTypeKey;
+    CExtKey accountKey;
+    CExtKey chainKey;
+
+    // A bip39/bip44 wallet stores the binary seed derived from its mnemonic in vchSeed.
+    // A plain bip32 wallet leaves vchSeed empty: its seed is an ordinary key held in the
+    // keystore and referenced by seed_id. Mirrors the lookup in DeriveNewChildKey().
+    SecureVector vchSeed = hd_chain.vchSeed;
+    if (vchSeed.empty()) {
+        CKey seed;
+        if (!spk_man.GetKey(hd_chain.seed_id, seed)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "HD seed not found in wallet");
+        }
+        vchSeed.assign(seed.begin(), seed.end());
+    }
+    masterKey.SetSeed(vchSeed.data(), vchSeed.size());
+
+    int nAccountIndex = 0;
+    bool internal = false;
+
+    if (hd_chain.vchMnemonic.size() > 0) {
+        SecureString ssMnemonic(hd_chain.vchMnemonic.begin(), hd_chain.vchMnemonic.end());
+        SecureString ssMnemonicPassphrase(hd_chain.vchMnemonicPassphrase.begin(), hd_chain.vchMnemonicPassphrase.end());
+
+        result.pushKV("mnemonic", ssMnemonic.c_str());
+        result.pushKV("mnemonicpassphrase", ssMnemonicPassphrase.c_str());
+    }
+
+    result.pushKV("hdseed", HexStr(vchSeed));
+    result.pushKV("rootprivkey", EncodeExtKey(masterKey));
+
+    if (!hd_chain.IsBip44()) {
+        // Derive new account keys
+        masterKey.Derive(accountKey, 0x80000000);
+
+        // Derive new chain keys
+        accountKey.Derive(chainKey, 0x80000000);
+
+    } else {
+        // derive m/purpose'
+        // use hardened derivation (child keys >= 0x80000000 are hardened after bip32)
+        masterKey.Derive(purposeKey, 44 | 0x80000000);
+
+        // derive m/purpose'/coin_type'
+        purposeKey.Derive(coinTypeKey, Params().ExtCoinType() | 0x80000000);
+
+        // derive m/purpose'/coin_type'/account'
+        coinTypeKey.Derive(accountKey, nAccountIndex | 0x80000000);
+
+        CExtPubKey accountpubKey = accountKey.Neuter();
+
+        result.pushKV("accountextendedprivkey", EncodeExtKey(accountKey));
+        result.pushKV("accountextendedpubkey", EncodeExtPubKey(accountpubKey));
+
+        // Derive new chain keys
+        accountKey.Derive(chainKey, (internal ? 1 : 0));
+    }
+
+
+    CExtPubKey chainpubKey = chainKey.Neuter();
+
+    result.pushKV("extendedprivkey", EncodeExtKey(chainKey));
+    result.pushKV("extendedpubkey", EncodeExtPubKey(chainpubKey));
+
+    return result;
 },
     };
 }

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -218,10 +218,26 @@ class CreateWalletTest(BitcoinTestFramework):
         info = w_default.getwalletinfo()
         assert_equal(info['hd_type'], 'bip32')
 
+        self.log.info("Test gethdwalletinfo on a plain bip32 wallet")
+        # Regression: a wallet with no bip39 seed used to return null under a declared
+        # OBJ result, tripping CHECK_NONFATAL in RPCHelpMan::HandleRequest and surfacing
+        # as "Internal bug detected". A bip32 wallet has a seed key in the keystore, so
+        # the seed and the derived keys are all reportable.
+        hdinfo_bip32 = w_default.gethdwalletinfo()
+        assert_equal(len(hdinfo_bip32['hdseed']), 64)  # 32-byte seed key
+        for field in ['rootprivkey', 'extendedprivkey', 'extendedpubkey']:
+            assert field in hdinfo_bip32
+        # bip39/bip44-only fields must be absent rather than empty
+        for field in ['mnemonic', 'mnemonicpassphrase', 'accountextendedprivkey', 'accountextendedpubkey']:
+            assert field not in hdinfo_bip32
+
         self.log.info("Test gethdwalletinfo returns matching mnemonic")
         w_bip44_info = node.get_wallet_rpc('bip44test')
         hdinfo = w_bip44_info.gethdwalletinfo()
         assert_equal(hdinfo['mnemonic'], mnemonic)
+        assert_equal(len(hdinfo['hdseed']), 128)  # 64-byte bip39 binary seed
+        for field in ['accountextendedprivkey', 'accountextendedpubkey']:
+            assert field in hdinfo
 
         self.log.info("Test encrypted BIP44 wallet")
         resp = node.createwallet(wallet_name='enc_bip44', wallet_type='bip44', passphrase='test')


### PR DESCRIPTION

`gethdwalletinfo` fails on any wallet that is not bip39/bip44, returning an RPC
error instead of wallet info. Since `wallet_type` defaults to `"bip32"`, a plain
`createwallet <name>` produces a wallet the RPC cannot describe.

Fixes [RED-95](https://reddink.youtrack.cloud/issue/RED-95).

## Reproduction

```
$ reddcoin-cli -regtest createwallet w1
{ "name": "w1", "warning": "", "wallet_type": "bip32" }

$ reddcoin-cli -regtest -rpcwallet=w1 gethdwalletinfo
error code: -1
rpc/util.cpp:577 (HandleRequest)
Internal bug detected: 'std::any_of(m_results.m_results.begin(), m_results.m_results.end(), [&ret](const RPCResult& res) { return res.MatchesType(ret); })'
You may report this issue here: https://github.com/reddcoin-project/reddcoin/issues
```

`CHECK_NONFATAL` is ungated, so release builds are affected too, not only
`--enable-debug`.

## Cause

The function declares `RPCResult::Type::OBJ` but returns `NullUniValue` when the
HD chain has no bip39 seed:

```cpp
if (spk_man.GetHDChain().vchSeed.size() > 0) {
    ...
    return result;      // VOBJ
}

return NullUniValue;    // VNULL
```

`RPCHelpMan::HandleRequest` asserts the returned value matches a declared result
type, and `MatchesType` for `Type::OBJ` requires `VOBJ`. `VNULL` does not match,
so `CHECK_NONFATAL` throws.

`vchSeed` holds the binary seed derived from a mnemonic and is written in exactly
one place, `GenerateNewBip39Seed()` via `CHDChain::SetMnemonic`. A plain bip32
wallet goes through `GenerateNewSeed()` -> `SetHDSeed()` -> `DeriveNewSeed()`,
which never sets it, so every bip32 wallet took the null return.

## Fix

A bip32 wallet is not missing its seed, it just stores it differently: the seed
is an ordinary key in the keystore, referenced by `hd_chain.seed_id`. Look it up
the same way `DeriveNewChildKey()` already does, and the seed, root key and
derived extended keys can all be reported:

```cpp
SecureVector vchSeed = hd_chain.vchSeed;
if (vchSeed.empty()) {
    CKey seed;
    if (!spk_man.GetKey(hd_chain.seed_id, seed)) {
        throw JSONRPCError(RPC_WALLET_ERROR, "HD seed not found in wallet");
    }
    vchSeed.assign(seed.begin(), seed.end());
}
masterKey.SetSeed(vchSeed.data(), vchSeed.size());
```

`hdseed`, `rootprivkey`, `extendedprivkey` and `extendedpubkey` are now returned
for every HD wallet. The mnemonic fields remain conditional on `vchMnemonic`, and
the account-level keys remain conditional on the bip44 branch, so a bip32 wallet
gets the fields that apply to it and no empty placeholders.

Seed material is held in a `SecureVector` rather than a plain buffer, consistent
with the rest of this path.

Most of the diff is re-indentation from unwrapping the outer `if`. The logic
change is small.

## Also in this change

* `mnemonic` and `mnemonicpassphrase` marked optional in `RPCResult`.
* `accountextendedprivkey` and `accountextendedpubkey` declared for the first
  time. They were pushed on the bip44 path but never documented, so they did not
  appear in `help gethdwalletinfo`.
* `hdseed` description updated, since its meaning differs by wallet type: a
  64-byte bip39 binary seed, or a 32-byte bip32 seed key.
* A wallet with no HD seed at all now gets `RPC_WALLET_ERROR` "Wallet has no HD
  seed" rather than an internal-bug report.
* Removed `if (!pwallet) return NullUniValue;`. It is the same declared-type
  mismatch and it is unreachable: `GetWalletForJSONRPCRequest()` either returns a
  wallet or throws. Confirmed at runtime, where calling with no `-rpcwallet`
  gives `-19 Wallet file not specified`.

## Testing

`wallet_createwallet.py` already created a bip32 wallet and already called
`gethdwalletinfo` on a bip44 one, but never crossed the two, which is how this
went unnoticed. Added:

* `gethdwalletinfo` on the bip32 wallet, asserting a 64 hex character `hdseed`,
  the three always-present fields, and that all four bip39/bip44-only fields are
  absent rather than empty. This call reproduces the failure without the code
  change.
* On the existing bip44 case, a 128 hex character `hdseed` and the presence of
  the account-level fields.

## Compatibility

No change to the response for bip39/bip44 wallets: same fields, same order, same
values. Callers that previously had to handle a null return for bip32 wallets
will now receive an object; callers that treated the internal-bug error as "not
an HD wallet" should switch to the `RPC_WALLET_ERROR` case.

## Backport

The function is byte-identical on `v4.22.9-regtest`, so the source change
cherry-picks cleanly. The functional test needs trimming there: the 4.22.9 line
has no bip39/bip44 `createwallet` parameters, since that surface is Qt-only via
`createwalletwizard`, so the bip44 half of the test cannot be constructed over
RPC. That branch is where this bites hardest, since every RPC-created wallet
there is bip32.
