### PR TITLE
chainparams: enable BIP9 unknown-versionbit warnings on mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -372,7 +372,7 @@ public:
         consensus.POSVHeight = 1440;
         consensus.BIP66Height = 2189; // 84c24e7ec0023d9cf2ba50366f2a1806c30e7256606aaeb31ebd17a4c0a82e9b
         consensus.DonationHeight = 13260; // 7e62ee9c868aa8414909dff2c68d5f9a137d9eb8e9b93c28511cbf8a5cac7280
-        consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window
+        consensus.MinBIP9WarningHeight = 493920; // heightincb/cltv/csv/segwit activation (491904) + nMinerConfirmationWindow (2016)
         consensus.devScript = { CScript() << ParseHex("03d4b22ae69b0ff7554f4c343cd213d00fd5131466cc21d8ebfab97c52ec9a00c9") << OP_CHECKSIG, // Correct dev address
                                 CScript() << ParseHex("03081542439583f7632ce9ff7c8851b0e9f56d0a6db9a13645ce102a8809287d4f") << OP_CHECKSIG };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -79,7 +79,7 @@ public:
         consensus.POSVHeight = 260800;
         consensus.BIP66Height = 1564232; // a6e944cc38a0d8c7c5740569501e622ec2a011e7c9dd97a78e5fba40a45b8c61
         consensus.DonationHeight = 3382229; // 77ee468ea88227404a53bad63029a8d0aa58f9f6a470a076a2aa91c8494449ac
-        consensus.MinBIP9WarningHeight = std::numeric_limits<int>::max();
+        consensus.MinBIP9WarningHeight = 5572800; // heightincb/cltv activation (5558400) + nMinerConfirmationWindow (14400)
         consensus.devScript = { CScript() << ParseHex("03c8fc5c87f00bcc32b5ce5c036957f8befeff05bf4d88d2dcde720249f78d9313") << OP_CHECKSIG };
 
         /* pow specific */


### PR DESCRIPTION

On mainnet the BIP9 unknown-versionbit warning is unreachable dead code. If stakers begin signalling a versionbit this build does not recognise, a mainnet node raises no warning at all: no RPC `warnings` field, no Qt banner, no `-alertnotify`, no debug.log line.

Affects both v4.22.9 and current develop.

Fixes [RED-92](https://reddink.youtrack.cloud/issue/RED-92).

## Cause

`src/chainparams.cpp:82`, `CMainParams`:

```cpp
consensus.MinBIP9WarningHeight = std::numeric_limits<int>::max();
```

`WarningBitsConditionChecker::Condition()` (`src/validation.cpp:1683`) opens with:

```cpp
return pindex->nHeight >= params.MinBIP9WarningHeight && ...
```

At `INT_MAX` that clause can never hold, so the threshold state machine never leaves DEFINED for any of the 29 bits.

Introduced in `80b9c562c6`, the original Core-22 consensus migration, which replaced Bitcoin's `SegwitHeight + nMinerConfirmationWindow` with `INT_MAX`. It reads as migration fallout rather than a deliberate choice, and `git log -L82,82:src/chainparams.cpp` confirms it has never been revisited.

`src/warnings.cpp` and `.h` are byte-identical between v4.22.9 and develop, so the plumbing never regressed. Only the mainnet gate is wrong.

## Why it matters now

This is directly relevant to the mainnet CSV / BIP68 / BIP112 deployment work and to the PoSV3 REP program. During a real mainnet activation, node operators would get no signal that unrecognised rules are being signalled, and no `-alertnotify` hook would fire. That is precisely the scenario the mechanism exists for.

## Commit 1: mainnet

```
5,558,400 + 14,400 = 5,572,800
```

Activation height plus `nMinerConfirmationWindow`, the Core convention.

Verified safe by a full scan of all 6.56M blocks in a synced mainnet datadir (2026-08-13, tip 6,561,506):

* Only bits **0 and 1** have ever been signalled on mainnet. No unknown bit exists anywhere in Reddcoin's history. Versions observed: 1, 2, 3, 4, 5 (legacy), then `0x20000003` (142,291 blocks, bits 0+1), `0x20000002` (128), `0x20000000` (remainder).
* `heightincb` (bit 0) and `cltv` (bit 1) went ACTIVE at height **5,558,400**.
* Signalling stopped cleanly at exactly that height: 5,558,395 = `0x20000003`, 5,558,400 onward = `0x20000000`. Sampled every 5,000 blocks through 5,760,000, plus a straggler check immediately after activation.

So there is no post-activation signalling tail that could retroactively drive the warning checker to LOCKED_IN/ACTIVE and produce a false "Unknown new rules activated" once the gate is opened.

## Commit 2: testnet

```
491,904 + 2,016 = 493,920
```

All four testnet BIP9 deployments (`heightincb`, `cltv`, `csv`, `segwit`) activated at height 491,904.

Evidence from a synced testnet node (tip 1,893,001, `initialblockdownload: false`, `warnings: ""`): only bits 0 through 3 have ever been signalled, all known deployments. Versions observed: 1, 2, 4, 5 (legacy), then `0x20000000` (1,402,939), `0x2000000f` (37,998, bits 0-3), `0x20000003` (4,417), `0x20000001` (2,309), `0x20000007` (29). Clean cutover at activation: 491,903 = `0x2000000f`, 491,904 onward = `0x20000000`.

The old value of 483,840 came across from Bitcoin verbatim, comment included. On Reddcoin testnet that block is a legacy `nVersion=5` block, inside the mixed legacy/versionbits transition roughly 8k blocks before any deployment activated.

**To be clear on severity: testnet was never broken.** The gate at 483,840 was already below the activation height, so the mechanism was live and correctly reported no warning. This commit makes the value derived rather than inherited. It is a correctness-of-intent cleanup, not a bug fix, and it is kept separate from commit 1 for that reason.

## Two things that are not blockers

* Mainnet blocks genuinely carry the BIP9 top bits (`0x20000000`), so the `VERSIONBITS_TOP_MASK` clause passes. `CBlockHeader::CURRENT_VERSION=5` is only the default-constructor value; `src/miner.cpp:157` emits `ComputeBlockVersion()`.
* `IsProofOfStake()` is content-derived (`vtx[1]->IsCoinStake()`, `src/primitives/block.h:139-142`), not version-derived, so versionbits does not collide with the PoW/PoS discriminator. The `nVersion > POW_BLOCK_VERSION` branch at `src/primitives/block.h:114` only gates `vchBlockSig`, and `VERSIONBITS_NUM_BITS = 29` means nVersion can never go negative.

## Signet left alone

Signet keeps 483,840. Reddcoin signet has no chain history to derive a value from. If signet is not actually used, deleting the line and letting it default may be tidier than inventing a number. Reviewer's call.

## Scope and testing

`MinBIP9WarningHeight` has only two other references in the tree: the read at `src/validation.cpp:1683` and the field declaration at `src/consensus/params.h:96`. Nothing in `src/test/` or `test/functional/` asserts against it, so there is no test churn. Line 82 was the only `std::numeric_limits` use in `chainparams.cpp`, and the file has no explicit `#include <limits>` to clean up.

No new test accompanies this. `test/functional/feature_versionbits_warning.py` already covers the mechanism itself, is enabled, was PoS-adapted in `3b5e30cf61`, and passes on develop. It exercises regtest only, so it does not and cannot cover mainnet gating. A unit test asserting the mainnet constant would only restate the value; happy to add one if a regression guard against a future migration re-introducing `INT_MAX` is wanted.
