### PR TITLE
pos: restart a wallet's staking thread from setstaking

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -544,7 +544,7 @@ static bool ProcessBlockFound(const CBlock* pblock, ChainstateManager* chainman,
     return true;
 }
 
-void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running)
+void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt)
 {
     LogPrintf("CPUMiner [%d] started for proof-of-stake wallet [%s]\n", thread_id, pwallet->GetName());
     util::ThreadRename(strprintf("staker-%d", thread_id));
@@ -583,6 +583,15 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
         return;
     }
 
+    // Every reason this thread should return. The waiting loops below can run
+    // for as long as the condition they wait on lasts, which for a locked wallet
+    // is indefinitely, so each of them has to check all of these and not just
+    // the shutdown flag: otherwise disabling staking for this wallet cannot
+    // stop it, and neither can the node-wide switch.
+    const auto stop_requested = [&]() {
+        return ShutdownRequested() || !running || !pwallet->GetEnableStaking();
+    };
+
     try {
         bool fNeedToClear = false;
         while (running) {
@@ -591,7 +600,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
             if (ShutdownRequested())
                 return;
             while (pwallet->IsLocked()) {
-                if (ShutdownRequested())
+                if (stop_requested())
                     return;
                 if (strMintWarning != strMintMessage) {
                     strMintWarning = strMintMessage;
@@ -599,14 +608,14 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                     pwallet->NotifyWalletStakingStatusChanged();
                 }
                 fNeedToClear = true;
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
+                if (!interrupt.sleep_for(std::chrono::seconds(2)))
                     return;
             }
 
             // Busy-wait for the network to come online so we don't waste time mining
             // on an obsolete chain. In regtest mode we expect to fly solo.
             while(connman == nullptr || connman->GetNodeCount(ConnectionDirection::Both) == 0 || chainman->ActiveChainstate().IsInitialBlockDownload()) {
-                if (ShutdownRequested())
+                if (stop_requested())
                     return;
                 LogPrintf("Staker thread [%d]: sleeps while IBD at %d\n", thread_id, chainman->ActiveChain().Tip()->nHeight);
                 if (strMintWarning != strMintSyncMessage) {
@@ -615,13 +624,13 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                     pwallet->NotifyWalletStakingStatusChanged();
                 }
                 fNeedToClear = true;
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
+                if (!interrupt.sleep_for(std::chrono::seconds(2)))
                     return;
             }
 
             while (GuessVerificationProgress(Params().TxData(), chainman->ActiveChain().Tip()) < 0.9996)
             {
-                if (ShutdownRequested())
+                if (stop_requested())
                     return;
                 LogPrintf("Staker thread [%d]: sleeps while sync at %f\n", thread_id, GuessVerificationProgress(Params().TxData(), chainman->ActiveChain().Tip()));
                 if (strMintWarning != strMintSyncMessage) {
@@ -630,7 +639,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                     pwallet->NotifyWalletStakingStatusChanged();
                 }
                 fNeedToClear = true;
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(2)))
+                if (!interrupt.sleep_for(std::chrono::seconds(2)))
                         return;
             }
             if (fNeedToClear) {
@@ -658,7 +667,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
             {
                 if (fPoSCancel == true)
                 {
-                    if (!connman->interruptNet.sleep_for(std::chrono::milliseconds(pos_timio)))
+                    if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
                         return;
                     continue;
                 }
@@ -666,7 +675,7 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 uiInterface.NotifyAlertChanged();
                 pwallet->NotifyWalletStakingStatusChanged();
                 LogPrintf("Staker thread [%d]: Error in ReddcoinMiner: Keypool ran out, please call keypoolrefill before restarting the mining thread\n", thread_id);
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(10)))
+                if (!interrupt.sleep_for(std::chrono::seconds(10)))
                    return;
 
                 return;
@@ -691,11 +700,11 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 ProcessBlockFound(pblock, chainman, &chainman->ActiveChainstate(), Params());
                 reservedest.KeepDestination();
                 // Rest for ~3 minutes after successful block to preserve close quick
-                if (!connman->interruptNet.sleep_for(std::chrono::seconds(60 + GetRand(4))))
+                if (!interrupt.sleep_for(std::chrono::seconds(60 + GetRand(4))))
                     return;
             }
 
-            if (!connman->interruptNet.sleep_for(std::chrono::milliseconds(pos_timio)))
+            if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
                 return;
 
             continue;

--- a/src/miner.h
+++ b/src/miner.h
@@ -27,6 +27,7 @@
 
 class CConnman;
 class ChainstateManager;
+class CThreadInterrupt;
 namespace interfaces {
 class Chain;
 } /* namespace interfaces */
@@ -224,7 +225,12 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 /** Update an old GenerateCoinbaseCommitment from CreateNewBlock after the block txs have changed */
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman);
 
-void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running);
+/** Staking loop for one wallet.
+ *
+ *  Every sleep in the loop waits on interrupt, so signalling it returns this
+ *  thread promptly instead of after the current sleep, which is up to a minute
+ *  once a block has been found. The caller owns it and must outlive the call. */
+void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt);
 
 void InitStakeWallet();
 void SetStakingActive(bool active);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -348,7 +348,22 @@ static RPCHelpMan setstaking()
                 } else if (pwallet->IsWalletFlagSet(WALLET_FLAG_BLANK_WALLET)) {
                     result.pushKV("error", "Blank wallet flag set.");
                 } else {
-                    pwallet->SetEnableStaking(request.params[0].getBool());
+                    bool enable = request.params[0].getBool();
+                    pwallet->SetEnableStaking(enable);
+
+                    // Tell CStakeman to start or stop the staking thread for
+                    // this wallet. The staking loop returns on the flag, so
+                    // without this a disabled wallet loses its thread and
+                    // nothing ever starts another one.
+                    NodeContext& node = EnsureAnyNodeContext(request.context);
+                    if (node.stakeman) {
+                        if (enable) {
+                            node.stakeman->StakeWalletAdd(pwallet->GetName());
+                        } else {
+                            node.stakeman->StakeWalletRemove(pwallet->GetName());
+                        }
+                    }
+
                     if (!request.params[1].isNull()) {
                         interfaces::Chain& chain = pwallet->chain();
                         std::string name = pwallet->GetName();

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -108,7 +108,6 @@ bool CStakeman::Start()
     // Start threads
     //
     uiInterface.InitMessage(_("Starting staking threads…").translated);
-    interruptStake.reset();
 
     std::vector<std::shared_ptr<CWallet>> m_stake_wallets = GetWallets();
     for (const auto& wallet : m_stake_wallets) {
@@ -146,7 +145,6 @@ bool CStakeman::Start(CScheduler& scheduler, const Options& stakeOptions)
     // Start threads
     //
     uiInterface.InitMessage(_("Starting staking threads…").translated);
-    interruptStake.reset();
 
     std::vector<std::shared_ptr<CWallet>> m_stake_wallets = GetWallets();
     for (const auto& wallet : m_stake_wallets) {
@@ -173,24 +171,47 @@ bool CStakeman::Start(CScheduler& scheduler, const Options& stakeOptions)
 void CStakeman::Interrupt()
 {
     LogPrintf("CStakeman::%s\n", __func__);
-    interruptStake();
+    LOCK(cs_threadStakeMinterGroup);
+    for (const auto& staker : m_stakers) {
+        (*staker.second.interrupt)();
+    }
 }
 
 void CStakeman::StopThreads()
 {
     LogPrintf("CStakeman::%s\n", __func__);
+
+    // Take the threads out of the map first so that the joins below happen with
+    // the lock released: a staking pass can take a while to notice it has been
+    // interrupted, and GetStakingThreadCount() should not block behind it.
+    std::unordered_map<std::string, StakerThread> stakers;
     {
         LOCK(cs_threadStakeMinterGroup);
-        for (std::thread& t : threadStakeMinterGroup) {
-            LogPrintf("CStakeman::%s Stopping thread %i!\n", __func__, t.get_id());
-            if (t.joinable()) t.join();
-        }
-        threadStakeMinterGroup.clear();
-        tm_.clear();
+        stakers.swap(m_stakers);
+    }
+
+    // Signal every thread before joining any of them, so they wind down in
+    // parallel rather than one sleep at a time.
+    for (const auto& staker : stakers) {
+        (*staker.second.interrupt)();
+    }
+    for (auto& staker : stakers) {
+        LogPrintf("CStakeman::%s Stopping thread %i!\n", __func__, staker.second.thread.get_id());
+        if (staker.second.thread.joinable()) staker.second.thread.join();
     }
 
     uiInterface.NotifyNodeStakingActiveChanged(false);
     LogPrintf("CStakeman::%s done!\n", __func__);
+}
+
+int CStakeman::GetStakingThreadCount()
+{
+    LOCK(cs_threadStakeMinterGroup);
+    int count = 0;
+    for (const auto& staker : m_stakers) {
+        if (!staker.second.finished->load()) ++count;
+    }
+    return count;
 }
 
 void CStakeman::SetStakingActive(bool active)
@@ -211,51 +232,78 @@ void CStakeman::StakeWalletAdd(const std::string& walletname)
     if (!fStakingActive) {
         return;
     }
-    std::vector<std::shared_ptr<CWallet>> m_stake_wallets = GetWallets();
-    for (const auto& wallet : m_stake_wallets) {
-        if (wallet->GetName() == walletname) {
-            if (wallet->GetEnableStaking()) {
-                {
-                    LOCK(cs_threadStakeMinterGroup);
-                    threadStakeMinterGroup.push_back(
-                        std::thread(&util::TraceThread, "staker", [this, pwallet = wallet.get(), chainManager = chainManager, connManager = connManager, mempool = memPool]() {
-                            tm_[pwallet->GetName()] = std::this_thread::get_id();
-                            ThreadStaker(pwallet, chainManager, connManager, mempool, std::this_thread::get_id(), fStakingActive);
-                        }));
-                }
 
-                LogPrintf("CStakeman::%s Launching wallet..  [%s]\n", __func__, wallet->GetName());
-                wallet.get()->NotifyWalletStakingStatusChanged();
-            }
-        }
+    std::shared_ptr<CWallet> wallet = GetWallet(walletname);
+    if (!wallet || !wallet->GetEnableStaking()) {
+        return;
     }
+
+    auto interrupt = std::make_shared<CThreadInterrupt>();
+    auto finished = std::make_shared<std::atomic<bool>>(false);
+
+    {
+        LOCK(cs_threadStakeMinterGroup);
+
+        auto it = m_stakers.find(walletname);
+        if (it != m_stakers.end()) {
+            if (!it->second.finished->load()) {
+                // Already staking. A second thread for one wallet would search
+                // the same coins twice, and only one of the two would ever be
+                // reachable again for stopping.
+                LogPrintf("CStakeman::%s [%s] is already staking\n", __func__, walletname);
+                return;
+            }
+            // The previous thread returned on its own (an exhausted keypool, a
+            // runtime error). Reap it before it is replaced; it has finished, so
+            // this join does not wait.
+            if (it->second.thread.joinable()) it->second.thread.join();
+            m_stakers.erase(it);
+        }
+
+        StakerThread staker;
+        staker.interrupt = interrupt;
+        staker.finished = finished;
+        staker.thread = std::thread(&util::TraceThread, "staker", [this, pwallet = wallet.get(), interrupt, finished, chainManager = chainManager, connManager = connManager, mempool = memPool]() {
+            ThreadStaker(pwallet, chainManager, connManager, mempool, std::this_thread::get_id(), fStakingActive, *interrupt);
+            *finished = true;
+        });
+        m_stakers.emplace(walletname, std::move(staker));
+    }
+
+    LogPrintf("CStakeman::%s Launching wallet..  [%s]\n", __func__, walletname);
+    wallet->NotifyWalletStakingStatusChanged();
 }
 
 void CStakeman::StakeWalletRemove(const std::string& walletname)
 {
-    ThreadMap::const_iterator it = tm_.find(walletname);
-    if (it != tm_.end()) {
-        {
-            LOCK(cs_threadStakeMinterGroup);
-            auto iter = std::find_if(threadStakeMinterGroup.begin(), threadStakeMinterGroup.end(), [=](std::thread& t) { return (t.get_id() == it->second); });
-            if (iter != threadStakeMinterGroup.end()) {
-                iter->join();
-                threadStakeMinterGroup.erase(iter);
-            }
+    StakerThread staker;
+    {
+        LOCK(cs_threadStakeMinterGroup);
+        auto it = m_stakers.find(walletname);
+        if (it == m_stakers.end()) {
+            return;
         }
-
-        tm_.erase(walletname);
-        LogPrintf("CStakeman::%s Thread %s removed\n", __func__, walletname);
-        uiInterface.NotifyWalletStakingActiveChanged(false);
+        staker = std::move(it->second);
+        m_stakers.erase(it);
     }
+
+    // Wake the thread before joining it: it spends nearly all its time asleep,
+    // and an uninterrupted sleep runs for a minute after a block is found. The
+    // join is outside the lock so that the `staking` RPC stays responsive while
+    // this thread winds down.
+    (*staker.interrupt)();
+    if (staker.thread.joinable()) staker.thread.join();
+
+    LogPrintf("CStakeman::%s Thread %s removed\n", __func__, walletname);
+    uiInterface.NotifyWalletStakingActiveChanged(false);
 }
 
-void CStakeman::ThreadStaker(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running)
+void CStakeman::ThreadStaker(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt)
 {
     LogPrintf("CStakeman::%s\n", __func__);
     LogPrintf("CStakeman::%s Staking thread [%s] starting\n", __func__, thread_id);
     try {
-        PoSMiner(pwallet, chainman, connman, mempool, thread_id, running);
+        PoSMiner(pwallet, chainman, connman, mempool, thread_id, running, interrupt);
     } catch (std::exception& e) {
         PrintExceptionContinue(&e, "ThreadStakeMinter()");
     } catch (...) {

--- a/src/staker.h
+++ b/src/staker.h
@@ -10,6 +10,7 @@
 #include <threadsafety.h>
 
 #include <atomic>
+#include <memory>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -53,28 +54,32 @@ public:
     };
     bool GetNodeStakingActive() const { return fStakingActive; };
     void SetStakingActive(bool active);
-    int GetStakingThreadCount()
-    {
-        LOCK(cs_threadStakeMinterGroup);
-        return threadStakeMinterGroup.size();
-    };
-    void static ThreadStaker(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running);
+    //! Number of staking threads that are still running. A thread that returned
+    //! on its own is not counted, even though it has not been joined yet.
+    int GetStakingThreadCount();
+    void static ThreadStaker(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt);
     void StakeWalletAdd(const std::string& walletname);
     void StakeWalletRemove(const std::string& walletname);
-
-    /**
-     * This is signaled when staking activity should cease.
-     */
-    CThreadInterrupt interruptStake;
 
 private:
     std::atomic<bool> fStakingActive{true};
 
-    std::vector<std::thread> threadStakeMinterGroup GUARDED_BY(cs_threadStakeMinterGroup);
-    mutable RecursiveMutex cs_threadStakeMinterGroup;
+    //! One staking thread per wallet. Keyed by wallet name so that the entry is
+    //! created by whoever launches the thread, rather than by the thread itself
+    //! once it has started running: a stop that arrives in between would
+    //! otherwise find nothing to stop and leave the thread behind.
+    struct StakerThread {
+        std::thread thread;
+        //! Signalled to wake this thread out of a sleep so it can stop. Held by
+        //! shared_ptr because the thread's callable outlives this entry.
+        std::shared_ptr<CThreadInterrupt> interrupt;
+        //! Set by the thread as it returns, so a thread that stopped on its own
+        //! is not reported as running and is reaped before it is replaced.
+        std::shared_ptr<std::atomic<bool>> finished;
+    };
 
-    typedef std::unordered_map<std::string, std::thread::id> ThreadMap;
-    ThreadMap tm_;
+    std::unordered_map<std::string, StakerThread> m_stakers GUARDED_BY(cs_threadStakeMinterGroup);
+    mutable RecursiveMutex cs_threadStakeMinterGroup;
 
     CClientUIInterface* clientInterface;
     ChainstateManager* chainManager;


### PR DESCRIPTION
`setstaking false` ends a wallet's staking thread and `setstaking true` cannot bring it back, so a node stops staking with nothing reporting an error.

YouTrack: https://reddink.youtrack.cloud/issue/RED-102

Found on a live mainnet node while runtime-verifying the RED-101 backport (#491). Observed there: `setstaking false` stopped the staker, `setstaking true` left `getstakinginfo` reporting `staking: false` and `search-interval: 0`, polled 400 times with no recovery and no `Set proof-of-stake timeout` line, which is what a thread launch logs. The only way back without restarting the node was the node-wide `staking false` then `staking true`, which cycles every loaded wallet's threads.

## Why it happens

`setstaking` sets the wallet's staking flag and nothing else. The staking loop returns on that flag, and a returned thread is gone. Passing the second argument does not help: `StakeWallet()` only calls `UpdateStakeSetting()`, which writes the persistent setting. The only launcher is `CStakeman::StakeWalletAdd()`, reachable until now from `CStakeman::Start()` alone.

Nothing surfaced this. The `staking` RPC kept reporting `thread_count: 1`, because the dead `std::thread` stayed in the thread group: only `StakeWalletRemove()` cleared it, and the self-return path never called it.

## Why this is two commits and not one

`develop` already calls `StakeWalletAdd`/`StakeWalletRemove` from `setstaking`. Porting only that call would land it on bookkeeping that cannot carry it, and would reproduce this same symptom through a different route. So the develop-side lifecycle fix (RED-103, #493) comes first here, and the `setstaking` change second. No commit in this branch pairs the notifications with the bookkeeping that cannot support them.

The first commit fixes:

- `tm_` was written by the staking thread itself once it was running, and read by `StakeWalletRemove` outside `cs_threadStakeMinterGroup`, with no `GUARDED_BY` on the map. A data race, and a stop arriving in that window found nothing to stop.
- Enabling an already staking wallet launched a second thread and orphaned the first.
- `StakeWalletRemove` joined while holding the lock, so disabling staking could block the `staking` RPC for a staker sleep, a minute after a block is found.
- The wait loops for an unlocked wallet, for peers, and for chain sync checked only `ShutdownRequested()`. On a locked wallet, disabling staking blocked forever, including the node-wide `staking false` that is the documented recovery for this bug.
- `interruptStake` was signalled by `Interrupt()` but never waited on, since every sleep used `connman->interruptNet`.
- `GetStakingThreadCount()` counted threads that had already returned.

Threads are now held one per wallet, keyed by name and registered by the launcher rather than by the thread, each owning its own interrupt and a finished flag. `PoSMiner` takes that interrupt and every sleep waits on it, and a `stop_requested()` helper gathers all three reasons to return for the waiting loops.

## Testing

Source only, per the standing constraint that no functional test can run on this branch: the framework hardcodes `src/bitcoind`, and the block cache needs staking above `nLastPowHeight=89`.

Coverage for this change lives on the develop PR, #493, where `rpc_staking.py` gained two cases: start, stop and restart of the thread, refusal of a duplicate, and a thread parked on a locked wallet being stoppable. On develop the full set passes, `src/test/test_reddcoin` (490 cases) and nine staking and mining functional tests.

Here, all three touched translation units syntax-check cleanly and the C++ lint scripts pass.

## Out of scope, noted

`StakeWalletAdd` still captures a raw `CWallet*` from the shared_ptr and the thread holds it for its lifetime, so unloading a wallet while it stakes remains a use-after-free on this branch. That is pre-existing and separate from the lifecycle of the thread itself, so it is left alone here and filed as https://reddink.youtrack.cloud/issue/RED-104.

To be precise about what `develop` does differently: it does not have the use-after-free, because the staking wallet reaches the thread as a shared_ptr behind the `interfaces::StakingWallet` seam, but it is not safe either. Nothing on either branch stops a wallet's staking thread when the wallet is unloaded, so on `develop` the thread keeps its reference alive and `unloadwallet` waits for it forever. Same missing hookup, different symptom. RED-104 covers both, and depends on this lifecycle change landing first: joining a staker is only prompt once the interrupt exists.
