### PR TITLE
gui: name the available version in the update notice

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -297,7 +297,7 @@ void BitcoinGUI::checkUpdates()
         }
 
         if (updateavailable) {
-            labelCheckUpdate->setText(tr("Update to %1 is available.").arg(QString::fromStdString(localversion)));
+            labelCheckUpdate->setText(tr("Update to %1 is available.").arg(QString::fromStdString(remoteversion)));
             labelCheckUpdate->setVisible(true);
         } else {
             labelCheckUpdate->setVisible(false);


### PR DESCRIPTION
Backport of #501 to the 4.22.9 release line.

## Problem

The status-bar update notice interpolates the *local* version into a string that is meant to name the *new* one, so a node is told to update to the version it is already running. A client on 4.22.9.3 with 4.22.9.4 available renders:

```
Update to 4.22.9.3 is available.
```

Cosmetic but actively confusing: the notice appears to be telling the user to install what they already have, which reads as a bug in the update check itself and invites them to dismiss it. This matters more on the release line than on develop, since these are the nodes that actually see the 4.22.9.4 notice.

## Fix

Here the check is still synchronous, and the surrounding block already reads `remoteversion` out of the `checkforupdatesinfo` result into a local, so only the argument changes:

```diff
-labelCheckUpdate->setText(tr("Update to %1 is available.").arg(QString::fromStdString(localversion)));
+labelCheckUpdate->setText(tr("Update to %1 is available.").arg(QString::fromStdString(remoteversion)));
```

## Scope

Only the status-bar label was wrong. The dialog behind the click (`HelpMessageDialog::showUpdateInfo`) already reports both the installed and the latest repository version correctly, and is untouched here.

The translated source string `"Update to %1 is available."` is unchanged, so no locale updates are needed and existing translations keep working.

## Notes

This leaves `localversion` assigned but no longer read inside `checkUpdates()`. That produces no warning: it is a `std::string`, and `-Wunused-but-set-variable` does not apply to non-trivial class types. The same block already declares four other unused `std::string` locals (`message`, `warning`, `officialDownloadLink`, `errors`), so the pattern is pre-existing. The variable is left in place to keep the change to a single word, per the policy of holding this branch close to the release.

## Testing

Not compiled on this branch: it is a one-word substitution between two locals of the same type in the same scope, both already consumed by the same `QString::fromStdString()` call shape a few lines apart. The equivalent change compiles clean on develop in #501.

Runtime behaviour is not covered by an automated test; the Qt update notice has no functional-test coverage, and no functional test runs on this branch.

YouTrack: https://reddink.youtrack.cloud/issue/RED-100