### PR TITLE
pos: stop a wallet's staking thread when the wallet is unloaded

### DIFF
--- a/src/interfaces/staking.h
+++ b/src/interfaces/staking.h
@@ -9,6 +9,7 @@
 #include <primitives/transaction.h> // For COutPoint, CMutableTransaction
 #include <script/standard.h> // For CTxDestination
 
+#include <functional>
 #include <memory>
 #include <stdint.h>
 #include <string>
@@ -28,6 +29,8 @@ struct Params;
 static const unsigned int DEFAULT_STAKETIMIO = 500;
 
 namespace interfaces {
+
+class Handler;
 
 //! Wallet-free description of a coin that can be staked.
 //!
@@ -92,6 +95,18 @@ public:
 
     //! Emit the wallet's staking-status-changed notification.
     virtual void notifyStakingStatusChanged() = 0;
+
+    //! Register a callback for when this wallet is unloaded.
+    //!
+    //! A staking thread holds its wallet alive for as long as it runs, so an
+    //! unload cannot take the wallet away from it, but it also cannot complete
+    //! until the thread lets go. The thread registers here to be told to stop.
+    //!
+    //! The returned handler MUST be released before the last reference to the
+    //! wallet is, because ~CWallet asserts that nothing is still subscribed.
+    //! Keeping it on the staking thread's own stack gets that ordering right.
+    using UnloadFn = std::function<void()>;
+    virtual std::unique_ptr<Handler> handleUnload(UnloadFn fn) = 0;
 
     //! Number of spendable coins, used to scale the stake search timeout.
     virtual size_t getAvailableCoinCount() = 0;

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -4,6 +4,7 @@
 
 #include <staker.h>
 
+#include <interfaces/handler.h>
 #include <interfaces/staking.h>
 #include <logging.h>
 #include <miner.h>
@@ -287,6 +288,22 @@ void CStakeman::ThreadStaker(std::shared_ptr<interfaces::StakingWallet> staking_
 {
     LogPrintf("CStakeman::%s\n", __func__);
     LogPrintf("CStakeman::%s Staking thread [%s] starting\n", __func__, thread_id);
+
+    // Stop when the wallet is unloaded. This thread holds the wallet alive for
+    // as long as it runs, so an unload cannot pull it away mid-pass, but it
+    // also cannot finish until this thread lets go: UnloadWallet() waits for
+    // the last reference to be released. Interrupting is enough, since the loop
+    // returns out of its next sleep.
+    //
+    // The handler is deliberately a local of this function. It has to be
+    // disconnected before the wallet's last reference goes, because ~CWallet
+    // asserts that nothing is still subscribed, and a local is destroyed ahead
+    // of the staking_wallet parameter it was registered on.
+    std::unique_ptr<interfaces::Handler> unload_handler = staking_wallet->handleUnload([&interrupt, thread_id]() {
+        LogPrintf("CStakeman::ThreadStaker Staking thread [%s] stopping, wallet unloaded\n", thread_id);
+        interrupt();
+    });
+
     try {
         PoSMiner(*staking_wallet, chainman, connman, mempool, thread_id, running, interrupt);
     } catch (std::exception& e) {

--- a/src/wallet/staking.cpp
+++ b/src/wallet/staking.cpp
@@ -11,6 +11,7 @@
 #include <deploymentstatus.h>
 #include <index/disktxpos.h>
 #include <index/txindex.h>
+#include <interfaces/handler.h>
 #include <node/blockstorage.h>
 #include <pos/kernel.h>
 #include <pos/stake.h>
@@ -657,6 +658,11 @@ public:
     }
 
     void notifyStakingStatusChanged() override { m_wallet->NotifyWalletStakingStatusChanged(); }
+
+    std::unique_ptr<interfaces::Handler> handleUnload(UnloadFn fn) override
+    {
+        return interfaces::MakeHandler(m_wallet->NotifyUnload.connect(fn));
+    }
 
     void setLastCoinStakeSearchInterval(int64_t interval) override
     {

--- a/test/functional/rpc_staking.py
+++ b/test/functional/rpc_staking.py
@@ -19,9 +19,10 @@ records the intent on one wallet and adds or removes it from the staking set.
 A wallet only actually stakes when both are on, which is what the interaction
 at the end of this test pins down.
 
-The last case covers the thread behind the switches rather than the flag in
+The last cases cover the thread behind the switches rather than the flag in
 front of it. Reporting the flag is not enough: a wallet whose staking thread
-has ended reports `setstaking` true and stakes nothing.
+has ended reports `setstaking` true and stakes nothing, and a thread that
+outlives its wallet keeps `unloadwallet` waiting forever.
 
 Staking is left off at every point where the test asserts on chain height,
 since a staking thread that finds a kernel would move the tip underneath it.
@@ -259,6 +260,40 @@ class StakingRpcTest(BitcoinTestFramework):
 
         node.staking(False)
 
+    def test_unloading_a_wallet_stops_its_staking_thread(self):
+        """Unloading a staking wallet has to end its thread.
+
+        Nothing told the thread to stop when its wallet went away. The thread
+        holds the wallet alive for as long as it runs, and UnloadWallet waits
+        for the last reference to be released, so unloadwallet waited on a
+        thread that was never going to let go.
+
+        Like the locked-wallet case, without a fix this does not fail, it hangs.
+        """
+        node = self.nodes[0]
+
+        node.createwallet(wallet_name="unload_staker")
+        wallet = node.get_wallet_rpc("unload_staker")
+
+        node.staking(True)
+        wallet.setstaking(True)
+        assert_equal(node.staking()["thread_count"], 1)
+
+        self.log.info("unloadwallet returns while the wallet is staking")
+        # Through the wallet's own endpoint: self.nodes[0] is scoped to the
+        # default wallet, and unloadwallet refuses a wallet_name that disagrees
+        # with its endpoint. It resolves the wallet by name either way, so this
+        # holds no extra reference that would keep the unload waiting.
+        wallet.unloadwallet()
+
+        # unloadwallet only returns once the last reference to the wallet is
+        # released, and the thread is what holds it, so it has necessarily
+        # stopped by now. No waiting needed.
+        assert_equal(node.staking()["thread_count"], 0)
+        assert "unload_staker" not in node.listwallets()
+
+        node.staking(False)
+
     def run_test(self):
         self.test_staking_switch()
         self.test_setstaking_switch()
@@ -266,6 +301,7 @@ class StakingRpcTest(BitcoinTestFramework):
         self.test_switches_are_independent()
         self.test_staking_thread_lifecycle()
         self.test_locked_wallet_thread_can_be_stopped()
+        self.test_unloading_a_wallet_stops_its_staking_thread()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Nothing tells a staking thread that its wallet has gone away, so `unloadwallet` on a staking wallet never returns.

YouTrack: https://reddink.youtrack.cloud/issue/RED-104

## The bug

`UnloadWallet()` (src/wallet/wallet.cpp:188) fires `NotifyUnload()`, drops its own reference, and then waits indefinitely for every remaining `shared_ptr<CWallet>` to be released. A staking thread holds one for as long as it runs, and nothing subscribes to `NotifyUnload` or calls `StakeWalletRemove()` on any unload path. `RemoveWallet()` only takes the wallet out of `GetWallets()`; a thread already running is untouched. So the thread keeps staking on a wallet that is no longer loaded, and the RPC waits on a reference that is never released.

The GUI reaches the same wait through the wallet-close path.

Reproduce with a wallet that is staking (`staking true`, `setstaking true`, `staking` reporting a non-zero `thread_count`):

    unloadwallet "<name>"

## The fix

The thread subscribes to the wallet's unload notification and stops on it. Signalling its interrupt is enough: `CThreadInterrupt` latches, so the loop returns out of its next sleep rather than needing a flag of its own, and the per-thread interrupt from #493 is what makes that prompt. The thread then releases the wallet and the unload finishes.

The handler never joins. That matters: a join from inside the notification would run on the unloading thread while the staker may be holding the wallet lock mid-pass, which is the deadlock this avoids by construction.

### Why the handler is a local of `ThreadStaker`

`~CWallet` asserts `NotifyUnload.empty()` (src/wallet/wallet.h:405-408). A subscriber still connected when the wallet is destroyed is not a leak, it is an assertion failure. The thread's entry in the staker map outlives the thread, so registering the handler there would turn this fix into a crash on wallet destruction.

Keeping it on the staking thread's own stack gets the ordering right by construction: a local is destroyed ahead of the `staking_wallet` parameter it was registered on, so the disconnect always happens before the thread's reference is dropped, and therefore before `~CWallet` can run.

### Why the wallet's notification rather than the RPC

Hooking `unloadwallet` itself would need every caller of `RemoveWallet()` to remember, and would miss the GUI. Subscribing to the wallet covers every path.

`interfaces::StakingWallet` gains `handleUnload`, mirroring `interfaces::Wallet::handleUnload` (src/wallet/interfaces.cpp:501), so no wallet header reaches the staker and no circular dependency appears.

## Not affected

Shutdown. `stakeman->Stop()` runs at init.cpp:212, before wallets are unloaded at line 280. This only ever mattered for a runtime unload.

## Testing

A third case in `rpc_staking.py` unloads a staking wallet. The assertion needs no waiting: `unloadwallet` only returns once the last reference is released, and the thread is what holds it, so the thread has necessarily stopped by then. Like the locked-wallet case added in #493, without the fix this does not fail, it hangs.

The log from a passing run shows the handoff, and shows the staking thread being the last holder, which is exactly the condition that used to hang:

```
[httpworker.2]            ThreadStaker Staking thread [...] stopping, wallet unloaded
[staker-...]              [unload_staker] keypool return 101
[staker-...]              [unload_staker] Releasing wallet
```

Run locally, all passing:

- `src/test/test_reddcoin`, 490 cases
- `rpc_staking.py`, `wallet_descriptor_staking.py`, `wallet_descriptor_staking_witness.py`, `feature_descriptor_legacy_staking.py`, `feature_pos_coinstake_fees.py`, `wallet_reorg_stale_coinstake.py`, `mining_basic.py`
- `wallet_multiwallet.py` and `wallet_createwallet.py`, both `--legacy-wallet` and `--descriptors`, since those exercise load and unload hardest

C++ lint scripts clean, including the circular-dependency check.

## 4.22.9 line

The same hole is a use-after-free on `v4.22.9-regtest`, where the thread is handed a bare `CWallet*` and nothing holds a reference at all, so the wallet is destroyed out from under it. That backport needs an extra half, converting the thread's pointer to a shared_ptr, and is opened separately.
