### PR TITLE
gui: restore the HD and encryption icons after a wallet is unloaded

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -894,9 +894,11 @@ void BitcoinGUI::removeWallet(WalletModel* walletModel)
     updateWindowTitle();
 
     // Refresh against whichever wallet is current now, so a wallet that is
-    // still open gets its staking icon straight back rather than waiting for
-    // its next status change.
+    // still open gets its status icons straight back rather than waiting for
+    // whatever would next change them. Both return early once the last wallet
+    // is gone, which is the case the hides above exist for.
     updateWalletStakingStatus();
+    updateWalletStatus();
 }
 
 void BitcoinGUI::setCurrentWallet(WalletModel* wallet_model)


### PR DESCRIPTION
Unloading a wallet leaves the wallet that is still open without its HD and encryption status icons.

YouTrack: https://reddink.youtrack.cloud/issue/RED-106

Sibling of RED-105 (#497), which fixed the third icon hidden by the same three lines in `removeWallet()`. Found immediately after it: on a live mainnet node, the unload that confirmed the staking icon now survives also confirmed that these two still do not.

## Not the same bug

RED-105 was an icon with one `hide()` and no `show()` anywhere. These two do have `show()` calls, so they are recoverable in principle. The calls live in `setHDStatus()` and `setEncryptionStatus()`, both reached only from `updateWalletStatus()`, which is wired to exactly two signals:

```cpp
connect(wallet_view, &WalletView::encryptionStatusChanged, this, &BitcoinGUI::updateWalletStatus);
connect(wallet_view, &WalletView::hdEnabledStatusChanged,  this, &BitcoinGUI::updateWalletStatus);
```

Removing a wallet emits neither for the wallet that remains, so nothing refreshes. Switching the current wallet does not help either: `WalletFrame::setCurrentWallet()` swaps the visible view and emits no status signal. In practice the icons come back only on a lock, unlock or encrypt of the remaining wallet, on loading another wallet, or on a GUI restart.

## Impact

`labelWalletHDStatusIcon` is a `ThemedLabel`, informational only.

`labelWalletEncryptionIcon` is a `ClickableLabel` wired to the lock context menu:

```cpp
connect(labelWalletEncryptionIcon, &GUIUtil::ClickableLabel::clicked, [this] {
    GUIUtil::PopupMenu(m_lock_context_menu, QCursor::pos());
});
```

So the quick lock and unlock control disappears with it, the same class of loss RED-105 had with the staking toggle. The menu bar actions are unaffected.

## The fix

One line beside the staking refresh RED-105 added at the end of `removeWallet()`.

Two things make the new call site safe. `updateWalletStatus()` returns early when there is no wallet frame or no current view, which is exactly the case the `hide()` calls exist for, so with the last wallet gone the icons correctly stay hidden. And unlike `updateWalletStakingStatus()` it dereferences the model without a null check, which is fine here because any `WalletView` on the stack has one: `WalletFrame::addWallet()` rejects a null model and calls `setWalletModel()` before `walletStack->addWidget()`.

Both functions sit inside `#ifdef ENABLE_WALLET`, as does `removeWallet()`, so a `--disable-wallet` build is unaffected.

## Inherited from upstream

Bitcoin Core master hides the same two icons in `removeWallet()` with no refresh, so this is not a Reddcoin regression. The staking icon in RED-105 was ours; these two are not.

## Testing

GUI-only; status bar widgets have no functional-test path. Verified by unloading a wallet with another still open and checking that all three status icons remain and keep tracking the remaining wallet.

`src/qt/bitcoingui.cpp` compiles clean, and `lint-qt` and `lint-whitespace` pass.
