### PR TITLE
pos: stop a wallet's staking thread when the wallet is unloaded

### DIFF
--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -18,6 +18,8 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
+#include <boost/signals2/connection.hpp>
+
 #include <algorithm>
 #include <iterator>
 #include <memory>
@@ -263,8 +265,11 @@ void CStakeman::StakeWalletAdd(const std::string& walletname)
         StakerThread staker;
         staker.interrupt = interrupt;
         staker.finished = finished;
-        staker.thread = std::thread(&util::TraceThread, "staker", [this, pwallet = wallet.get(), interrupt, finished, chainManager = chainManager, connManager = connManager, mempool = memPool]() {
-            ThreadStaker(pwallet, chainManager, connManager, mempool, std::this_thread::get_id(), fStakingActive, *interrupt);
+        // The wallet is captured as a shared_ptr, not a bare pointer: an
+        // unload would otherwise destroy it while this thread is still
+        // dereferencing it every pass.
+        staker.thread = std::thread(&util::TraceThread, "staker", [this, wallet, interrupt, finished, chainManager = chainManager, connManager = connManager, mempool = memPool]() {
+            ThreadStaker(wallet, chainManager, connManager, mempool, std::this_thread::get_id(), fStakingActive, *interrupt);
             *finished = true;
         });
         m_stakers.emplace(walletname, std::move(staker));
@@ -298,12 +303,28 @@ void CStakeman::StakeWalletRemove(const std::string& walletname)
     uiInterface.NotifyWalletStakingActiveChanged(false);
 }
 
-void CStakeman::ThreadStaker(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt)
+void CStakeman::ThreadStaker(std::shared_ptr<CWallet> pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt)
 {
     LogPrintf("CStakeman::%s\n", __func__);
     LogPrintf("CStakeman::%s Staking thread [%s] starting\n", __func__, thread_id);
+
+    // Stop when the wallet is unloaded. This thread holds the wallet alive for
+    // as long as it runs, so an unload cannot pull it away mid-pass, but it
+    // also cannot finish until this thread lets go: UnloadWallet() waits for
+    // the last reference to be released. Interrupting is enough, since the loop
+    // returns out of its next sleep.
+    //
+    // The connection is deliberately a local of this function. It has to be
+    // disconnected before the wallet's last reference goes, because ~CWallet
+    // asserts that nothing is still subscribed, and a local is destroyed ahead
+    // of the pwallet parameter it was registered on.
+    boost::signals2::scoped_connection unload_conn = pwallet->NotifyUnload.connect([&interrupt, thread_id]() {
+        LogPrintf("CStakeman::ThreadStaker Staking thread [%s] stopping, wallet unloaded\n", thread_id);
+        interrupt();
+    });
+
     try {
-        PoSMiner(pwallet, chainman, connman, mempool, thread_id, running, interrupt);
+        PoSMiner(pwallet.get(), chainman, connman, mempool, thread_id, running, interrupt);
     } catch (std::exception& e) {
         PrintExceptionContinue(&e, "ThreadStakeMinter()");
     } catch (...) {

--- a/src/staker.h
+++ b/src/staker.h
@@ -57,7 +57,7 @@ public:
     //! Number of staking threads that are still running. A thread that returned
     //! on its own is not counted, even though it has not been joined yet.
     int GetStakingThreadCount();
-    void static ThreadStaker(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt);
+    void static ThreadStaker(std::shared_ptr<CWallet> pwallet, ChainstateManager* chainman, CConnman* connman, CTxMemPool* mempool, std::thread::id thread_id, std::atomic<bool> &running, CThreadInterrupt& interrupt);
     void StakeWalletAdd(const std::string& walletname);
     void StakeWalletRemove(const std::string& walletname);
 


### PR DESCRIPTION
Unloading a wallet that is staking is a use-after-free on this branch.

YouTrack: https://reddink.youtrack.cloud/issue/RED-104 · develop side: #495

## The bug

Nothing stops a wallet's staking thread when the wallet is unloaded. No `NotifyUnload` subscription, no `StakeWalletRemove()` on any unload path; `RemoveWallet()` only takes the wallet out of `GetWallets()`.

On this branch the staking thread is handed a bare `CWallet*`:

```cpp
std::thread(&util::TraceThread, "staker", [this, pwallet = wallet.get(), ...]
```

Because nothing holds a reference, `UnloadWallet()` (src/wallet/wallet.cpp:188) has nothing to wait for. It completes and destroys the `CWallet` while `PoSMiner` is still dereferencing `pwallet` every pass: `IsLocked()`, `GetEnableStaking()`, coin selection, signing. Memory corruption in a released binary, reachable by an ordinary RPC on a staking node. The GUI wallet-close path reaches the same code.

Reproduce with a wallet that is staking (`staking true`, `setstaking true`, `staking` reporting a non-zero `thread_count`):

    unloadwallet "<name>"

## The fix

Two halves that only work together.

**Hold the wallet.** Capture it as a `shared_ptr` so it cannot be destroyed under the thread. On its own this only trades the crash for a hang, since `UnloadWallet()` waits for the last reference to be released and the thread would never let go. That hang is precisely what `develop` does today, since it already passes the wallet by shared_ptr behind the `interfaces::StakingWallet` seam.

**Then let go.** The thread subscribes to the wallet's unload notification and stops on it. Signalling its interrupt is enough: `CThreadInterrupt` latches, so the loop returns out of its next sleep, and the per-thread interrupt from #494 is what makes that prompt. The thread then releases the wallet and the unload finishes.

The handler never joins, so it cannot deadlock against a staker holding the wallet lock mid-pass.

### Why the connection is a local of `ThreadStaker`

`~CWallet` asserts `NotifyUnload.empty()` (src/wallet/wallet.h). A subscriber still connected when the wallet is destroyed is not a leak, it is an assertion failure. The thread's entry in the staker map outlives the thread, so registering there would turn this fix into a crash on wallet destruction.

A `boost::signals2::scoped_connection` local to `ThreadStaker` gets the ordering right by construction: it is destroyed ahead of the `pwallet` parameter it was registered on, so the disconnect always happens before the thread's reference is dropped.

### Why the wallet's notification rather than the RPC

Hooking `unloadwallet` itself would need every caller of `RemoveWallet()` to remember, and would miss the GUI.

## Not affected

Shutdown. `stakeman->Stop()` runs before wallets are unloaded. This only ever mattered for a runtime unload.

## Testing

Source only, per the standing constraint that no functional test can run on this branch: the framework hardcodes `src/bitcoind`, and the block cache needs staking above `nLastPowHeight=89`.

Coverage is on #495, where `rpc_staking.py` gained a case that unloads a staking wallet, and where the same shape passes `wallet_multiwallet.py` and `wallet_createwallet.py` in both wallet modes alongside `test_reddcoin` (490 cases) and the staking suite. The log there confirms the staking thread is the last holder and is what releases the wallet, which is the condition that hangs on develop and corrupts memory here.

Here, both touched translation units syntax-check cleanly and the C++ lint scripts pass.

Note that the two branches differ in what the bug does, but not in the fix: `develop` needed only the unload subscription because it already held the wallet, while this branch needs the ownership change as well.
