### PR TITLE
rpc: return HD info for bip32 wallets instead of throwing

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -716,10 +716,12 @@ RPCHelpMan gethdwalletinfo()
                 RPCResult{
                     RPCResult::Type::OBJ, "", "",
                     {
-                        {RPCResult::Type::STR, "hdseed", "The HD seed (bip32, in hex)"},
-                        {RPCResult::Type::STR, "mnemonic", "The mnemonic for this HD wallet (bip39, english words)"},
-                        {RPCResult::Type::STR, "mnemonicpassphrase", "The mnemonic passphrase for this HD wallet (bip39)"},
+                        {RPCResult::Type::STR, "hdseed", "The HD seed, in hex. For a bip39/bip44 wallet this is the binary seed derived from the mnemonic; for a plain bip32 wallet it is the seed key held in the keystore"},
+                        {RPCResult::Type::STR, "mnemonic", /* optional */ true, "The mnemonic for this HD wallet (bip39/bip44 wallets only)"},
+                        {RPCResult::Type::STR, "mnemonicpassphrase", /* optional */ true, "The mnemonic passphrase for this HD wallet (bip39/bip44 wallets only)"},
                         {RPCResult::Type::STR, "rootprivkey", "The bip32 root private key"},
+                        {RPCResult::Type::STR, "accountextendedprivkey", /* optional */ true, "The extended private key at m/44'/coin_type'/account' (bip44 wallets only)"},
+                        {RPCResult::Type::STR, "accountextendedpubkey", /* optional */ true, "The extended public key at m/44'/coin_type'/account' (bip44 wallets only)"},
                         {RPCResult::Type::STR, "extendedprivkey", "The bip32 extended private key"},
                         {RPCResult::Type::STR, "extendedpubkey", "The bip32 extended public key"}
                     }
@@ -732,7 +734,6 @@ RPCHelpMan gethdwalletinfo()
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!pwallet) return NullUniValue;
 
     CWallet& wallet = *pwallet;
     LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(wallet);
@@ -743,69 +744,80 @@ RPCHelpMan gethdwalletinfo()
 
     LOCK(spk_man.cs_KeyStore);
 
-    SecureVector vchSeed = spk_man.GetHDChain().vchSeed;
+    const CHDChain& hd_chain = spk_man.GetHDChain();
 
-    if (spk_man.GetHDChain().vchSeed.size() > 0) {
-        UniValue result(UniValue::VOBJ);
-        CExtKey masterKey;
-        CExtKey purposeKey;
-        CExtKey coinTypeKey;
-        CExtKey accountKey;
-        CExtKey chainKey;
-
-        masterKey.SetSeed(spk_man.GetHDChain().vchSeed.data(), spk_man.GetHDChain().vchSeed.size());
-
-        int nAccountIndex = 0;
-        bool internal = false;
-
-        if (spk_man.GetHDChain().vchMnemonic.size() > 0) {
-            SecureString ssMnemonic(spk_man.GetHDChain().vchMnemonic.begin(), spk_man.GetHDChain().vchMnemonic.end());
-            SecureString ssMnemonicPassphrase(spk_man.GetHDChain().vchMnemonicPassphrase.begin(), spk_man.GetHDChain().vchMnemonicPassphrase.end());
-
-            result.pushKV("mnemonic", ssMnemonic.c_str());
-            result.pushKV("mnemonicpassphrase", ssMnemonicPassphrase.c_str());
-        }
-
-        result.pushKV("hdseed", HexStr(spk_man.GetHDChain().vchSeed));
-        result.pushKV("rootprivkey", EncodeExtKey(masterKey));
-
-        if (!spk_man.GetHDChain().IsBip44()) {
-            // Derive new account keys
-            masterKey.Derive(accountKey, 0x80000000);
-
-            // Derive new chain keys
-            accountKey.Derive(chainKey, 0x80000000);
-
-        } else {
-            // derive m/purpose'
-            // use hardened derivation (child keys >= 0x80000000 are hardened after bip32)
-            masterKey.Derive(purposeKey, 44 | 0x80000000);
-
-            // derive m/purpose'/coin_type'
-            purposeKey.Derive(coinTypeKey, Params().ExtCoinType() | 0x80000000);
-
-            // derive m/purpose'/coin_type'/account'
-            coinTypeKey.Derive(accountKey, nAccountIndex | 0x80000000);
-
-            CExtPubKey accountpubKey = accountKey.Neuter();
-
-            result.pushKV("accountextendedprivkey", EncodeExtKey(accountKey));
-            result.pushKV("accountextendedpubkey", EncodeExtPubKey(accountpubKey));
-
-            // Derive new chain keys
-            accountKey.Derive(chainKey, (internal ? 1 : 0));
-        }
-
-
-        CExtPubKey chainpubKey = chainKey.Neuter();
-
-        result.pushKV("extendedprivkey", EncodeExtKey(chainKey));
-        result.pushKV("extendedpubkey", EncodeExtPubKey(chainpubKey));
-
-        return result;
+    if (!spk_man.IsHDEnabled()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet has no HD seed");
     }
 
-    return NullUniValue;
+    UniValue result(UniValue::VOBJ);
+    CExtKey masterKey;
+    CExtKey purposeKey;
+    CExtKey coinTypeKey;
+    CExtKey accountKey;
+    CExtKey chainKey;
+
+    // A bip39/bip44 wallet stores the binary seed derived from its mnemonic in vchSeed.
+    // A plain bip32 wallet leaves vchSeed empty: its seed is an ordinary key held in the
+    // keystore and referenced by seed_id. Mirrors the lookup in DeriveNewChildKey().
+    SecureVector vchSeed = hd_chain.vchSeed;
+    if (vchSeed.empty()) {
+        CKey seed;
+        if (!spk_man.GetKey(hd_chain.seed_id, seed)) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "HD seed not found in wallet");
+        }
+        vchSeed.assign(seed.begin(), seed.end());
+    }
+    masterKey.SetSeed(vchSeed.data(), vchSeed.size());
+
+    int nAccountIndex = 0;
+    bool internal = false;
+
+    if (hd_chain.vchMnemonic.size() > 0) {
+        SecureString ssMnemonic(hd_chain.vchMnemonic.begin(), hd_chain.vchMnemonic.end());
+        SecureString ssMnemonicPassphrase(hd_chain.vchMnemonicPassphrase.begin(), hd_chain.vchMnemonicPassphrase.end());
+
+        result.pushKV("mnemonic", ssMnemonic.c_str());
+        result.pushKV("mnemonicpassphrase", ssMnemonicPassphrase.c_str());
+    }
+
+    result.pushKV("hdseed", HexStr(vchSeed));
+    result.pushKV("rootprivkey", EncodeExtKey(masterKey));
+
+    if (!hd_chain.IsBip44()) {
+        // Derive new account keys
+        masterKey.Derive(accountKey, 0x80000000);
+
+        // Derive new chain keys
+        accountKey.Derive(chainKey, 0x80000000);
+
+    } else {
+        // derive m/purpose'
+        // use hardened derivation (child keys >= 0x80000000 are hardened after bip32)
+        masterKey.Derive(purposeKey, 44 | 0x80000000);
+
+        // derive m/purpose'/coin_type'
+        purposeKey.Derive(coinTypeKey, Params().ExtCoinType() | 0x80000000);
+
+        // derive m/purpose'/coin_type'/account'
+        coinTypeKey.Derive(accountKey, nAccountIndex | 0x80000000);
+
+        CExtPubKey accountpubKey = accountKey.Neuter();
+
+        result.pushKV("accountextendedprivkey", EncodeExtKey(accountKey));
+        result.pushKV("accountextendedpubkey", EncodeExtPubKey(accountpubKey));
+
+        // Derive new chain keys
+        accountKey.Derive(chainKey, (internal ? 1 : 0));
+    }
+
+
+    CExtPubKey chainpubKey = chainKey.Neuter();
+
+    result.pushKV("extendedprivkey", EncodeExtKey(chainKey));
+    result.pushKV("extendedpubkey", EncodeExtPubKey(chainpubKey));
+
+    return result;
 },
     };
 }


### PR DESCRIPTION

Backports the `gethdwalletinfo` fix from `develop` to the 4.22.9 line. Based on
`v4.22.9-regtest` at `e92efe4a63`, i.e. on top of the merged #482.

Fixes [RED-95](https://reddink.youtrack.cloud/issue/RED-95) on this branch.
Develop side is #483.

## The defect

`gethdwalletinfo` fails on any wallet that is not bip39/bip44. Reproduced below
on a v4.22.9 build of this branch, unmodified:

```
$ reddcoin-cli -regtest createwallet w1
{
  "name": "w1",
  "warning": ""
}

$ reddcoin-cli -regtest -rpcwallet=w1 gethdwalletinfo
error code: -1
rpc/util.cpp:577 (HandleRequest)
Internal bug detected: 'std::any_of(m_results.m_results.begin(), m_results.m_results.end(), [&ret](const RPCResult& res) { return res.MatchesType(ret); })'
```

The function declares `RPCResult::Type::OBJ` but returns `NullUniValue` when the
HD chain has no bip39 seed. `RPCHelpMan::HandleRequest` asserts the returned
value matches a declared result type, and `MatchesType` for `Type::OBJ` requires
`VOBJ`, so `CHECK_NONFATAL` throws.

`vchSeed` holds the binary seed derived from a mnemonic and is written in exactly
one place, `GenerateNewBip39Seed()`. A plain bip32 wallet goes through
`GenerateNewSeed()` -> `SetHDSeed()` -> `DeriveNewSeed()`, which never sets it.

**This branch is where it bites hardest.** `createwallet` here has no bip39/bip44
parameters at all, since that surface is Qt-only via `createwalletwizard`, so
every wallet created over RPC takes the failing path. Note the response above has
no `wallet_type` field, unlike develop. `CHECK_NONFATAL` is ungated, so the
shipped v4.22.9.3 binary is affected, not only `--enable-debug` builds.

## The fix

A bip32 wallet is not missing its seed, it just stores it differently: the seed
is an ordinary key in the keystore, referenced by `hd_chain.seed_id`. Look it up
the same way `DeriveNewChildKey()` already does:

```cpp
SecureVector vchSeed = hd_chain.vchSeed;
if (vchSeed.empty()) {
    CKey seed;
    if (!spk_man.GetKey(hd_chain.seed_id, seed)) {
        throw JSONRPCError(RPC_WALLET_ERROR, "HD seed not found in wallet");
    }
    vchSeed.assign(seed.begin(), seed.end());
}
masterKey.SetSeed(vchSeed.data(), vchSeed.size());
```

`hdseed`, `rootprivkey`, `extendedprivkey` and `extendedpubkey` are now returned
for every HD wallet. Mnemonic fields remain conditional on `vchMnemonic`, and
account-level keys remain conditional on the bip44 branch.

Also: the conditional fields are marked optional in `RPCResult`,
`accountextendedprivkey`/`accountextendedpubkey` are declared for the first time,
a wallet with no HD seed gets `RPC_WALLET_ERROR` instead of an internal-bug
report, and the unreachable `if (!pwallet) return NullUniValue;` is removed.

Most of the diff is re-indentation from unwrapping the outer `if`.

## Relationship to the develop commit

`src/wallet/rpcdump.cpp` is **byte-identical** to the post-fix file on `develop`,
verified by diffing against `76872161b6`. That is the entire diff here.

## Why there is no functional test

develop's version of this fix extends `wallet_createwallet.py`. That test cannot
be brought across, because the functional suite does not run on this branch at
all. Two independent, pre-existing blockers:

1. `test/functional/test_framework/test_framework.py:233` looks for
   `src/bitcoind`, not `src/reddcoind`. The node is never launched. develop
   renamed this at its line 238; the change was never backported.
2. The shared cache in `_initialize_chain()` builds a 199-block chain with plain
   `generatetoaddress`, while regtest `nLastPowHeight` is 89. Every block past 89
   would have to be staked, and v4.22.9 cannot stake on regtest. Any test that
   uses the cache, which includes `wallet_createwallet.py`, fails during setup.

Both are far outside the scope of an RPC fix. Adding a test that cannot execute
would be noise, so this PR is the source change only.

Coverage for this behaviour lives on develop in #483, which asserts both the
bip32 and bip44 response shapes. The change here is byte-identical to the one
under that test.

## Testing

* Reproduced on this branch by hand against an unmodified v4.22.9 build, output
  above.
* `src/wallet/rpcdump.cpp` syntax-checks clean here.
* The identical source change is built and passing on develop under #483.

Please confirm the post-fix behaviour by hand on a build of this branch before
merging: `createwallet` then `gethdwalletinfo` should return an object with
`hdseed` (64 hex characters, the 32-byte seed key), `rootprivkey`,
`extendedprivkey` and `extendedpubkey`, and no mnemonic or account-level fields.
