### PR TITLE
wallet: abandon orphaned coinstakes on block disconnect, not on every block template

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -177,9 +177,6 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     if (pwallet)
     {
-        // flush orphaned coinstakes
-        pwallet->AbandonOrphanedCoinstakes();
-
         // attempt to find a coinstake
         *pfPoSCancel = true;
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1134,6 +1134,12 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
     LOCK(cs_wallet);
 
     WalletBatch batch(GetDatabase());
+    return AbandonTransaction(batch, hashTx);
+}
+
+bool CWallet::AbandonTransaction(WalletBatch& batch, const uint256& hashTx)
+{
+    AssertLockHeld(cs_wallet);
 
     std::set<uint256> todo;
     std::set<uint256> done;
@@ -1318,6 +1324,38 @@ void CWallet::blockDisconnected(const CBlock& block, int height)
     m_last_block_processed = block.hashPrevBlock;
     for (const CTransactionRef& ptx : block.vtx) {
         SyncTransaction(ptx, {CWalletTx::Status::UNCONFIRMED, /* block height */ 0, /* block hash */ {}, /* index */ 0});
+    }
+
+    // A coinstake of ours in a block that just left the chain is orphaned for
+    // good: coinstakes are never accepted into the mempool, so nothing will
+    // reconfirm it on this chain and it would sit UNCONFIRMED forever. While it
+    // does, CWallet::IsSpent still counts it as spending its input, keeping that
+    // coin out of AvailableCoins and so out of reach of the staker. Abandon it
+    // here to return the input to the wallet.
+    //
+    // This is the only way a coinstake becomes orphaned while we are running, so
+    // it replaces the full mapWallet sweep that used to run before every block
+    // template. If a deeper reorg later remines the coinstake, AddToWallet
+    // overwrites the abandoned status when the confirmation arrives.
+    std::vector<uint256> orphaned;
+    for (const CTransactionRef& ptx : block.vtx) {
+        if (!ptx->IsCoinStake()) continue;
+        auto it = mapWallet.find(ptx->GetHash());
+        if (it == mapWallet.end()) continue;
+        const CWalletTx& wtx = it->second;
+        if (wtx.GetDepthInMainChain() != 0 || wtx.isAbandoned()) continue;
+        orphaned.push_back(ptx->GetHash());
+    }
+    if (!orphaned.empty()) {
+        // One database transaction for the whole block, not one per coinstake.
+        WalletBatch batch(GetDatabase());
+        for (const uint256& wtxid : orphaned) {
+            LogPrint(BCLog::STAKE, "Abandoning coinstake wtx %s orphaned by disconnect of block %s\n",
+                     wtxid.ToString(), block.GetHash().ToString());
+            if (!AbandonTransaction(batch, wtxid)) {
+                LogPrint(BCLog::STAKE, "Failed to abandon coinstake tx %s\n", wtxid.ToString());
+            }
+        }
     }
 }
 
@@ -1755,6 +1793,7 @@ void CWallet::ReacceptWalletTransactions()
     if (!fBroadcastTransactions)
         return;
     std::map<int64_t, CWalletTx*> mapSorted;
+    std::vector<uint256> to_abandon;
 
     // Sort pending wallet transactions based on their initial wallet insertion order
     for (std::pair<const uint256, CWalletTx>& item : mapWallet) {
@@ -1766,10 +1805,19 @@ void CWallet::ReacceptWalletTransactions()
 
         if (nDepth == 0 && !wtx.isAbandoned()) {
             if (wtx.IsCoinBase() || wtx.IsCoinStake()) {
-                LogPrintf("Abandoning wtx %s\n", wtx.GetHash().ToString());
-                AbandonTransaction(wtxid);
+                to_abandon.push_back(wtxid);
             } else
                 mapSorted.insert(std::make_pair(wtx.nOrderPos, &wtx));
+        }
+    }
+
+    // Abandon under a single batch: one database transaction for the whole set
+    // rather than one per transaction.
+    if (!to_abandon.empty()) {
+        WalletBatch batch(GetDatabase());
+        for (const uint256& wtxid : to_abandon) {
+            LogPrintf("Abandoning wtx %s\n", wtxid.ToString());
+            AbandonTransaction(batch, wtxid);
         }
     }
 
@@ -1784,15 +1832,26 @@ void CWallet::ReacceptWalletTransactions()
 void CWallet::AbandonOrphanedCoinstakes()
 {
     LOCK(cs_wallet);
-    for (std::pair<const uint256, CWalletTx>& item : mapWallet) {
+
+    // Collect first, then abandon, so the whole sweep costs one database
+    // transaction rather than one per orphan. AbandonTransaction also mutates
+    // mapWallet entries, which is not safe to do while iterating it.
+    std::vector<uint256> orphaned;
+    for (const std::pair<const uint256, CWalletTx>& item : mapWallet) {
         const uint256& wtxid = item.first;
-        CWalletTx& wtx = item.second;
+        const CWalletTx& wtx = item.second;
         assert(wtx.GetHash() == wtxid);
         if (wtx.GetDepthInMainChain() == 0 && !wtx.isAbandoned() && wtx.IsCoinStake()) {
-            LogPrint(BCLog::STAKE, "Abandoning coinstake wtx %s\n", wtx.GetHash().ToString());
-            if (!AbandonTransaction(wtxid)) {
-                LogPrint(BCLog::STAKE, "Failed to abandon coinstake tx %s\n", wtx.GetHash().ToString());
-            }
+            orphaned.push_back(wtxid);
+        }
+    }
+    if (orphaned.empty()) return;
+
+    WalletBatch batch(GetDatabase());
+    for (const uint256& wtxid : orphaned) {
+        LogPrint(BCLog::STAKE, "Abandoning coinstake wtx %s\n", wtxid.ToString());
+        if (!AbandonTransaction(batch, wtxid)) {
+            LogPrint(BCLog::STAKE, "Failed to abandon coinstake tx %s\n", wtxid.ToString());
         }
     }
 }
@@ -2970,6 +3029,14 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
 void CWallet::postInitProcess()
 {
     LOCK(cs_wallet);
+
+    // Return the inputs of any coinstake this wallet loaded already orphaned, so
+    // the staker can spend them again. While we are running, blockDisconnected()
+    // abandons them as the disconnect arrives; this covers a wallet that was
+    // offline across the reorg. LoadToWallet() has already reset such a coinstake
+    // to UNCONFIRMED by resolving its recorded block against the active chain, so
+    // it is at depth zero here for the sweep to find.
+    AbandonOrphanedCoinstakes();
 
     // Add wallet transactions that aren't already in a block to mempool
     // Do this here as mempool requires genesis block to be loaded

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -822,6 +822,12 @@ public:
     /* Mark a transaction (and it in-wallet descendants) as abandoned so its inputs may be respent. */
     bool AbandonTransaction(const uint256& hashTx);
 
+    /* As above, but writing through a caller-supplied batch so several
+     * transactions can be abandoned in a single database transaction. Abandoning
+     * N transactions one at a time costs N commits, and on BDB each commit can
+     * involve a log write and flush. */
+    bool AbandonTransaction(WalletBatch& batch, const uint256& hashTx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     /** Mark a transaction as replaced by another transaction (e.g., BIP 125). */
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
@@ -848,7 +854,10 @@ public:
     /* Returns true if the wallet can give out new addresses. This means it has keys in the keypool or can generate new keys */
     bool CanGetAddresses(bool internal = false) const;
 
-    /* Function that will remove potentially abandoned coinstakes, returning the input to the wallet. */
+    /* Sweep the whole wallet for orphaned coinstakes, returning their inputs to
+     * the wallet. Coinstakes left behind by a reorg are normally abandoned as
+     * the disconnect arrives, in blockDisconnected(); this covers the ones a
+     * wallet loads already orphaned, having been offline across the reorg. */
     void AbandonOrphanedCoinstakes();
 
     /**


### PR DESCRIPTION
Backport of #474 to the 4.22.9 release line.

## The problem, on this branch

`AbandonOrphanedCoinstakes` is called unconditionally from `BlockAssembler::CreateNewBlock` (src/miner.cpp:181), so it sweeps the whole of `mapWallet` under `cs_wallet` before every proof-of-stake block template. The staker loop calls `CreateNewBlock` every `pos_timio` ms, which is `DEFAULT_STAKETIMIO(500) + 30 * sqrt(nUTXOs)`, so a wallet with a few hundred stakeable outputs pays for the scan roughly once a second, on top of every `getblocktemplate` and `generatetoaddress` call. Each orphan it finds is abandoned through its own `AbandonTransaction`, which opens its own `WalletBatch` and therefore its own database write transaction.

There is a user-visible half as well, not just latency. Because the sweep only ever ran from the block-template path, a wallet that is not staking never abandoned an orphaned coinstake while it was running. `CWallet::IsSpent` keeps counting the depth-zero unabandoned coinstake as spending its input, so `AvailableCoins` withholds that coin and the spendable balance reads short after a reorg until the node is restarted.

The shipped 4.22.9.x binaries are built from this branch, so released wallets still carry this.

## What this does

- Drops the sweep from `CreateNewBlock`.
- Abandons the disconnected block's own coinstakes from `CWallet::blockDisconnected`, which is the only way a coinstake becomes orphaned while the node is running (coinstakes never enter the mempool, so nothing reconfirms them on this chain). This runs on the validation interface thread rather than between an RPC and its block template, and it also fixes the non-staking case above.
- Adds an `AbandonTransaction(WalletBatch&, const uint256&)` overload so a sweep costs one database transaction rather than one per orphan, and uses it from `AbandonOrphanedCoinstakes` and `ReacceptWalletTransactions`.
- Keeps `AbandonOrphanedCoinstakes` and calls it once from `postInitProcess`, for a wallet that loaded with coinstakes already orphaned across a reorg it was offline for. `LoadToWallet` has already resolved each recorded block against the active chain and reset anything no longer on it to `UNCONFIRMED`, which is the depth-zero state the sweep acts on.

## Deliberately not ported from #474

- **The `m_orphaned_coinstakes_swept` flag and the `updatedBlockTip` re-run.** Those exist on `develop` because its `ReacceptWalletTransactions` skips abandonment during initial block download, so its `postInitProcess` sweep has to be gated and retried once IBD ends. This branch has no such guard: `ReacceptWalletTransactions` abandons every depth-zero coinbase and coinstake unconditionally, two lines after the new call, which is a strict superset of what the sweep touches. The gate would buy nothing here and the flag would be dead state.
- **The `interfaces/staking.h` and `wallet/staking.cpp` hunks.** That seam is the RED-46 staking decoupling, which is not on this branch; here `miner.cpp` calls `pwallet->` directly.
- **`test/functional/wallet_orphanedreward.py` and `wallet_reorg_stale_coinstake.py`.** No functional test can run on `v4.22.9-regtest`: the framework hardcodes `src/bitcoind` and the block cache needs staking above `nLastPowHeight = 89`, which 4.22.9 cannot do on regtest. Coverage for the change itself stays on the develop PR.

The one behavioural difference the unconditional `postInitProcess` call introduces is under `-walletbroadcast=0`, where `ReacceptWalletTransactions` returns early. That is precisely the gap being closed, and a coinstake abandoned there because its block had not arrived yet is re-confirmed by `AddToWallet`, which overwrites `m_confirm.status` whenever it differs.

## Testing

Built and run as `reddcoin-qt` on a live, fully synced mainnet staking node (~575 stakeable UTXOs).

**The new path was exercised directly.** With staking disabled so the node could not fork, `invalidateblock` was used to force a single-block disconnect of a block this wallet had staked (height 6587666, containing our coinstake `384995171cdb6c62...`):

```
2026-08-31T06:00:36Z Abandoning coinstake wtx 384995171cdb6c62d153e069581f3fb0c225a57e64db118f79f80bcfb632913f
                     orphaned by disconnect of block a0ff0f091d5f1cde5baee9d120ecb49e704ea6da1d0d9ca3560a9a0080a264c7
```

That message string exists only in the new `blockDisconnected` code. Wallet state:

| | before | disconnected | after `reconsiderblock` |
|---|---|---|---|
| confirmations | 1 | 0 | 3 |
| `abandoned` | false | true | false |
| category | `stake` | `stake-orphan` | `stake` |

The last column confirms that abandoning is not a terminal state: `AddToWallet` restores the coinstake when the block reconnects.

**Wiring verified against the built binary** with `objdump`:

- `CWallet::AbandonOrphanedCoinstakes()` has exactly one call site, `CWallet::postInitProcess()`. It is no longer reachable from `BlockAssembler::CreateNewBlock`.
- `AbandonTransaction(WalletBatch&, const uint256&)` is called from exactly four places: the public overload, `ReacceptWalletTransactions`, `AbandonOrphanedCoinstakes`, `blockDisconnected`.
- The `abandontransaction` RPC and `WalletImpl::abandonTransaction` still bind the single-argument overload, so the new overload captured no existing caller.

**Input-return invariant**, checked read-only across 40 of the wallet's 321 abandoned depth-zero orphaned coinstakes by cross-referencing each staked input against `listunspent` and `gettxout`: 38 genuinely spent on-chain and correctly absent, 0 still in the UTXO set but withheld by the wallet.

A note for anyone repeating that last check: `listunspent` is not a usable probe here. Reddcoin stake inputs are P2PK, and 0 of this wallet's 575 `listunspent` entries are P2PK, so looking there for a freed stake input returns nothing whether or not the coin came back. Use `gettxout` against the wallet's own spend set instead.

No functional test, for the reason given above. The node was fully restored afterwards: block back on the main chain, staking re-enabled, log categories reset.
