### PR TITLE
gui: name the available version in the update notice

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -310,7 +310,7 @@ void BitcoinGUI::checkUpdates()
 void BitcoinGUI::updateCheckFinished(const QVariantMap& info)
 {
     if (info.value("updateavailable").toBool()) {
-        labelCheckUpdate->setText(tr("Update to %1 is available.").arg(info.value("localversion").toString()));
+        labelCheckUpdate->setText(tr("Update to %1 is available.").arg(info.value("remoteversion").toString()));
         labelCheckUpdate->setVisible(true);
     } else {
         labelCheckUpdate->setVisible(false);


### PR DESCRIPTION
## Problem

The status-bar update notice interpolates the *local* version into a string that is meant to name the *new* one, so a node is told to update to the version it is already running. A client on 4.22.9.3 with 4.22.9.4 available renders:

```
Update to 4.22.9.3 is available.
```

Cosmetic but actively confusing: the notice appears to be telling the user to install what they already have, which reads as a bug in the update check itself and invites them to dismiss it.

## Fix

Use `remoteversion` instead of `localversion` for the label argument. Both keys are already present in the map that `UpdateCheckWorker::check()` builds, so the label just needs the other one.

```diff
-labelCheckUpdate->setText(tr("Update to %1 is available.").arg(info.value("localversion").toString()));
+labelCheckUpdate->setText(tr("Update to %1 is available.").arg(info.value("remoteversion").toString()));
```

## Scope

Only the status-bar label was wrong. The dialog behind the click (`HelpMessageDialog::showUpdateInfo`) already reports both the installed and the latest repository version correctly, and is untouched here.

The translated source string `"Update to %1 is available."` is unchanged, so no locale updates are needed and existing translations keep working.

## Testing

`src/qt/bitcoingui.cpp` compiles clean.

Runtime behaviour is not covered by an automated test; the Qt update notice has no functional-test coverage.

## Related

Backported to the 4.22.9 release line in a companion PR.

YouTrack: https://reddink.youtrack.cloud/issue/RED-100