### PR TITLE
build: ignore the bench_reddcoin binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/reddcoin-wallet
 src/test/fuzz/fuzz
 src/test/test_reddcoin
 src/qt/test/test_reddcoin-qt
+src/bench/bench_reddcoin
 
 # autoreconf
 Makefile.in


### PR DESCRIPTION
`src/bench/bench_reddcoin` is a build output, but unlike the other built binaries it was never added to `.gitignore`. The neighbouring entries already cover the rest:

```
src/reddcoind
src/reddcoin-cli
...
src/test/fuzz/fuzz
src/test/test_reddcoin
src/qt/test/test_reddcoin-qt
```

So after any build that includes the benchmarks, `bench_reddcoin` shows up as untracked in every `git status`. On this machine that is a 258MB binary sitting one `git add -A` away from being committed.

One line, added next to the existing binary entries.
