### PR TITLE
node: verify TLS certificates and send SNI in the update check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -652,6 +652,10 @@ case $host in
      AC_CHECK_LIB([ws2_32],   [WSAStartup],, AC_MSG_ERROR(libws2_32 missing))
      AC_CHECK_LIB([shlwapi],  [PathRemoveFileSpecW],, AC_MSG_ERROR(libshlwapi missing))
      AC_CHECK_LIB([iphlpapi], [GetAdaptersAddresses],, AC_MSG_ERROR(libiphlpapi missing))
+     dnl OpenSSL's winstore loader reads the system ROOT certificate store, which
+     dnl is how the update check gets its TLS trust anchors on Windows. depends
+     dnl must not be configured with no-winstore.
+     AC_CHECK_LIB([crypt32],  [CertOpenStore],, AC_MSG_ERROR(libcrypt32 missing))
 
      dnl -static is interpreted by libtool, where it has a different meaning.
      dnl In libtool-speak, it's -all-static.
@@ -734,6 +738,9 @@ case $host in
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"],, [[$LDFLAG_WERROR]])
      CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
+     dnl The update check reads its TLS trust anchors from the system trust
+     dnl store, which OpenSSL has no loader for on this platform.
+     LIBS="$LIBS -framework Security -framework CoreFoundation"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *android*)

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -112,6 +112,7 @@ MACHO_ALLOWED_LIBRARIES = {
 
 PE_ALLOWED_LIBRARIES = {
 'ADVAPI32.dll', # security & registry
+'CRYPT32.dll', # certificate store, for the update check's TLS trust anchors
 'IPHLPAPI.DLL', # IP helper API
 'KERNEL32.dll', # win32 base APIs
 'msvcrt.dll', # C standard library for MSVC

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -37,11 +37,11 @@ $(package)_config_opts+=no-tests
 $(package)_config_opts+=no-unit-test
 $(package)_config_opts+=no-weak-ssl-ciphers
 $(package)_config_opts+=no-whirlpool
-# The 3.x series added a store backed by the Windows certificate store, which
-# calls into crypt32 and so does not link unless that library is added to every
-# Windows target. Nothing here uses it, and capieng above is already disabled
-# for the same reason.
-$(package)_config_opts+=no-winstore
+# The 3.x series added a store backed by the Windows certificate store. It is
+# how the update check gets its TLS trust anchors on Windows, since depends
+# bakes the builder's own path into OPENSSLDIR and so the default verify paths
+# find nothing on the machine that runs the binary. It calls into crypt32,
+# which configure.ac links for every Windows target.
 $(package)_config_opts+=no-zlib
 $(package)_config_opts+=no-zlib-dynamic
 $(package)_config_opts+=$($(package)_cflags) $($(package)_cppflags)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -187,6 +187,7 @@ BITCOIN_CORE_H = \
   node/blockstorage.h \
   node/coin.h \
   node/coinstats.h \
+  node/ca_store.h \
   node/context.h \
   node/psbt.h \
   node/transaction.h \
@@ -365,6 +366,7 @@ libbitcoin_server_a_SOURCES = \
   node/blockstorage.cpp \
   node/coin.cpp \
   node/coinstats.cpp \
+  node/ca_store.cpp \
   node/context.cpp \
   node/interfaces.cpp \
   node/psbt.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -147,6 +147,7 @@ BITCOIN_TESTS =\
   test/txrequest_tests.cpp \
   test/txvalidation_tests.cpp \
   test/uint256_tests.cpp \
+  test/update_check_tests.cpp \
   test/uint512_tests.cpp \
   test/util_tests.cpp \
   test/validation_block_tests.cpp \

--- a/src/node/ca_store.cpp
+++ b/src/node/ca_store.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/ca_store.h>
+
+#include <openssl/err.h>
+#include <openssl/opensslv.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+
+#include <cstdlib>
+#include <string>
+
+#if defined(WIN32)
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#error "Windows builds need OpenSSL 3.0 or later for the winstore certificate loader; build against depends."
+#endif
+#elif defined(MAC_OSX)
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+#else
+#include <sys/stat.h>
+#endif
+
+namespace {
+#if defined(MAC_OSX)
+//! Add one DER-encoded certificate to a store.
+//!
+//! A certificate the store already holds is not a failure. Platform trust
+//! stores can list the same root more than once, and OpenSSL reports the
+//! duplicate as an error that would otherwise abort the whole load.
+bool AddDerCertificate(X509_STORE* store, const unsigned char* der, long der_len)
+{
+    // d2i_X509 advances the pointer it is given, so hand it a copy.
+    const unsigned char* pos{der};
+    X509* cert{d2i_X509(nullptr, &pos, der_len)};
+    if (cert == nullptr) {
+        ERR_clear_error();
+        return false;
+    }
+
+    bool ok{true};
+    if (X509_STORE_add_cert(store, cert) != 1) {
+        ok = ERR_GET_REASON(ERR_peek_last_error()) == X509_R_CERT_ALREADY_IN_HASH_TABLE;
+        ERR_clear_error();
+    }
+
+    // X509_STORE_add_cert takes its own reference, so drop ours either way.
+    X509_free(cert);
+    return ok;
+}
+#endif // MAC_OSX
+
+#if !defined(WIN32) && !defined(MAC_OSX)
+//! Bundle locations used by the distributions this is likely to run on. The
+//! first one that exists wins; they hold the same set of public roots.
+const char* const CA_FILE_CANDIDATES[]{
+    "/etc/ssl/certs/ca-certificates.crt",                // Debian, Ubuntu, Gentoo, Alpine
+    "/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora, RHEL, CentOS
+    "/etc/ssl/ca-bundle.pem",                            // openSUSE
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS 7 and later
+    "/etc/ssl/cert.pem",                                 // FreeBSD, OpenBSD, Alpine
+};
+
+//! Hashed certificate directories, used only if no bundle file is found.
+const char* const CA_DIR_CANDIDATES[]{
+    "/etc/ssl/certs",
+    "/etc/pki/tls/certs",
+};
+
+bool PathExists(const char* path)
+{
+    struct stat sb;
+    return ::stat(path, &sb) == 0;
+}
+#endif // !WIN32 && !MAC_OSX
+} // namespace
+
+std::string node::LoadTrustedCACertificates(SSL_CTX* ssl_ctx)
+{
+    if (ssl_ctx == nullptr) return "No TLS context to load certificates into";
+
+#if defined(WIN32)
+    // OpenSSL 3.2 and later expose the Windows ROOT store through the OSSL_STORE
+    // URI below. It reads the same anchors the rest of the system trusts, so it
+    // picks up enterprise roots and administrator revocations without any
+    // enumeration code here. depends must not be configured with no-winstore.
+    if (SSL_CTX_load_verify_store(ssl_ctx, "org.openssl.winstore://") != 1) {
+        ERR_clear_error();
+        return "Could not read the Windows system certificate store";
+    }
+    return "";
+
+#elif defined(MAC_OSX)
+    // OpenSSL has no equivalent loader for the macOS keychain, so the anchors
+    // are copied across one at a time.
+    CFArrayRef anchors{nullptr};
+    if (SecTrustCopyAnchorCertificates(&anchors) != errSecSuccess || anchors == nullptr) {
+        return "Could not read the macOS system trust store";
+    }
+
+    X509_STORE* store{SSL_CTX_get_cert_store(ssl_ctx)};
+    if (store == nullptr) {
+        CFRelease(anchors);
+        return "No TLS certificate store to load anchors into";
+    }
+
+    long loaded{0};
+    const CFIndex count{CFArrayGetCount(anchors)};
+    for (CFIndex i = 0; i < count; ++i) {
+        const void* elem{CFArrayGetValueAtIndex(anchors, i)};
+        if (elem == nullptr) continue;
+        SecCertificateRef cert{reinterpret_cast<SecCertificateRef>(const_cast<void*>(elem))};
+
+        CFDataRef der{SecCertificateCopyData(cert)};
+        if (der == nullptr) continue;
+        if (AddDerCertificate(store, CFDataGetBytePtr(der), static_cast<long>(CFDataGetLength(der)))) {
+            ++loaded;
+        }
+        CFRelease(der);
+    }
+    CFRelease(anchors);
+
+    if (loaded == 0) return "The macOS system trust store contained no usable certificates";
+    return "";
+
+#else
+    // An explicit environment setting is honoured first, so a container or a
+    // distribution that keeps its bundle somewhere unusual can point at it
+    // without a rebuild. These are the same two variables OpenSSL's own default
+    // verify paths consult.
+    const char* const env_file{std::getenv("SSL_CERT_FILE")};
+    const char* const env_dir{std::getenv("SSL_CERT_DIR")};
+    if ((env_file != nullptr && *env_file != '\0') || (env_dir != nullptr && *env_dir != '\0')) {
+        if (SSL_CTX_load_verify_locations(ssl_ctx,
+                                          (env_file != nullptr && *env_file != '\0') ? env_file : nullptr,
+                                          (env_dir != nullptr && *env_dir != '\0') ? env_dir : nullptr) == 1) {
+            return "";
+        }
+        ERR_clear_error();
+        return "SSL_CERT_FILE or SSL_CERT_DIR is set but no certificates could be read from it";
+    }
+
+    for (const char* const candidate : CA_FILE_CANDIDATES) {
+        if (!PathExists(candidate)) continue;
+        if (SSL_CTX_load_verify_locations(ssl_ctx, candidate, nullptr) == 1) return "";
+        ERR_clear_error();
+    }
+
+    for (const char* const candidate : CA_DIR_CANDIDATES) {
+        if (!PathExists(candidate)) continue;
+        if (SSL_CTX_load_verify_locations(ssl_ctx, nullptr, candidate) == 1) return "";
+        ERR_clear_error();
+    }
+
+    // Last resort: OpenSSL's compiled-in location, which is what a build
+    // against a system OpenSSL rather than against depends will normally
+    // succeed with.
+    //
+    // Whether it exists has to be checked here. SSL_CTX_set_default_verify_paths
+    // only registers the lookups and reports success without touching the
+    // filesystem, so trusting its return value would report an empty trust
+    // store as a working one, which is precisely the depends case this function
+    // exists to catch.
+    const char* const default_file{X509_get_default_cert_file()};
+    const char* const default_dir{X509_get_default_cert_dir()};
+    if ((default_file != nullptr && PathExists(default_file)) ||
+        (default_dir != nullptr && PathExists(default_dir))) {
+        if (SSL_CTX_set_default_verify_paths(ssl_ctx) == 1) return "";
+        ERR_clear_error();
+    }
+
+    return "No CA certificate bundle was found in any of the usual locations; "
+           "set SSL_CERT_FILE or SSL_CERT_DIR to point at one";
+#endif
+}

--- a/src/node/ca_store.h
+++ b/src/node/ca_store.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_CA_STORE_H
+#define BITCOIN_NODE_CA_STORE_H
+
+#include <string>
+
+//! Forward declared so callers do not have to include the OpenSSL headers, and
+//! so this header stays free of the Boost.Asio wrapper around them.
+typedef struct ssl_ctx_st SSL_CTX;
+
+namespace node {
+/**
+ * Load the host platform's trusted root certificates into ssl_ctx.
+ *
+ * This exists because the depends build cannot use OpenSSL's default verify
+ * paths. depends configures OpenSSL with
+ * `--openssldir=$(host_prefix)/etc/openssl`, which bakes the *builder's*
+ * absolute path into libcrypto. On the machine that later runs the binary that
+ * directory does not exist, so SSL_CTX_set_default_verify_paths() installs no
+ * trust anchors at all and every verification fails. That is true of release
+ * builds on every host, not only Windows and macOS.
+ *
+ * The anchors therefore come from the operating system instead:
+ *
+ *   - Windows: OpenSSL's own winstore loader, which reads the system ROOT
+ *     certificate store.
+ *   - macOS: the system trust store via Security.framework.
+ *   - Everything else: SSL_CERT_FILE / SSL_CERT_DIR when set, otherwise the
+ *     first of the well-known distribution bundle locations that exists.
+ *
+ * Taking the anchors from the platform rather than shipping a bundle means the
+ * trust list follows the operating system's own updates and revocations, and
+ * leaves no CA list in this repository that somebody has to remember to
+ * refresh.
+ *
+ * @return An empty string on success, otherwise a description of why no
+ *         anchors could be loaded. Callers must treat a non-empty return as
+ *         fatal to the connection: continuing without anchors would leave
+ *         verification enabled but trusting nothing, or worse, be papered over
+ *         by disabling verification.
+ */
+std::string LoadTrustedCACertificates(SSL_CTX* ssl_ctx);
+} // namespace node
+
+#endif // BITCOIN_NODE_CA_STORE_H

--- a/src/node/update_check.cpp
+++ b/src/node/update_check.cpp
@@ -46,6 +46,34 @@ static std::string strDownloadLink = "https://download.reddcoin.com/bin/reddcoin
 static std::string strGithubLink = "/repos/reddcoin-project/reddcoin/releases/latest";
 
 namespace {
+//! Value of one header, matched case insensitively as RFC 7230 requires, or an
+//! empty string when the header is absent.
+//!
+//! headers is the status line plus the header block, without the blank line
+//! that terminates it. Matching walks line by line rather than searching the
+//! block for the name, so a name appearing inside some other header's value
+//! cannot be mistaken for the header itself.
+std::string GetHeader(const std::string& headers, const std::string& lower_name)
+{
+    std::string::size_type pos{headers.find("\r\n")};
+    while (pos != std::string::npos) {
+        const std::string::size_type start{pos + 2};
+        std::string::size_type end{headers.find("\r\n", start)};
+        const bool last_line{end == std::string::npos};
+        if (last_line) end = headers.size();
+
+        const std::string line{headers.substr(start, end - start)};
+        const std::string::size_type colon{line.find(':')};
+        if (colon != std::string::npos && ToLower(line.substr(0, colon)) == lower_name) {
+            return TrimString(line.substr(colon + 1));
+        }
+
+        if (last_line) break;
+        pos = end;
+    }
+    return "";
+}
+
 const std::string UPDATE_CHECK_HOST{"api.github.com"};
 
 //! Budget for the whole exchange, from name resolution to the last byte of the
@@ -180,11 +208,16 @@ std::string HttpsFetcher::Get(const std::string& target)
     Await("sending the request to " + m_host);
 
     // The server was asked to close when done, so read to the end of the
-    // stream. Both a clean end of file and a connection dropped without a TLS
-    // shutdown mean the response is complete.
+    // stream. Neither ending is an error here: a clean end of file means the
+    // peer sent close_notify, and a truncated stream means the connection went
+    // away without one, which plenty of servers do. They are not equivalent
+    // though, so which one arrived is carried through to the completeness check
+    // rather than being flattened into success.
+    bool clean_eof{false};
     boost::asio::streambuf response;
     boost::asio::async_read(m_stream, response, boost::asio::transfer_all(),
         [&](const boost::system::error_code& ec, std::size_t) {
+            clean_eof = (ec == boost::asio::error::eof);
             m_ec = (ec == boost::asio::error::eof || ec == boost::asio::ssl::error::stream_truncated)
                        ? boost::system::error_code{}
                        : ec;
@@ -194,12 +227,16 @@ std::string HttpsFetcher::Get(const std::string& target)
 
     std::ostringstream raw;
     raw << &response;
-    const std::string str_raw{raw.str()};
+    return node::ExtractHttpBody(raw.str(), clean_eof);
+}
+} // namespace
 
+std::string node::ExtractHttpBody(const std::string& raw_response, bool clean_eof)
+{
     // Status line.
-    const std::string::size_type eol{str_raw.find("\r\n")};
+    const std::string::size_type eol{raw_response.find("\r\n")};
     if (eol == std::string::npos) throw std::runtime_error("Invalid response");
-    std::istringstream status_stream{str_raw.substr(0, eol)};
+    std::istringstream status_stream{raw_response.substr(0, eol)};
     std::string http_version;
     unsigned int status_code{0};
     status_stream >> http_version >> status_code;
@@ -211,11 +248,37 @@ std::string HttpsFetcher::Get(const std::string& target)
     }
 
     // Headers are terminated by a blank line; everything after it is the body.
-    const std::string::size_type body{str_raw.find("\r\n\r\n")};
-    if (body == std::string::npos) throw std::runtime_error("Invalid response");
-    return str_raw.substr(body + 4);
+    const std::string::size_type terminator{raw_response.find("\r\n\r\n")};
+    if (terminator == std::string::npos) throw std::runtime_error("Invalid response");
+    const std::string headers{raw_response.substr(0, terminator)};
+    std::string body{raw_response.substr(terminator + 4)};
+
+    // A chunked body carries its own framing, which is not decoded here, so
+    // returning it would hand back the chunk sizes along with the content.
+    // Reject it rather than pass it off as the body.
+    const std::string transfer_encoding{GetHeader(headers, "transfer-encoding")};
+    if (!transfer_encoding.empty()) {
+        throw std::runtime_error("Response uses an unsupported transfer encoding: " + transfer_encoding);
+    }
+
+    const std::string content_length{GetHeader(headers, "content-length")};
+    if (!content_length.empty()) {
+        int64_t expected{0};
+        if (!ParseInt64(content_length, &expected) || expected < 0) {
+            throw std::runtime_error("Response has an unusable Content-Length: " + content_length);
+        }
+        if (body.size() != static_cast<std::string::size_type>(expected)) {
+            throw std::runtime_error("Incomplete response: got " + ToString(body.size()) +
+                                     " of " + content_length + " bytes");
+        }
+    } else if (!clean_eof) {
+        // Without a Content-Length the body runs until the connection closes,
+        // so a clean shutdown is the only evidence that all of it arrived.
+        throw std::runtime_error("Response gave no Content-Length and ended without a clean shutdown");
+    }
+
+    return body;
 }
-} // namespace
 
 std::string node::SslVersion()
 {

--- a/src/node/update_check.cpp
+++ b/src/node/update_check.cpp
@@ -35,6 +35,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <ostream>
 #include <regex>
 #include <sstream>
@@ -72,6 +73,67 @@ std::string GetHeader(const std::string& headers, const std::string& lower_name)
         pos = end;
     }
     return "";
+}
+
+//! Parse a hexadecimal chunk size. Rejects an empty field, a non-hex
+//! character, and anything wider than 64 bits.
+bool ParseChunkSize(const std::string& str, uint64_t& out)
+{
+    if (str.empty() || str.size() > 16) return false;
+    uint64_t value{0};
+    for (const char c : str) {
+        const signed char digit{HexDigit(c)};
+        if (digit < 0) return false;
+        value = (value << 4) | static_cast<uint64_t>(digit);
+    }
+    out = value;
+    return true;
+}
+
+//! Reassemble a chunked body.
+//!
+//! Completeness is inherent here rather than checked afterwards: the loop only
+//! returns on the terminating zero length chunk, so a body that stops early
+//! throws instead of yielding what arrived. Chunk extensions and trailers are
+//! ignored, neither being used by anything this talks to.
+std::string DecodeChunkedBody(const std::string& body)
+{
+    std::string decoded;
+    std::string::size_type pos{0};
+
+    while (true) {
+        const std::string::size_type eol{body.find("\r\n", pos)};
+        if (eol == std::string::npos) {
+            throw std::runtime_error("Chunked response ended before its final chunk");
+        }
+
+        std::string size_field{body.substr(pos, eol - pos)};
+        const std::string::size_type extension{size_field.find(';')};
+        if (extension != std::string::npos) size_field = size_field.substr(0, extension);
+
+        uint64_t size{0};
+        if (!ParseChunkSize(TrimString(size_field), size)) {
+            throw std::runtime_error("Chunked response has an unusable chunk size");
+        }
+        pos = eol + 2;
+
+        // The zero length chunk ends the body. Anything after it is trailers.
+        if (size == 0) return decoded;
+
+        // Each chunk is followed by its own CRLF, so both it and the data have
+        // to be present. Compared this way round so neither side can overflow.
+        const std::string::size_type available{body.size() - pos};
+        if (size > available || available - size < 2) {
+            throw std::runtime_error("Chunked response ended mid-chunk");
+        }
+
+        decoded.append(body, pos, static_cast<std::string::size_type>(size));
+        pos += static_cast<std::string::size_type>(size);
+        if (body.compare(pos, 2, "\r\n") != 0) {
+            throw std::runtime_error("Chunked response has a malformed chunk terminator");
+        }
+        pos += 2;
+    }
 }
 
 const std::string UPDATE_CHECK_HOST{"api.github.com"};
@@ -253,12 +315,20 @@ std::string node::ExtractHttpBody(const std::string& raw_response, bool clean_eo
     const std::string headers{raw_response.substr(0, terminator)};
     std::string body{raw_response.substr(terminator + 4)};
 
-    // A chunked body carries its own framing, which is not decoded here, so
-    // returning it would hand back the chunk sizes along with the content.
-    // Reject it rather than pass it off as the body.
-    const std::string transfer_encoding{GetHeader(headers, "transfer-encoding")};
+    // A chunked body carries its own framing, so the chunk sizes have to be
+    // stripped out before anything downstream sees the content. api.github.com
+    // does use this: it answers with Content-Length most of the time and
+    // switches to chunked intermittently, so a client that cannot reassemble a
+    // chunked body fails a fraction of its checks for no visible reason.
+    //
+    // Content-Length is not consulted in this case. RFC 7230 forbids sending
+    // both, and the terminating chunk is what proves the body is complete.
+    const std::string transfer_encoding{ToLower(GetHeader(headers, "transfer-encoding"))};
     if (!transfer_encoding.empty()) {
-        throw std::runtime_error("Response uses an unsupported transfer encoding: " + transfer_encoding);
+        if (transfer_encoding != "chunked") {
+            throw std::runtime_error("Response uses an unsupported transfer encoding: " + transfer_encoding);
+        }
+        return DecodeChunkedBody(body);
     }
 
     const std::string content_length{GetHeader(headers, "content-length")};

--- a/src/node/update_check.cpp
+++ b/src/node/update_check.cpp
@@ -5,6 +5,7 @@
 #include <node/update_check.h>
 
 #include <clientversion.h>
+#include <node/ca_store.h>
 #include <util/semver.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -29,6 +30,8 @@
 
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
+#include <openssl/ssl.h>
+#include <openssl/tls1.h>
 
 #include <chrono>
 #include <cstddef>
@@ -67,6 +70,30 @@ public:
           m_ssl_ctx{boost::asio::ssl::context::tls_client},
           m_stream{m_ioc, m_ssl_ctx}
     {
+        // Without this the connection is encrypted but unauthenticated: any
+        // party able to intercept it can present any certificate and substitute
+        // the response. The most useful thing that buys an attacker is silently
+        // suppressing upgrade notices, which is the wrong failure mode for the
+        // mechanism whose job is to get security fixes onto user machines.
+        const std::string ca_error{node::LoadTrustedCACertificates(m_ssl_ctx.native_handle())};
+        if (!ca_error.empty()) throw std::runtime_error(ca_error);
+
+        // verify_peer rejects a certificate that does not chain to one of those
+        // anchors; the callback additionally binds the certificate to the host
+        // that was asked for, so a valid certificate for some other name is no
+        // use. Boost 1.71 spells this rfc2818_verification; the
+        // host_name_verification that replaced it arrived in 1.73.
+        m_ssl_ctx.set_verify_mode(boost::asio::ssl::verify_peer);
+        m_ssl_ctx.set_verify_callback(boost::asio::ssl::rfc2818_verification(m_host));
+
+        // Server Name Indication. Without it a host that serves several names
+        // from one address, which includes anything behind a CDN, cannot tell
+        // which certificate to present and may not serve the request at all.
+        // This is a functional fix rather than a security one: the certificate
+        // is checked against m_host above regardless of what SNI asked for.
+        if (SSL_set_tlsext_host_name(m_stream.native_handle(), m_host.c_str()) != 1) {
+            throw std::runtime_error("Could not set the TLS server name for " + m_host);
+        }
     }
 
     //! Fetch target and return the response body. Throws std::runtime_error on

--- a/src/node/update_check.h
+++ b/src/node/update_check.h
@@ -22,6 +22,33 @@ namespace node {
 std::string SslVersion();
 
 /**
+ * Split an HTTP/1.x response into its body, rejecting anything that cannot be
+ * shown to be complete.
+ *
+ * Completeness has to be checked explicitly. The response is read to the end of
+ * the stream, and at that layer a connection that died mid-body looks exactly
+ * like one that finished, so a truncated body would otherwise be returned as a
+ * successful result. For the update check that surfaces as an upgrade notice
+ * that silently never appears; for anything that later downloads a file it
+ * would mean a partial download reported as a complete one.
+ *
+ * A body is accepted when its length matches Content-Length, or, when the
+ * response carries no Content-Length and is therefore delimited by the
+ * connection closing, when the stream ended with a clean TLS shutdown.
+ *
+ * @param[in] raw_response The status line, headers and body as received.
+ * @param[in] clean_eof    Whether the read ended with a clean end of file
+ *                         rather than a truncated stream.
+ * @return The response body.
+ * @throws std::runtime_error if the response is malformed, reports a status
+ *         other than 200, uses a transfer encoding this does not decode, or
+ *         cannot be shown to have arrived in full.
+ *
+ * Exposed for testing.
+ */
+std::string ExtractHttpBody(const std::string& raw_response, bool clean_eof);
+
+/**
  * Ask the release server which version is current and report how it compares
  * with this build.
  *

--- a/src/node/update_check.h
+++ b/src/node/update_check.h
@@ -36,12 +36,16 @@ std::string SslVersion();
  * response carries no Content-Length and is therefore delimited by the
  * connection closing, when the stream ended with a clean TLS shutdown.
  *
+ * A chunked body is reassembled, and is complete only if its terminating zero
+ * length chunk arrived. api.github.com answers with Content-Length most of the
+ * time and switches to chunked intermittently, so both have to work.
+ *
  * @param[in] raw_response The status line, headers and body as received.
  * @param[in] clean_eof    Whether the read ended with a clean end of file
  *                         rather than a truncated stream.
  * @return The response body.
  * @throws std::runtime_error if the response is malformed, reports a status
- *         other than 200, uses a transfer encoding this does not decode, or
+ *         other than 200, uses a transfer encoding other than chunked, or
  *         cannot be shown to have arrived in full.
  *
  * Exposed for testing.

--- a/src/test/update_check_tests.cpp
+++ b/src/test/update_check_tests.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/update_check.h>
+
+#include <test/util/setup_common.h>
+#include <util/string.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <stdexcept>
+#include <string>
+
+using node::ExtractHttpBody;
+
+namespace {
+//! The body every positive case expects back, shaped like the response the
+//! update check actually parses.
+const std::string BODY{"{\"tag_name\":\"v4.22.9.4\"}"};
+
+std::string WithLength(const std::string& body, const std::string& declared_length)
+{
+    return "HTTP/1.1 200 OK\r\n"
+           "Content-Type: application/json\r\n"
+           "Content-Length: " +
+           declared_length + "\r\n\r\n" + body;
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(update_check_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(complete_body_is_returned)
+{
+    BOOST_CHECK_EQUAL(ExtractHttpBody(WithLength(BODY, ToString(BODY.size())), true), BODY);
+
+    // A truncated stream is fine when Content-Length accounts for every byte:
+    // plenty of servers close without a TLS shutdown.
+    BOOST_CHECK_EQUAL(ExtractHttpBody(WithLength(BODY, ToString(BODY.size())), false), BODY);
+}
+
+BOOST_AUTO_TEST_CASE(short_body_is_rejected)
+{
+    // The regression this guards. Before the completeness check a body cut off
+    // mid-flight was returned as a successful result, so the caller saw a well
+    // formed but empty answer and reported no error at all: an upgrade notice
+    // that silently never appears.
+    const std::string cut{BODY.substr(0, BODY.size() - 5)};
+    const std::string response{WithLength(cut, ToString(BODY.size()))};
+
+    BOOST_CHECK_THROW(ExtractHttpBody(response, false), std::runtime_error);
+    // Clean shutdown or not, a short body is still short.
+    BOOST_CHECK_THROW(ExtractHttpBody(response, true), std::runtime_error);
+
+    // The error has to name the shortfall, otherwise a truncated download is
+    // indistinguishable from an unreachable server in the logs.
+    try {
+        ExtractHttpBody(response, false);
+        BOOST_ERROR("expected a throw");
+    } catch (const std::runtime_error& e) {
+        const std::string what{e.what()};
+        BOOST_CHECK(what.find("Incomplete response") != std::string::npos);
+        BOOST_CHECK(what.find(ToString(cut.size())) != std::string::npos);
+        BOOST_CHECK(what.find(ToString(BODY.size())) != std::string::npos);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(overlong_body_is_rejected)
+{
+    BOOST_CHECK_THROW(ExtractHttpBody(WithLength(BODY + "trailing", ToString(BODY.size())), true),
+                      std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(unusable_content_length_is_rejected)
+{
+    BOOST_CHECK_THROW(ExtractHttpBody(WithLength(BODY, "not-a-number"), true), std::runtime_error);
+    BOOST_CHECK_THROW(ExtractHttpBody(WithLength(BODY, "-1"), true), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(connection_close_framing_needs_a_clean_shutdown)
+{
+    // No Content-Length, so the body runs until the connection closes and only
+    // a clean shutdown proves all of it arrived.
+    const std::string response{"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n" + BODY};
+
+    BOOST_CHECK_EQUAL(ExtractHttpBody(response, true), BODY);
+    BOOST_CHECK_THROW(ExtractHttpBody(response, false), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(chunked_encoding_is_rejected)
+{
+    // Chunk sizes are interleaved with the content and are not decoded here,
+    // so the body must not be handed back as if it were the payload.
+    const std::string response{
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n"
+        "17\r\n" +
+        BODY + "\r\n0\r\n\r\n"};
+
+    BOOST_CHECK_THROW(ExtractHttpBody(response, true), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(headers_match_case_insensitively)
+{
+    // RFC 7230 field names are case insensitive, and the casing a server picks
+    // must not decide whether the length is checked at all.
+    const std::string lower{"HTTP/1.1 200 OK\r\ncontent-length: " + ToString(BODY.size()) + "\r\n\r\n" + BODY};
+    const std::string upper{"HTTP/1.1 200 OK\r\nCONTENT-LENGTH: " + ToString(BODY.size()) + "\r\n\r\n" + BODY};
+    BOOST_CHECK_EQUAL(ExtractHttpBody(lower, false), BODY);
+    BOOST_CHECK_EQUAL(ExtractHttpBody(upper, false), BODY);
+
+    const std::string short_lower{"HTTP/1.1 200 OK\r\ncontent-length: 999\r\n\r\n" + BODY};
+    BOOST_CHECK_THROW(ExtractHttpBody(short_lower, false), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(header_name_inside_a_value_is_not_matched)
+{
+    // "content-length" appears in another header's value. Matching the block
+    // rather than each field name would pick it up and check the wrong number.
+    const std::string response{
+        "HTTP/1.1 200 OK\r\n"
+        "X-Note: content-length: 99999\r\n\r\n" +
+        BODY};
+
+    // No real Content-Length, so this falls through to the clean shutdown rule.
+    BOOST_CHECK_EQUAL(ExtractHttpBody(response, true), BODY);
+    BOOST_CHECK_THROW(ExtractHttpBody(response, false), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(malformed_responses_are_rejected)
+{
+    BOOST_CHECK_THROW(ExtractHttpBody("", true), std::runtime_error);
+    BOOST_CHECK_THROW(ExtractHttpBody("not http at all\r\n\r\n", true), std::runtime_error);
+    // Headers never terminated.
+    BOOST_CHECK_THROW(ExtractHttpBody("HTTP/1.1 200 OK\r\nContent-Length: 1\r\n", true), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(non_200_status_is_rejected)
+{
+    for (const std::string& status : {"404 Not Found", "403 Forbidden", "500 Internal Server Error"}) {
+        const std::string response{"HTTP/1.1 " + status + "\r\nContent-Length: 0\r\n\r\n"};
+        BOOST_CHECK_THROW(ExtractHttpBody(response, true), std::runtime_error);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/update_check_tests.cpp
+++ b/src/test/update_check_tests.cpp
@@ -5,6 +5,7 @@
 #include <node/update_check.h>
 
 #include <test/util/setup_common.h>
+#include <tinyformat.h>
 #include <util/string.h>
 
 #include <boost/test/unit_test.hpp>
@@ -18,6 +19,12 @@ namespace {
 //! The body every positive case expects back, shaped like the response the
 //! update check actually parses.
 const std::string BODY{"{\"tag_name\":\"v4.22.9.4\"}"};
+
+//! Chunk sizes are hexadecimal.
+std::string ToHex(std::string::size_type n)
+{
+    return strprintf("%x", n);
+}
 
 std::string WithLength(const std::string& body, const std::string& declared_length)
 {
@@ -87,16 +94,66 @@ BOOST_AUTO_TEST_CASE(connection_close_framing_needs_a_clean_shutdown)
     BOOST_CHECK_THROW(ExtractHttpBody(response, false), std::runtime_error);
 }
 
-BOOST_AUTO_TEST_CASE(chunked_encoding_is_rejected)
+BOOST_AUTO_TEST_CASE(chunked_body_is_reassembled)
 {
-    // Chunk sizes are interleaved with the content and are not decoded here,
-    // so the body must not be handed back as if it were the payload.
-    const std::string response{
-        "HTTP/1.1 200 OK\r\n"
-        "Transfer-Encoding: chunked\r\n\r\n"
-        "17\r\n" +
-        BODY + "\r\n0\r\n\r\n"};
+    // api.github.com answers with Content-Length most of the time and switches
+    // to chunked intermittently, so both have to work. Before this was decoded
+    // the chunk sizes were handed back as part of the body, the JSON parse
+    // failed, and the update check reported nothing at all.
+    const std::string head{"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"};
 
+    // One chunk holding the whole body.
+    const std::string single{head + ToHex(BODY.size()) + "\r\n" + BODY + "\r\n0\r\n\r\n"};
+    BOOST_CHECK_EQUAL(ExtractHttpBody(single, true), BODY);
+
+    // Split across chunks, which is the shape a real server sends.
+    const std::string first{BODY.substr(0, 8)};
+    const std::string rest{BODY.substr(8)};
+    const std::string split{head + ToHex(first.size()) + "\r\n" + first + "\r\n" +
+                            ToHex(rest.size()) + "\r\n" + rest + "\r\n0\r\n\r\n"};
+    BOOST_CHECK_EQUAL(ExtractHttpBody(split, true), BODY);
+
+    // Chunk extensions are ignored, and trailers after the final chunk too.
+    const std::string extras{head + ToHex(BODY.size()) + ";name=value\r\n" + BODY +
+                             "\r\n0\r\nX-Trailer: ignored\r\n\r\n"};
+    BOOST_CHECK_EQUAL(ExtractHttpBody(extras, true), BODY);
+
+    // Case of the header value must not decide whether it is decoded.
+    const std::string upper{"HTTP/1.1 200 OK\r\nTransfer-Encoding: CHUNKED\r\n\r\n" +
+                            ToHex(BODY.size()) + "\r\n" + BODY + "\r\n0\r\n\r\n"};
+    BOOST_CHECK_EQUAL(ExtractHttpBody(upper, true), BODY);
+}
+
+BOOST_AUTO_TEST_CASE(incomplete_chunked_body_is_rejected)
+{
+    const std::string head{"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"};
+
+    // The terminating zero length chunk never arrived, so the body is short
+    // even though everything received parsed cleanly.
+    const std::string no_last_chunk{head + ToHex(BODY.size()) + "\r\n" + BODY + "\r\n"};
+    BOOST_CHECK_THROW(ExtractHttpBody(no_last_chunk, true), std::runtime_error);
+
+    // Cut off partway through a chunk's data.
+    const std::string mid_chunk{head + ToHex(BODY.size()) + "\r\n" + BODY.substr(0, 6)};
+    BOOST_CHECK_THROW(ExtractHttpBody(mid_chunk, true), std::runtime_error);
+
+    // A chunk whose declared size overruns what is present.
+    const std::string overrun{head + "ffff\r\n" + BODY + "\r\n0\r\n\r\n"};
+    BOOST_CHECK_THROW(ExtractHttpBody(overrun, true), std::runtime_error);
+
+    // Size field that is not hexadecimal.
+    const std::string bad_size{head + "zz\r\n" + BODY + "\r\n0\r\n\r\n"};
+    BOOST_CHECK_THROW(ExtractHttpBody(bad_size, true), std::runtime_error);
+
+    // Chunk data not followed by its CRLF.
+    const std::string bad_terminator{head + ToHex(BODY.size()) + "\r\n" + BODY + "XX0\r\n\r\n"};
+    BOOST_CHECK_THROW(ExtractHttpBody(bad_terminator, true), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(other_transfer_encodings_are_rejected)
+{
+    // Only chunked is decoded. Anything else must not be passed off as a body.
+    const std::string response{"HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\n\r\n" + BODY};
     BOOST_CHECK_THROW(ExtractHttpBody(response, true), std::runtime_error);
 }
 


### PR DESCRIPTION
Fixes the update check accepting any certificate from any party able to intercept the connection.

## Problem

`HttpsFetcher` constructed an ssl context and never configured it, so there were no trust anchors, verification was never requested, and the hostname was never checked against the certificate. The connection was encrypted but unauthenticated.

The most useful thing that buys an attacker is **silently suppressing upgrade notices**, which is the wrong failure mode for the mechanism whose job is to get security fixes onto user machines. It also let them inject an arbitrary version string into the comparison. The blast radius is limited today because `officialDownloadLink` is assembled from compiled-in constants, but that limit disappears as soon as the client downloads anything, which is why this gates RED-98.

## A correction to the issue and the design doc

Both say Linux is fine and only Windows and macOS need care. That is wrong, and it makes the "obvious" fix actively harmful.

depends builds OpenSSL with `--openssldir=$(host_prefix)/etc/openssl`, which bakes the **builder's absolute path** into libcrypto. Read back out of the built `libcrypto.a`:

```
OPENSSLDIR: "/home/john/.../reddcoin/depends/x86_64-pc-linux-gnu/etc/openssl"
```

That directory exists on no user's machine on **any** platform. So a fix that just calls `set_default_verify_paths()` plus `verify_peer` would find zero anchors and break the update check on every release binary, turning a silent weakness into a visible outage everywhere.

Two smaller corrections:

- `host_name_verification`, which the issue and the design doc both prescribe, **arrived in Boost 1.73**. depends pins 1.71, which has only `rfc2818_verification`. The prescribed call would not compile.
- OpenSSL's `winstore` was explicitly disabled in depends (`no-winstore`), so it had to be enabled here.

## Fix

Anchors come from the operating system, in new `src/node/ca_store.{h,cpp}`:

| Platform | Source |
| --- | --- |
| Windows | OpenSSL's winstore loader over the system ROOT store |
| macOS | system trust store via Security.framework |
| Everything else | `SSL_CERT_FILE` / `SSL_CERT_DIR`, else the first well-known distribution bundle that exists |

Taking anchors from the platform means the trust list follows the OS's own updates and revocations, and leaves no CA list in this repository for somebody to remember to refresh. That is the same reasoning that led the epic to reject pinning a release key.

The fetcher then sets `verify_peer`, an `rfc2818_verification` callback bound to the host, and SNI via `SSL_set_tlsext_host_name`.

**Failing to obtain anchors is fatal to the connection**, not a downgrade to an unverified fetch. It surfaces through the existing `errors` field.

One subtlety worth reviewing: the loader checks the compiled-in location *exists* before falling back to it, because `SSL_CTX_set_default_verify_paths` only registers the lookups and reports success without touching the filesystem. Trusting its return value would report an empty trust store as a working one, which is precisely the depends case this is meant to catch.

## Build changes

- `depends/packages/openssl.mk`: drop `no-winstore`.
- `configure.ac`: link `crypt32` on Windows, `Security` and `CoreFoundation` on macOS. Both frameworks are present in the depends SDK.

## Testing

Verified against live endpoints, using a harness around the real `ca_store.cpp` and the exact context configuration the fetcher applies:

```
PASS  accept api.github.com          -> handshake succeeded
PASS  accept download.reddcoin.com   -> handshake succeeded
PASS  reject expired.badssl.com          -> certificate verify failed
PASS  reject wrong.host.badssl.com       -> certificate verify failed
PASS  reject self-signed.badssl.com      -> certificate verify failed
PASS  reject untrusted-root.badssl.com   -> certificate verify failed
```

Fail-closed confirmed separately: with `SSL_CERT_FILE` pointing at a nonexistent path the fetch refuses to connect at all rather than proceeding unverified, and with it pointing at a real bundle it succeeds.

`src/node/ca_store.cpp` and `src/node/update_check.cpp` compile clean.

**Not verified:** the Windows and macOS paths are not compile-tested here, as this has no cross toolchain built. The winstore call and the Security.framework enumeration need a check on a real cross build before this is called done on all hosts.

YouTrack: https://reddink.youtrack.cloud/issue/RED-99
Phase 0 of https://reddink.youtrack.cloud/issue/RED-98

Backport to the 4.22.9 release line in a companion PR, which also carries the OpenSSL 1.1.1s to 3.5.7 bump that branch needs first.