### PR TITLE
pos: fix the staking thread lifecycle

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -571,7 +571,7 @@ static bool ProcessBlockFound(const CBlock* pblock, ChainstateManager* chainman,
     return true;
 }
 
-void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running)
+void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt)
 {
     LogPrintf("CPUMiner [%d] started for proof-of-stake wallet [%s]\n", thread_id, staking_wallet.getName());
     util::ThreadRename(strprintf("staker-%d", thread_id));
@@ -609,6 +609,15 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
         return;
     }
 
+    // Every reason this thread should return. The waiting loops below can run
+    // for as long as the condition they wait on lasts, which for a locked wallet
+    // is indefinitely, so each of them has to check all of these and not just
+    // the shutdown flag: otherwise disabling staking for this wallet cannot
+    // stop it, and neither can the node-wide switch.
+    const auto stop_requested = [&]() {
+        return ShutdownRequested() || !running || !staking_wallet.getEnableStaking();
+    };
+
     try {
         bool fNeedToClear = false;
         while (running) {
@@ -617,7 +626,7 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
             if (ShutdownRequested())
                 return;
             while (staking_wallet.isLocked()) {
-                if (ShutdownRequested())
+                if (stop_requested())
                     return;
                 if (strMintWarning != strMintMessage) {
                     strMintWarning = strMintMessage;
@@ -625,7 +634,7 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
                     staking_wallet.notifyStakingStatusChanged();
                 }
                 fNeedToClear = true;
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
+                if (!interrupt.sleep_for(std::chrono::seconds(2)))
                     return;
             }
 
@@ -633,7 +642,7 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
             // on an obsolete chain. In regtest mode we expect to fly solo.
             bool isRegTest = Params().NetworkIDString() == CBaseChainParams::REGTEST;
             while(connman == nullptr || (!isRegTest && (connman->GetNodeCount(ConnectionDirection::Both) == 0 || chainman->ActiveChainstate().IsInitialBlockDownload()))) {
-                if (ShutdownRequested())
+                if (stop_requested())
                     return;
                 LogPrintf("Staker thread [%d]: sleeps while IBD at %d\n", thread_id, chainman->ActiveChain().Tip()->nHeight);
                 if (strMintWarning != strMintSyncMessage) {
@@ -642,13 +651,13 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
                     staking_wallet.notifyStakingStatusChanged();
                 }
                 fNeedToClear = true;
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
+                if (!interrupt.sleep_for(std::chrono::seconds(2)))
                     return;
             }
 
             while (!isRegTest && GuessVerificationProgress(Params().TxData(), chainman->ActiveChain().Tip()) < 0.9996)
             {
-                if (ShutdownRequested())
+                if (stop_requested())
                     return;
                 LogPrintf("Staker thread [%d]: sleeps while sync at %f\n", thread_id, GuessVerificationProgress(Params().TxData(), chainman->ActiveChain().Tip()));
                 if (strMintWarning != strMintSyncMessage) {
@@ -657,7 +666,7 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
                     staking_wallet.notifyStakingStatusChanged();
                 }
                 fNeedToClear = true;
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
+                if (!interrupt.sleep_for(std::chrono::seconds(2)))
                         return;
             }
             if (fNeedToClear) {
@@ -692,7 +701,7 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
             {
                 if (fPoSCancel == true)
                 {
-                    if (!connman->interruptNet.sleep_for(std::chrono::milliseconds(pos_timio)))
+                    if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
                         return;
                     continue;
                 }
@@ -700,7 +709,7 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
                 uiInterface.NotifyAlertChanged();
                 staking_wallet.notifyStakingStatusChanged();
                 LogPrintf("Staker thread [%d]: Error in ReddcoinMiner: Keypool ran out, please call keypoolrefill before restarting the mining thread\n", thread_id);
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(10)))
+                if (!interrupt.sleep_for(std::chrono::seconds(10)))
                    return;
 
                 return;
@@ -727,11 +736,11 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
                 // Rest after successful block to preserve resources
                 // Use shorter interval for regtest (10 second) vs mainnet/testnet (60 seconds)
                 int nStakeInterval = Params().NetworkIDString() == CBaseChainParams::REGTEST ? 10 : 60;
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(nStakeInterval + GetRand(4))))
+                if (!interrupt.sleep_for(std::chrono::seconds(nStakeInterval + GetRand(4))))
                     return;
             }
 
-            if (!connman->interruptNet.sleep_for(std::chrono::milliseconds(pos_timio)))
+            if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
                 return;
 
             continue;

--- a/src/miner.h
+++ b/src/miner.h
@@ -27,6 +27,7 @@
 
 class CConnman;
 class ChainstateManager;
+class CThreadInterrupt;
 namespace interfaces {
 class Chain;
 class StakingWallet;
@@ -232,8 +233,12 @@ void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
 /** Staking loop for one wallet. The caller owns staking_wallet and must keep it
  *  alive for the whole call: it holds the destination reserved for coinstake
- *  rewards across every iteration. */
-void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running);
+ *  rewards across every iteration.
+ *
+ *  Every sleep in the loop waits on interrupt, so signalling it returns this
+ *  thread promptly instead of after the current sleep, which is up to a minute
+ *  once a block has been found. The caller owns it and must outlive the call. */
+void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt);
 
 void InitStakeWallet();
 void SetStakingActive(bool active);

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -109,7 +109,6 @@ void CStakeman::LaunchStakingThreads()
     // Start threads
     //
     uiInterface.InitMessage(_("Starting staking threads…").translated);
-    interruptStake.reset();
 
     for (const auto& wallet : stakingSupport->getStakingWallets()) {
         if (!wallet->getEnableStaking()) {
@@ -122,7 +121,6 @@ void CStakeman::LaunchStakingThreads()
             continue;
         }
         StakeWalletAdd(wallet->getName());
-        LogPrintf("CStakeman::%s Launching wallet..  [%s]\n", __func__, wallet->getName());
     }
 
     uiInterface.InitMessage(_("Staking threads started…").translated);
@@ -156,24 +154,47 @@ bool CStakeman::Start(CScheduler& scheduler, const Options& stakeOptions)
 void CStakeman::Interrupt()
 {
     LogPrintf("CStakeman::%s\n", __func__);
-    interruptStake();
+    LOCK(cs_threadStakeMinterGroup);
+    for (const auto& staker : m_stakers) {
+        (*staker.second.interrupt)();
+    }
 }
 
 void CStakeman::StopThreads()
 {
     LogPrintf("CStakeman::%s\n", __func__);
+
+    // Take the threads out of the map first so that the joins below happen with
+    // the lock released: a staking pass can take a while to notice it has been
+    // interrupted, and GetStakingThreadCount() should not block behind it.
+    std::unordered_map<std::string, StakerThread> stakers;
     {
         LOCK(cs_threadStakeMinterGroup);
-        for (std::thread& t : threadStakeMinterGroup) {
-            LogPrintf("CStakeman::%s Stopping thread %i!\n", __func__, t.get_id());
-            if (t.joinable()) t.join();
-        }
-        threadStakeMinterGroup.clear();
-        tm_.clear();
+        stakers.swap(m_stakers);
+    }
+
+    // Signal every thread before joining any of them, so they wind down in
+    // parallel rather than one sleep at a time.
+    for (const auto& staker : stakers) {
+        (*staker.second.interrupt)();
+    }
+    for (auto& staker : stakers) {
+        LogPrintf("CStakeman::%s Stopping thread %i!\n", __func__, staker.second.thread.get_id());
+        if (staker.second.thread.joinable()) staker.second.thread.join();
     }
 
     uiInterface.NotifyNodeStakingActiveChanged(false);
     LogPrintf("CStakeman::%s done!\n", __func__);
+}
+
+int CStakeman::GetStakingThreadCount()
+{
+    LOCK(cs_threadStakeMinterGroup);
+    int count = 0;
+    for (const auto& staker : m_stakers) {
+        if (!staker.second.finished->load()) ++count;
+    }
+    return count;
 }
 
 void CStakeman::SetStakingActive(bool active)
@@ -202,13 +223,36 @@ void CStakeman::StakeWalletAdd(const std::string& walletname)
         return;
     }
 
+    auto interrupt = std::make_shared<CThreadInterrupt>();
+    auto finished = std::make_shared<std::atomic<bool>>(false);
+
     {
         LOCK(cs_threadStakeMinterGroup);
-        threadStakeMinterGroup.push_back(
-            std::thread(&util::TraceThread, "staker", [this, wallet, chainManager = chainManager, connManager = connManager, mempool = memPool]() {
-                tm_[wallet->getName()] = std::this_thread::get_id();
-                ThreadStaker(wallet, chainManager, connManager, mempool, std::this_thread::get_id(), fStakingActive);
-            }));
+
+        auto it = m_stakers.find(walletname);
+        if (it != m_stakers.end()) {
+            if (!it->second.finished->load()) {
+                // Already staking. A second thread for one wallet would search
+                // the same coins twice, and only one of the two would ever be
+                // reachable again for stopping.
+                LogPrintf("CStakeman::%s [%s] is already staking\n", __func__, walletname);
+                return;
+            }
+            // The previous thread returned on its own (an exhausted keypool, a
+            // runtime error). Reap it before it is replaced; it has finished, so
+            // this join does not wait.
+            if (it->second.thread.joinable()) it->second.thread.join();
+            m_stakers.erase(it);
+        }
+
+        StakerThread staker;
+        staker.interrupt = interrupt;
+        staker.finished = finished;
+        staker.thread = std::thread(&util::TraceThread, "staker", [wallet, interrupt, finished, this, chainManager = chainManager, connManager = connManager, mempool = memPool]() {
+            ThreadStaker(wallet, chainManager, connManager, mempool, std::this_thread::get_id(), fStakingActive, *interrupt);
+            *finished = true;
+        });
+        m_stakers.emplace(walletname, std::move(staker));
     }
 
     LogPrintf("CStakeman::%s Launching wallet..  [%s]\n", __func__, walletname);
@@ -217,29 +261,34 @@ void CStakeman::StakeWalletAdd(const std::string& walletname)
 
 void CStakeman::StakeWalletRemove(const std::string& walletname)
 {
-    ThreadMap::const_iterator it = tm_.find(walletname);
-    if (it != tm_.end()) {
-        {
-            LOCK(cs_threadStakeMinterGroup);
-            auto iter = std::find_if(threadStakeMinterGroup.begin(), threadStakeMinterGroup.end(), [=](std::thread& t) { return (t.get_id() == it->second); });
-            if (iter != threadStakeMinterGroup.end()) {
-                iter->join();
-                threadStakeMinterGroup.erase(iter);
-            }
+    StakerThread staker;
+    {
+        LOCK(cs_threadStakeMinterGroup);
+        auto it = m_stakers.find(walletname);
+        if (it == m_stakers.end()) {
+            return;
         }
-
-        tm_.erase(walletname);
-        LogPrintf("CStakeman::%s Thread %s removed\n", __func__, walletname);
-        uiInterface.NotifyWalletStakingActiveChanged(false);
+        staker = std::move(it->second);
+        m_stakers.erase(it);
     }
+
+    // Wake the thread before joining it: it spends nearly all its time asleep,
+    // and an uninterrupted sleep runs for a minute after a block is found. The
+    // join is outside the lock so that the `staking` RPC stays responsive while
+    // this thread winds down.
+    (*staker.interrupt)();
+    if (staker.thread.joinable()) staker.thread.join();
+
+    LogPrintf("CStakeman::%s Thread %s removed\n", __func__, walletname);
+    uiInterface.NotifyWalletStakingActiveChanged(false);
 }
 
-void CStakeman::ThreadStaker(std::shared_ptr<interfaces::StakingWallet> staking_wallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running)
+void CStakeman::ThreadStaker(std::shared_ptr<interfaces::StakingWallet> staking_wallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt)
 {
     LogPrintf("CStakeman::%s\n", __func__);
     LogPrintf("CStakeman::%s Staking thread [%s] starting\n", __func__, thread_id);
     try {
-        PoSMiner(*staking_wallet, chainman, connman, mempool, thread_id, running);
+        PoSMiner(*staking_wallet, chainman, connman, mempool, thread_id, running, interrupt);
     } catch (std::exception& e) {
         PrintExceptionContinue(&e, "ThreadStakeMinter()");
     } catch (...) {

--- a/src/staker.h
+++ b/src/staker.h
@@ -60,32 +60,36 @@ public:
     };
     bool GetNodeStakingActive() const { return fStakingActive; };
     void SetStakingActive(bool active);
-    int GetStakingThreadCount()
-    {
-        LOCK(cs_threadStakeMinterGroup);
-        return threadStakeMinterGroup.size();
-    };
-    void static ThreadStaker(std::shared_ptr<interfaces::StakingWallet> staking_wallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running);
+    //! Number of staking threads that are still running. A thread that returned
+    //! on its own is not counted, even though it has not been joined yet.
+    int GetStakingThreadCount();
+    void static ThreadStaker(std::shared_ptr<interfaces::StakingWallet> staking_wallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt);
     void StakeWalletAdd(const std::string& walletname);
     void StakeWalletRemove(const std::string& walletname);
-
-    /**
-     * This is signaled when staking activity should cease.
-     */
-    CThreadInterrupt interruptStake;
 
 private:
     std::atomic<bool> fStakingActive{true};
 
-    std::vector<std::thread> threadStakeMinterGroup GUARDED_BY(cs_threadStakeMinterGroup);
+    //! One staking thread per wallet. Keyed by wallet name so that the entry is
+    //! created by whoever launches the thread, rather than by the thread itself
+    //! once it has started running: a stop that arrives in between would
+    //! otherwise find nothing to stop and leave the thread behind.
+    struct StakerThread {
+        std::thread thread;
+        //! Signalled to wake this thread out of a sleep so it can stop. Held by
+        //! shared_ptr because the thread's callable outlives this entry.
+        std::shared_ptr<CThreadInterrupt> interrupt;
+        //! Set by the thread as it returns, so a thread that stopped on its own
+        //! is not reported as running and is reaped before it is replaced.
+        std::shared_ptr<std::atomic<bool>> finished;
+    };
+
+    std::unordered_map<std::string, StakerThread> m_stakers GUARDED_BY(cs_threadStakeMinterGroup);
     mutable RecursiveMutex cs_threadStakeMinterGroup;
 
     //! Launch a staking thread for each loaded, staking-enabled, stake-capable
     //! wallet. Shared by both Start() overloads.
     void LaunchStakingThreads();
-
-    typedef std::unordered_map<std::string, std::thread::id> ThreadMap;
-    ThreadMap tm_;
 
     CClientUIInterface* clientInterface;
     ChainstateManager* chainManager;

--- a/test/functional/rpc_staking.py
+++ b/test/functional/rpc_staking.py
@@ -19,6 +19,10 @@ records the intent on one wallet and adds or removes it from the staking set.
 A wallet only actually stakes when both are on, which is what the interaction
 at the end of this test pins down.
 
+The last case covers the thread behind the switches rather than the flag in
+front of it. Reporting the flag is not enough: a wallet whose staking thread
+has ended reports `setstaking` true and stakes nothing.
+
 Staking is left off at every point where the test asserts on chain height,
 since a staking thread that finds a kernel would move the tip underneath it.
 """
@@ -50,8 +54,10 @@ class StakingRpcTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         # Start with staking off so the tip stays put; the switches are then
-        # exercised explicitly.
-        self.extra_args = [["-staking=0"]]
+        # exercised explicitly. A staking thread reserves a destination for its
+        # coinstake rewards as it starts and throws if the keypool cannot cover
+        # it, which would end the thread the lifecycle case is watching.
+        self.extra_args = [["-staking=0", "-keypool=100"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -163,11 +169,103 @@ class StakingRpcTest(BitcoinTestFramework):
         node.staking(False)
         assert_equal(node.staking()["enabled"], False)
 
+    def test_staking_thread_lifecycle(self):
+        """setstaking has to be able to start a thread it stopped.
+
+        RED-102: turning staking off for a wallet ended its thread, and turning
+        it back on set the flag without starting a new one, so the node stopped
+        staking with nothing reporting an error. thread_count claimed a thread
+        was running the whole time, because a thread that had returned was
+        still counted.
+
+        This runs last: it is the only case that leaves both switches on, so
+        from here the node is free to move its own tip.
+        """
+        node = self.nodes[0]
+
+        node.setstaking(False)
+        node.staking(True)
+        assert_equal(node.staking()["thread_count"], 0)
+
+        self.log.info("setstaking(True) starts a thread for the wallet")
+        node.setstaking(True)
+        status = node.staking()
+        assert_equal(status["thread_count"], 1)
+        assert_equal(status["running"], True)
+
+        self.log.info("setstaking(False) stops it and stops counting it")
+        node.setstaking(False)
+        status = node.staking()
+        assert_equal(status["thread_count"], 0)
+        assert_equal(status["running"], False)
+
+        self.log.info("setstaking(True) starts a replacement thread")
+        node.setstaking(True)
+        assert_equal(node.staking()["thread_count"], 1)
+
+        self.log.info("Enabling an already staking wallet does not add a second thread")
+        with node.assert_debug_log(expected_msgs=["is already staking"]):
+            node.setstaking(True)
+        assert_equal(node.staking()["thread_count"], 1)
+
+        self.log.info("The node-wide switch stops the thread as well")
+        node.staking(False)
+        assert_equal(node.staking()["thread_count"], 0)
+
+        self.log.info("With the node-wide switch off, setstaking starts nothing")
+        node.setstaking(True)
+        assert_equal(node.staking()["thread_count"], 0)
+
+        node.setstaking(False)
+
+    def test_locked_wallet_thread_can_be_stopped(self):
+        """A thread waiting for its wallet to be unlocked still has to stop.
+
+        The wait loops checked only the shutdown flag, so a thread parked on a
+        locked wallet ignored both switches and the join that stops it never
+        returned. That hung the RPC that asked for the stop, and with it the
+        `staking` RPC behind the same lock, including the node-wide
+        `staking false` that RED-102 documents as the way to recover.
+
+        Without a fix this case does not fail, it hangs, and the framework's
+        RPC timeout is what ends it.
+        """
+        node = self.nodes[0]
+
+        # A wallet of its own, encrypted before it ever stakes: encryptwallet
+        # reloads the wallet, and a running thread holds the one it started on.
+        node.createwallet(wallet_name="locked_staker")
+        wallet = node.get_wallet_rpc("locked_staker")
+        wallet.encryptwallet("passphrase")
+
+        wallet.walletpassphrase("passphrase", 60)
+        # A starting thread reserves a destination, which the keypool of a
+        # freshly encrypted wallet cannot cover.
+        wallet.keypoolrefill(100)
+
+        node.staking(True)
+        wallet.setstaking(True)
+        assert_equal(node.staking()["thread_count"], 1)
+
+        self.log.info("A staking thread parks when its wallet is locked")
+        wallet.walletlock()
+        # The warning is only reachable from inside the wait loop, so seeing it
+        # is what proves the thread is parked rather than between passes.
+        self.wait_until(lambda: "locked wallet" in wallet.getstakinginfo()["warnings"])
+
+        self.log.info("setstaking(False) stops a thread parked on a locked wallet")
+        wallet.setstaking(False)
+        assert_equal(node.staking()["thread_count"], 0)
+
+        node.staking(False)
+
     def run_test(self):
         self.test_staking_switch()
         self.test_setstaking_switch()
         self.test_getstakinginfo()
         self.test_switches_are_independent()
+        self.test_staking_thread_lifecycle()
+        self.test_locked_wallet_thread_can_be_stopped()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Disabling staking for a wallet and enabling it again should leave the node staking. It does not, and the thread bookkeeping under the `setstaking` RPC is why.

YouTrack: https://reddink.youtrack.cloud/issue/RED-103 (found while verifying https://reddink.youtrack.cloud/issue/RED-102 on the 4.22.9 release line, where the RPC itself never restarts the thread; develop already calls `StakeWalletAdd`/`StakeWalletRemove`, so what is left is everything underneath them)

## The defects

1. **`tm_` was written by the wrong thread, without the lock.** `StakeWalletAdd` launched the thread and the *thread itself* recorded `tm_[name] = this_thread::get_id()`, while `StakeWalletRemove` read `tm_.find()` outside `cs_threadStakeMinterGroup`. The map carried no `GUARDED_BY`. That is a data race, and a stop arriving before the thread had registered itself found nothing to stop and left the thread behind. That is the RED-102 symptom, reachable here.

2. **Enabling an already staking wallet launched a second thread.** `StakeWalletAdd` had no already-running guard. Two threads then searched the same coins, and `tm_[name]` was overwritten by whichever wrote last, so one of them could never be found or joined again.

3. **`StakeWalletRemove` joined while holding the lock.** `PoSMiner` sleeps `pos_timio` ms per pass and 60 seconds after finding a block, so `setstaking false` could block its own RPC for a minute with the lock held, and `GetStakingThreadCount()` behind it, which is the `staking` RPC.

4. **The wait loops could not be stopped.** The loops that wait for an unlocked wallet, for peers, and for the chain to sync checked only `ShutdownRequested()`, never `running` or `getEnableStaking()`. On a locked wallet, `setstaking false` blocked forever, and so did the node-wide `staking false` that RED-102 documents as the recovery. The peer-wait loop is also entered when `connman == nullptr` and then dereferenced `connman` in its sleep.

5. **`interruptStake` was dead code.** It was declared, reset, and signalled by `Interrupt()`, but every staker sleep waited on `connman->interruptNet`, so `CStakeman::Interrupt()` did nothing to staker threads.

6. **`GetStakingThreadCount()` counted finished threads.** Nothing reaped a thread that returned on its own, so `staking` kept reporting `thread_count: 1` for a thread that had stopped. On a live node this is what made the symptom hard to read.

## The change

`vector<std::thread>` plus the id map are replaced by one entry per wallet, keyed by name, **created by whoever launches the thread** rather than by the thread once it is running. That is what closes the race: there is no window in which a running thread is not yet registered.

Each entry owns two things. A `shared_ptr<CThreadInterrupt>` that stops just that thread, so one wallet can be stopped without disturbing the others, and a `shared_ptr<atomic<bool>>` the thread sets as it returns, so a finished thread is never counted and is reaped before it is replaced. Joins moved outside the lock.

`PoSMiner` and `ThreadStaker` take a `CThreadInterrupt&` and every sleep waits on it, so a stop lands promptly instead of after the current sleep. A `stop_requested()` lambda gathers all three reasons to return and is checked by every waiting loop. Note that a single shared interrupt cannot serve this: the staker treats an interrupted sleep as "return", so firing one would kill every staker. Hence one per thread.

## Testing

`rpc_staking.py` toggled `setstaking` true and false but only asserted the flag it returns, so it passed against a node whose staking thread had ended. Two cases were added that assert the thread instead.

The first covers start, stop, and restart, that enabling an already staking wallet does not add a second thread, that the node-wide switch stops it, and that with the node-wide switch off `setstaking` starts nothing.

The second covers the worst stop path, a thread parked in the loop that waits for its wallet to be unlocked. It watches for the staking warning that is only reachable from inside that loop, so it stops a thread that is genuinely parked rather than one between passes. Without the fix this case does not fail, it hangs, and the framework RPC timeout is what ends it.

Two of the six defects are caught deterministically on the unfixed code: the duplicate thread, and the locked-wallet hang. The race and the thread count are timing-dependent and are not pinned by a test.

Run locally, all passing:

- `src/test/test_reddcoin`, 490 cases
- `rpc_staking.py`, `wallet_descriptor_staking.py`, `wallet_descriptor_staking_witness.py`, `feature_descriptor_legacy_staking.py`, `feature_pos_coinstake_fees.py`, `wallet_reorg_stale_coinstake.py`, `mining_basic.py`, `rpc_generate.py`, `rpc_generateblock.py`

The log from a passing run shows the lifecycle end to end: `StakeWalletAdd Launching wallet..`, then `Staking thread [...] starting`, `Set proof-of-stake timeout: 687ms for 39 UTXOs`, `stopped`, `Thread removed`, then a fresh launch on the next enable, and `[] is already staking` when the duplicate is refused.

## Out of scope, noted

Nothing stops a wallet's staking thread when the wallet is unloaded. On this branch the thread holds the wallet alive through the `interfaces::StakingWallet` seam, so `unloadwallet` on a staking wallet waits for a reference that is never released and never returns. On the 4.22.9 line the same missing hookup is a use-after-free instead, since the thread there holds a raw `CWallet*`. Filed as https://reddink.youtrack.cloud/issue/RED-104, which depends on this change: joining a staker is only prompt once the per-thread interrupt exists, and on a locked wallet the join does not return at all until the wait loops learn to stop.

## Note for the 4.22.9 line

RED-102 is the same class of bug on `v4.22.9-regtest`, where `setstaking` never notifies `CStakeman` at all. That backport is cut from this change rather than from the notify block alone, since porting only the RPC call would carry the race and the locked-wallet hang with it.
