### PR TITLE
chainparams: enable BIP9 unknown-versionbit warnings on mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -363,7 +363,7 @@ public:
         consensus.POSVHeight = 1440;
         consensus.BIP66Height = 2189; // 84c24e7ec0023d9cf2ba50366f2a1806c30e7256606aaeb31ebd17a4c0a82e9b
         consensus.DonationHeight = 13260; // 7e62ee9c868aa8414909dff2c68d5f9a137d9eb8e9b93c28511cbf8a5cac7280
-        consensus.MinBIP9WarningHeight = 483840; // segwit activation height + miner confirmation window
+        consensus.MinBIP9WarningHeight = 493920; // heightincb/cltv/csv/segwit activation (491904) + nMinerConfirmationWindow (2016)
         consensus.devScript = { CScript() << ParseHex("03d4b22ae69b0ff7554f4c343cd213d00fd5131466cc21d8ebfab97c52ec9a00c9") << OP_CHECKSIG, // Correct dev address
                                 CScript() << ParseHex("03081542439583f7632ce9ff7c8851b0e9f56d0a6db9a13645ce102a8809287d4f") << OP_CHECKSIG };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -73,7 +73,7 @@ public:
         consensus.POSVHeight = 260800;
         consensus.BIP66Height = 1564232; // a6e944cc38a0d8c7c5740569501e622ec2a011e7c9dd97a78e5fba40a45b8c61
         consensus.DonationHeight = 3382229; // 77ee468ea88227404a53bad63029a8d0aa58f9f6a470a076a2aa91c8494449ac
-        consensus.MinBIP9WarningHeight = std::numeric_limits<int>::max();
+        consensus.MinBIP9WarningHeight = 5572800; // heightincb/cltv activation (5558400) + nMinerConfirmationWindow (14400)
         consensus.devScript = { CScript() << ParseHex("03c8fc5c87f00bcc32b5ce5c036957f8befeff05bf4d88d2dcde720249f78d9313") << OP_CHECKSIG };
 
         /* pow specific */


### PR DESCRIPTION

Backports the BIP9 unknown-versionbit warning height fix from `develop` to the
4.22.9 line. Based on `v4.22.9-regtest` at `57e58c5257`, on top of the merged
#484.

Fixes [RED-92](https://reddink.youtrack.cloud/issue/RED-92) on this branch.
Develop side is #485.

## Why this matters more here than on develop

On mainnet the BIP9 unknown-versionbit warning is unreachable dead code. If
stakers begin signalling a versionbit this build does not recognise, a mainnet
node raises no warning at all: no RPC `warnings` field, no Qt banner, no
`-alertnotify`, no debug.log line.

**This branch is the shipped release that people are actually running on
mainnet right now.** The upcoming CSV / BIP68 / BIP112 deployment work and the
PoSV3 REP program are precisely the scenario the mechanism exists for, and the
nodes that most need to raise the warning are v4.22.9.x nodes, not develop
builds.

## Cause

`src/chainparams.cpp:76`, `CMainParams`:

```cpp
consensus.MinBIP9WarningHeight = std::numeric_limits<int>::max();
```

`WarningBitsConditionChecker::Condition()` (`src/validation.cpp:1672` on this
branch) opens with:

```cpp
return pindex->nHeight >= params.MinBIP9WarningHeight && ...
```

At `INT_MAX` that clause can never hold, so the threshold state machine never
leaves DEFINED for any of the 29 bits.

Introduced in `80b9c562c6`, the original Core-22 consensus migration, which
replaced Bitcoin's `SegwitHeight + nMinerConfirmationWindow` with `INT_MAX`. It
reads as migration fallout rather than a deliberate choice.

## Commit 1: mainnet, 5,572,800

```
5,558,400 + 14,400 = 5,572,800
```

Activation height plus `nMinerConfirmationWindow`, the Core convention.
`consensus.nMinerConfirmationWindow` is 14400 on this branch
(`chainparams.cpp:94`), the same as develop, so the arithmetic carries over
unchanged.

Verified safe by a full scan of all 6.56M blocks in a synced mainnet datadir
(tip 6,561,506):

* Only bits **0 and 1** have ever been signalled on mainnet. No unknown bit
  exists anywhere in Reddcoin's history. Versions observed: 1, 2, 3, 4, 5
  (legacy), then `0x20000003` (142,291 blocks, bits 0+1), `0x20000002` (128),
  `0x20000000` (remainder).
* `heightincb` (bit 0) and `cltv` (bit 1) went ACTIVE at height **5,558,400**.
* Signalling stopped cleanly at exactly that height: 5,558,395 = `0x20000003`,
  5,558,400 onward = `0x20000000`. Sampled every 5,000 blocks through
  5,760,000, plus a straggler check immediately after activation.

So there is no post-activation signalling tail that could retroactively drive
the warning checker to LOCKED_IN/ACTIVE and produce a false "Unknown new rules
activated" once the gate is opened. This matters especially on a release
branch: opening the gate must not make existing nodes start shouting about
history.

## Commit 2: testnet, 493,920

```
491,904 + 2,016 = 493,920
```

All four testnet BIP9 deployments (`heightincb`, `cltv`, `csv`, `segwit`)
activated at height 491,904. `nMinerConfirmationWindow` is 2016 here
(`chainparams.cpp:385`), matching develop.

Evidence from a synced testnet node (tip 1,893,001, `warnings: ""`): only bits
0 through 3 have ever been signalled, all known deployments. Clean cutover at
activation: 491,903 = `0x2000000f`, 491,904 onward = `0x20000000`.

The old 483,840 came from Bitcoin verbatim, comment included. On Reddcoin
testnet that block is a legacy `nVersion=5` block, roughly 8k blocks before any
deployment activated.

**Testnet was never broken.** The old gate already sat below the activation
height, so the mechanism was live and correctly reported no warning. This
commit makes the value derived rather than inherited. It is kept as a separate
commit for exactly that reason: only commit 1 is a defect.

## Parity with develop

Both commits are clean cherry-picks of `5b0fb354a1` and `bf15345879` from #485.
The resulting constants are identical on both branches. Verified that the
surrounding machinery matches:

* `WarningBitsConditionChecker::Condition()` is identical.
* `nMinerConfirmationWindow` is 14400 mainnet / 2016 testnet on both, so both
  derived heights are the same number.
* Signet keeps 483,840 on both. Reddcoin signet has no chain history to derive
  a value from.
* Regtest already carries `0` with a 144-block window on this branch, matching
  develop. No change needed.

## Scope

`MinBIP9WarningHeight` has only two other references in the tree: the read at
`src/validation.cpp:1672` and the field declaration at
`src/consensus/params.h`. Nothing in `src/test/` or `test/functional/` asserts
against it.

Line 76 was the only `std::numeric_limits` use in `chainparams.cpp`, and the
file has no explicit `#include <limits>` to clean up.

Note this changes a field on the `consensus` struct but **not** a consensus
rule. `MinBIP9WarningHeight` gates only the warning checker, which emits
warnings rather than affecting block validity, so it cannot split a patched
node from an unpatched one.

## Testing

`src/chainparams.cpp` syntax-checks clean against this branch's depends. The
identical change is built and tested on develop under #485.

No new test. The functional suite does not run on this branch at all, and
mainnet gating is not reachable from regtest in any case.
