### PR TITLE
gui: keep the wallet staking icon after a wallet is unloaded

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -892,6 +892,11 @@ void BitcoinGUI::removeWallet(WalletModel* walletModel)
     rpcConsole->removeWallet(walletModel);
     walletFrame->removeWallet(walletModel);
     updateWindowTitle();
+
+    // Refresh against whichever wallet is current now, so a wallet that is
+    // still open gets its staking icon straight back rather than waiting for
+    // its next status change.
+    updateWalletStakingStatus();
 }
 
 void BitcoinGUI::setCurrentWallet(WalletModel* wallet_model)
@@ -1705,6 +1710,10 @@ void BitcoinGUI::updateWalletStakingStatus()
 
     walletstakingStatusControl->setToolTip(msg);
     walletstakingStatusControl->setThemedPixmap(icon, STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE);
+    // removeWallet() hides this icon, and this is the only place that brings it
+    // back. The early returns above cover the case that hide is there for: once
+    // the last wallet is gone there is no status to show, so it stays hidden.
+    walletstakingStatusControl->show();
 }
 
 


### PR DESCRIPTION
The wallet staking status icon disappears from the status bar the first time any wallet is unloaded, and does not come back for the rest of the session. The click target for enabling and disabling staking goes with it.

YouTrack: https://reddink.youtrack.cloud/issue/RED-105

## The bug

`BitcoinGUI::removeWallet()` hides three status icons:

```cpp
labelWalletHDStatusIcon->hide();
labelWalletEncryptionIcon->hide();
walletstakingStatusControl->hide();
```

Counting the calls in `src/qt/bitcoingui.cpp`:

| Widget | `show()` | `hide()` |
|---|---|---|
| `labelWalletHDStatusIcon` | 1 | 1 |
| `labelWalletEncryptionIcon` | 2 | 3 |
| `walletstakingStatusControl` | **0** | 1 |
| `nodestakingStatusControl` | 0 | 0 |

The first two are shown again from `setEncryptionStatus()` and `updateWalletStatus()`. `updateWalletStakingStatus()` sets the tooltip and the pixmap but never touches visibility, so the staking icon has no path back: one `hide()`, no `show()`, anywhere. The node staking icon is never hidden and is unaffected, which is why only the per-wallet one goes missing.

Unloading one wallet removes the icon for every wallet, not just the one that went.

An RPC unload reaches this exactly as a GUI wallet close does, through `WalletController::removeAndDeleteWallet` and the `walletRemoved` signal.

This is long-standing and unrelated to the recent staking work: the last change to `bitcoingui.cpp` is `90aae77126` (PR #306). It was found while verifying RED-104 on a live mainnet node, where unloading a test wallet made the icon vanish. Before RED-104, unloading a *staking* wallet on the 4.22.9 line was a use-after-free, so it was rarely possible to get here and still have a running GUI to notice.

## The fix

Show the icon at the end of `updateWalletStakingStatus()`. That function already returns early when there is no wallet frame, no current view, or no model, which is exactly the case the `hide()` in `removeWallet()` exists for: with the last wallet gone there is no status to show and the icon correctly stays hidden.

Also refresh at the end of `removeWallet()`, after `walletFrame->removeWallet()` has settled the current wallet, so a wallet that is still open gets its icon straight back instead of waiting for whatever changes its status next. Without that the icon would return on the next block via `setNumBlocks()`, which is up to a minute on mainnet.

## Testing

GUI-only, so this needs the running application rather than a functional test; status bar widgets have no test path. Verified by building and checking that the icon survives an `unloadwallet` and continues to track staking state for the remaining wallet.

`src/qt/bitcoingui.cpp` compiles clean, and `lint-qt` and `lint-whitespace` pass.
