### PR TITLE
rpc: verify TLS certificates and send SNI in the update check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -649,6 +649,10 @@ case $host in
      AC_CHECK_LIB([ws2_32],   [WSAStartup],, AC_MSG_ERROR(libws2_32 missing))
      AC_CHECK_LIB([shlwapi],  [PathRemoveFileSpecW],, AC_MSG_ERROR(libshlwapi missing))
      AC_CHECK_LIB([iphlpapi], [GetAdaptersAddresses],, AC_MSG_ERROR(libiphlpapi missing))
+     dnl OpenSSL's winstore loader reads the system ROOT certificate store, which
+     dnl is how the update check gets its TLS trust anchors on Windows. depends
+     dnl must not be configured with no-winstore.
+     AC_CHECK_LIB([crypt32],  [CertOpenStore],, AC_MSG_ERROR(libcrypt32 missing))
 
      dnl -static is interpreted by libtool, where it has a different meaning.
      dnl In libtool-speak, it's -all-static.
@@ -731,6 +735,9 @@ case $host in
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"],, [[$LDFLAG_WERROR]])
      CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
+     dnl The update check reads its TLS trust anchors from the system trust
+     dnl store, which OpenSSL has no loader for on this platform.
+     LIBS="$LIBS -framework Security -framework CoreFoundation"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *android*)

--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -112,6 +112,7 @@ MACHO_ALLOWED_LIBRARIES = {
 
 PE_ALLOWED_LIBRARIES = {
 'ADVAPI32.dll', # security & registry
+'CRYPT32.dll', # certificate store, for the update check's TLS trust anchors
 'IPHLPAPI.DLL', # IP helper API
 'KERNEL32.dll', # win32 base APIs
 'msvcrt.dll', # C standard library for MSVC

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,22 +1,26 @@
 package=openssl
-$(package)_version=1.1.1
-$(package)_version_suffix=s
-$(package)_download_path=https://www.openssl.org/source
-$(package)_file_name=$(package)-$($(package)_version)$($(package)_version_suffix).tar.gz
-$(package)_sha256_hash=c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa
+$(package)_version=3.5.7
+$(package)_download_path=https://github.com/openssl/openssl/releases/download/openssl-$($(package)_version)
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=a8c0d28a529ca480f9f36cf5792e2cd21984552a3c8e4aa11a24aa31aeac98e8
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)" RC="$($(package)_windres)"
 $(package)_config_opts=--prefix=$(host_prefix) --openssldir=$(host_prefix)/etc/openssl
+# The 3.x series defaults to lib64 on 64 bit targets, but everything else in
+# depends installs into lib, and that is the only library path the build is
+# given. A second directory also breaks Boost detection, which picks the first
+# candidate directory that exists and then finds no Boost in it.
+$(package)_config_opts+=--libdir=lib
 $(package)_config_opts+=no-camellia
 $(package)_config_opts+=no-capieng
 $(package)_config_opts+=no-cast
 $(package)_config_opts+=no-comp
+$(package)_config_opts+=no-docs
 $(package)_config_opts+=no-dso
 $(package)_config_opts+=no-dtls1
 $(package)_config_opts+=no-ec_nistp_64_gcc_128
 $(package)_config_opts+=no-gost
-$(package)_config_opts+=no-heartbeats
 $(package)_config_opts+=no-idea
 $(package)_config_opts+=no-md2
 $(package)_config_opts+=no-mdc2
@@ -28,11 +32,16 @@ $(package)_config_opts+=no-sctp
 $(package)_config_opts+=no-seed
 $(package)_config_opts+=no-shared
 $(package)_config_opts+=no-ssl-trace
-$(package)_config_opts+=no-ssl2
 $(package)_config_opts+=no-ssl3
+$(package)_config_opts+=no-tests
 $(package)_config_opts+=no-unit-test
 $(package)_config_opts+=no-weak-ssl-ciphers
 $(package)_config_opts+=no-whirlpool
+# The 3.x series added a store backed by the Windows certificate store. It is
+# how the update check gets its TLS trust anchors on Windows, since depends
+# bakes the builder's own path into OPENSSLDIR and so the default verify paths
+# find nothing on the machine that runs the binary. It calls into crypt32,
+# which configure.ac links for every Windows target.
 $(package)_config_opts+=no-zlib
 $(package)_config_opts+=no-zlib-dynamic
 $(package)_config_opts+=$($(package)_cflags) $($(package)_cppflags)
@@ -67,7 +76,7 @@ define $(package)_build_cmds
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install_sw
 endef
 
 define $(package)_postprocess_cmds

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -184,6 +184,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   netmessagemaker.h \
   node/blockstorage.h \
+  node/ca_store.h \
   node/coin.h \
   node/coinstats.h \
   node/context.h \
@@ -360,6 +361,7 @@ libbitcoin_server_a_SOURCES = \
   net.cpp \
   net_processing.cpp \
   node/blockstorage.cpp \
+  node/ca_store.cpp \
   node/coin.cpp \
   node/coinstats.cpp \
   node/context.cpp \

--- a/src/node/ca_store.cpp
+++ b/src/node/ca_store.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/ca_store.h>
+
+#include <openssl/err.h>
+#include <openssl/opensslv.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+
+#include <cstdlib>
+#include <string>
+
+#if defined(WIN32)
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#error "Windows builds need OpenSSL 3.0 or later for the winstore certificate loader; build against depends."
+#endif
+#elif defined(MAC_OSX)
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+#else
+#include <sys/stat.h>
+#endif
+
+namespace {
+#if defined(MAC_OSX)
+//! Add one DER-encoded certificate to a store.
+//!
+//! A certificate the store already holds is not a failure. Platform trust
+//! stores can list the same root more than once, and OpenSSL reports the
+//! duplicate as an error that would otherwise abort the whole load.
+bool AddDerCertificate(X509_STORE* store, const unsigned char* der, long der_len)
+{
+    // d2i_X509 advances the pointer it is given, so hand it a copy.
+    const unsigned char* pos{der};
+    X509* cert{d2i_X509(nullptr, &pos, der_len)};
+    if (cert == nullptr) {
+        ERR_clear_error();
+        return false;
+    }
+
+    bool ok{true};
+    if (X509_STORE_add_cert(store, cert) != 1) {
+        ok = ERR_GET_REASON(ERR_peek_last_error()) == X509_R_CERT_ALREADY_IN_HASH_TABLE;
+        ERR_clear_error();
+    }
+
+    // X509_STORE_add_cert takes its own reference, so drop ours either way.
+    X509_free(cert);
+    return ok;
+}
+#endif // MAC_OSX
+
+#if !defined(WIN32) && !defined(MAC_OSX)
+//! Bundle locations used by the distributions this is likely to run on. The
+//! first one that exists wins; they hold the same set of public roots.
+const char* const CA_FILE_CANDIDATES[]{
+    "/etc/ssl/certs/ca-certificates.crt",                // Debian, Ubuntu, Gentoo, Alpine
+    "/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora, RHEL, CentOS
+    "/etc/ssl/ca-bundle.pem",                            // openSUSE
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS 7 and later
+    "/etc/ssl/cert.pem",                                 // FreeBSD, OpenBSD, Alpine
+};
+
+//! Hashed certificate directories, used only if no bundle file is found.
+const char* const CA_DIR_CANDIDATES[]{
+    "/etc/ssl/certs",
+    "/etc/pki/tls/certs",
+};
+
+bool PathExists(const char* path)
+{
+    struct stat sb;
+    return ::stat(path, &sb) == 0;
+}
+#endif // !WIN32 && !MAC_OSX
+} // namespace
+
+std::string node::LoadTrustedCACertificates(SSL_CTX* ssl_ctx)
+{
+    if (ssl_ctx == nullptr) return "No TLS context to load certificates into";
+
+#if defined(WIN32)
+    // OpenSSL 3.2 and later expose the Windows ROOT store through the OSSL_STORE
+    // URI below. It reads the same anchors the rest of the system trusts, so it
+    // picks up enterprise roots and administrator revocations without any
+    // enumeration code here. depends must not be configured with no-winstore.
+    if (SSL_CTX_load_verify_store(ssl_ctx, "org.openssl.winstore://") != 1) {
+        ERR_clear_error();
+        return "Could not read the Windows system certificate store";
+    }
+    return "";
+
+#elif defined(MAC_OSX)
+    // OpenSSL has no equivalent loader for the macOS keychain, so the anchors
+    // are copied across one at a time.
+    CFArrayRef anchors{nullptr};
+    if (SecTrustCopyAnchorCertificates(&anchors) != errSecSuccess || anchors == nullptr) {
+        return "Could not read the macOS system trust store";
+    }
+
+    X509_STORE* store{SSL_CTX_get_cert_store(ssl_ctx)};
+    if (store == nullptr) {
+        CFRelease(anchors);
+        return "No TLS certificate store to load anchors into";
+    }
+
+    long loaded{0};
+    const CFIndex count{CFArrayGetCount(anchors)};
+    for (CFIndex i = 0; i < count; ++i) {
+        const void* elem{CFArrayGetValueAtIndex(anchors, i)};
+        if (elem == nullptr) continue;
+        SecCertificateRef cert{reinterpret_cast<SecCertificateRef>(const_cast<void*>(elem))};
+
+        CFDataRef der{SecCertificateCopyData(cert)};
+        if (der == nullptr) continue;
+        if (AddDerCertificate(store, CFDataGetBytePtr(der), static_cast<long>(CFDataGetLength(der)))) {
+            ++loaded;
+        }
+        CFRelease(der);
+    }
+    CFRelease(anchors);
+
+    if (loaded == 0) return "The macOS system trust store contained no usable certificates";
+    return "";
+
+#else
+    // An explicit environment setting is honoured first, so a container or a
+    // distribution that keeps its bundle somewhere unusual can point at it
+    // without a rebuild. These are the same two variables OpenSSL's own default
+    // verify paths consult.
+    const char* const env_file{std::getenv("SSL_CERT_FILE")};
+    const char* const env_dir{std::getenv("SSL_CERT_DIR")};
+    if ((env_file != nullptr && *env_file != '\0') || (env_dir != nullptr && *env_dir != '\0')) {
+        if (SSL_CTX_load_verify_locations(ssl_ctx,
+                                          (env_file != nullptr && *env_file != '\0') ? env_file : nullptr,
+                                          (env_dir != nullptr && *env_dir != '\0') ? env_dir : nullptr) == 1) {
+            return "";
+        }
+        ERR_clear_error();
+        return "SSL_CERT_FILE or SSL_CERT_DIR is set but no certificates could be read from it";
+    }
+
+    for (const char* const candidate : CA_FILE_CANDIDATES) {
+        if (!PathExists(candidate)) continue;
+        if (SSL_CTX_load_verify_locations(ssl_ctx, candidate, nullptr) == 1) return "";
+        ERR_clear_error();
+    }
+
+    for (const char* const candidate : CA_DIR_CANDIDATES) {
+        if (!PathExists(candidate)) continue;
+        if (SSL_CTX_load_verify_locations(ssl_ctx, nullptr, candidate) == 1) return "";
+        ERR_clear_error();
+    }
+
+    // Last resort: OpenSSL's compiled-in location, which is what a build
+    // against a system OpenSSL rather than against depends will normally
+    // succeed with.
+    //
+    // Whether it exists has to be checked here. SSL_CTX_set_default_verify_paths
+    // only registers the lookups and reports success without touching the
+    // filesystem, so trusting its return value would report an empty trust
+    // store as a working one, which is precisely the depends case this function
+    // exists to catch.
+    const char* const default_file{X509_get_default_cert_file()};
+    const char* const default_dir{X509_get_default_cert_dir()};
+    if ((default_file != nullptr && PathExists(default_file)) ||
+        (default_dir != nullptr && PathExists(default_dir))) {
+        if (SSL_CTX_set_default_verify_paths(ssl_ctx) == 1) return "";
+        ERR_clear_error();
+    }
+
+    return "No CA certificate bundle was found in any of the usual locations; "
+           "set SSL_CERT_FILE or SSL_CERT_DIR to point at one";
+#endif
+}

--- a/src/node/ca_store.h
+++ b/src/node/ca_store.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_CA_STORE_H
+#define BITCOIN_NODE_CA_STORE_H
+
+#include <string>
+
+//! Forward declared so callers do not have to include the OpenSSL headers, and
+//! so this header stays free of the Boost.Asio wrapper around them.
+typedef struct ssl_ctx_st SSL_CTX;
+
+namespace node {
+/**
+ * Load the host platform's trusted root certificates into ssl_ctx.
+ *
+ * This exists because the depends build cannot use OpenSSL's default verify
+ * paths. depends configures OpenSSL with
+ * `--openssldir=$(host_prefix)/etc/openssl`, which bakes the *builder's*
+ * absolute path into libcrypto. On the machine that later runs the binary that
+ * directory does not exist, so SSL_CTX_set_default_verify_paths() installs no
+ * trust anchors at all and every verification fails. That is true of release
+ * builds on every host, not only Windows and macOS.
+ *
+ * The anchors therefore come from the operating system instead:
+ *
+ *   - Windows: OpenSSL's own winstore loader, which reads the system ROOT
+ *     certificate store.
+ *   - macOS: the system trust store via Security.framework.
+ *   - Everything else: SSL_CERT_FILE / SSL_CERT_DIR when set, otherwise the
+ *     first of the well-known distribution bundle locations that exists.
+ *
+ * Taking the anchors from the platform rather than shipping a bundle means the
+ * trust list follows the operating system's own updates and revocations, and
+ * leaves no CA list in this repository that somebody has to remember to
+ * refresh.
+ *
+ * @return An empty string on success, otherwise a description of why no
+ *         anchors could be loaded. Callers must treat a non-empty return as
+ *         fatal to the connection: continuing without anchors would leave
+ *         verification enabled but trusting nothing, or worse, be papered over
+ *         by disabling verification.
+ */
+std::string LoadTrustedCACertificates(SSL_CTX* ssl_ctx);
+} // namespace node
+
+#endif // BITCOIN_NODE_CA_STORE_H

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -19,9 +19,21 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/signals2/signal.hpp>
 
+// boost 1.71 predates OpenSSL 3.0 and its ssl wrapper still calls functions the
+// 3.x series deprecated, such as RSA_free and SSL_CTX_use_RSAPrivateKey. The
+// warnings come from boost rather than from anything here, and depends headers
+// are reached with -I rather than -isystem, so they would otherwise break any
+// build using -Werror.
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #include <boost/assign/list_of.hpp>
 
 using boost::asio::ip::tcp;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -7,6 +7,7 @@
 #include <rpc/server.h>
 
 #include <clientversion.h>
+#include <node/ca_store.h>
 #include <rpc/util.h>
 #include <rpc/semver.h>
 #include <shutdown.h>
@@ -36,10 +37,14 @@
 #endif
 #include <boost/assign/list_of.hpp>
 
+#include <openssl/ssl.h>
+#include <openssl/tls1.h>
+
 using boost::asio::ip::tcp;
 
 #include <cassert>
 #include <memory> // for unique_ptr
+#include <stdexcept>
 #include <mutex>
 #include <regex>
 #include <unordered_map>
@@ -57,6 +62,9 @@ static bool ExecuteCommand(const CRPCCommand& command, const JSONRPCRequest& req
 
 static std::string strDownloadLink = "https://download.reddcoin.com/bin/reddcoin-core-";
 static std::string strGithubLink = "/repos/reddcoin-project/reddcoin/releases/latest";
+//! Named once so the resolver, the SNI extension, the certificate check and the
+//! Host header cannot drift apart from one another.
+static const std::string strGithubHost = "api.github.com";
 
 struct RPCCommandExecutionInfo
 {
@@ -315,10 +323,46 @@ void checkforupdatesinfo(UniValue& result)
 
     try {
         boost::asio::io_service svc;
-        boost::asio::ssl::context ctx(boost::asio::ssl::context::method::sslv23_client);
+
+        // tls_client rather than the sslv23_client this used to ask for. Both
+        // negotiate the best protocol both ends support, but the sslv23 spelling
+        // names methods the 3.x series deprecated.
+        boost::asio::ssl::context ctx(boost::asio::ssl::context::method::tls_client);
+
+        // Without this the connection is encrypted but unauthenticated: any
+        // party able to intercept it can present any certificate and substitute
+        // the response. The most useful thing that buys an attacker is silently
+        // suppressing upgrade notices, which is the wrong failure mode for the
+        // mechanism whose job is to get security fixes onto user machines.
+        //
+        // Failing to obtain trust anchors is fatal to the fetch rather than a
+        // downgrade to an unverified one. The catch below reports it like any
+        // other failure.
+        const std::string ca_error = node::LoadTrustedCACertificates(ctx.native_handle());
+        if (!ca_error.empty()) throw std::runtime_error(ca_error);
+
+        // verify_peer rejects a certificate that does not chain to one of those
+        // anchors; the callback additionally binds the certificate to the host
+        // that was asked for, so a valid certificate for some other name is no
+        // use. boost 1.71 spells this rfc2818_verification; the
+        // host_name_verification that replaced it arrived in 1.73.
+        ctx.set_verify_mode(boost::asio::ssl::verify_peer);
+        ctx.set_verify_callback(boost::asio::ssl::rfc2818_verification(strGithubHost));
+
         boost::asio::ssl::stream<boost::asio::ip::tcp::socket> ssock(svc, ctx);
+
+        // Server Name Indication. Without it a host that serves several names
+        // from one address, which includes anything behind a CDN, cannot tell
+        // which certificate to present and may not serve the request at all.
+        // This is a functional fix rather than a security one: the certificate
+        // is checked against strGithubHost above regardless of what SNI asked
+        // for.
+        if (SSL_set_tlsext_host_name(ssock.native_handle(), strGithubHost.c_str()) != 1) {
+            throw std::runtime_error("Could not set the TLS server name for " + strGithubHost);
+        }
+
         boost::asio::ip::tcp::resolver resolver(svc);
-        boost::asio::ip::tcp::resolver::query query("api.github.com", "https");
+        boost::asio::ip::tcp::resolver::query query(strGithubHost, "https");
         boost::asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
 
         // Establish a connection.
@@ -329,7 +373,7 @@ void checkforupdatesinfo(UniValue& result)
         boost::asio::streambuf request;
         std::ostream request_stream(&request);
         request_stream << "GET " << strGithubLink << " HTTP/1.1\r\n"; // note that you can change it if you wish to HTTP/1.0
-        request_stream << "Host: api.github.com\r\n";
+        request_stream << "Host: " << strGithubHost << "\r\n";
         request_stream << "User-Agent: C/1.0\r\n";
         request_stream << "Content-Type: application/json; charset=utf-8\r\n";
         request_stream << "Accept: */*\r\n";


### PR DESCRIPTION
Backport of #503 to the 4.22.9 release line, plus the OpenSSL bump this branch needs before it.

Two commits, reviewable independently:

1. **`depends: update openssl to 3.5.7`** - stands on its own merits.
2. **`rpc: verify TLS certificates and send SNI in the update check`** - the security fix.

## 1. OpenSSL 1.1.1s to 3.5.7

1.1.1 went out of support in September 2023 and receives no fixes of any kind, including security. The download is also simply broken: `www.openssl.org/source` now redirects to GitHub, so the recorded URL fails, and there is no usable mirror since Bitcoin Core dropped OpenSSL and stopped carrying the tarball.

Brought over from develop unchanged, with the configuration 3.x needs (`--libdir=lib`, `no-docs`/`no-tests` replacing the 1.1.x-only `no-heartbeats`/`no-ssl2`/`no-unit-test`, and `install_sw`).

Boost 1.71 predates OpenSSL 3.0 and its ssl wrapper still calls deprecated functions, so the include is wrapped in the same diagnostic guard develop uses. Without it any `-Werror` build breaks. OpenSSL is reached only through `boost::asio::ssl` in the update check, so nothing else in the tree is affected by the major version change.

## 2. TLS verification and SNI

Same defect as develop, different code: this branch still has the synchronous fetch in `rpc/server.cpp`, constructing a context and never configuring it. No trust anchors, no verification, no hostname check. Any party able to intercept the connection could present any certificate and substitute the response, the most useful result being **silently suppressed upgrade notices**.

This matters more here than on develop, since these are the nodes actually running in the field.

`src/node/ca_store.{h,cpp}` is byte-identical to the develop copy. Anchors come from the OS: winstore on Windows, Security.framework on macOS, `SSL_CERT_FILE`/`SSL_CERT_DIR` or the standard distribution bundles elsewhere. The default verify paths cannot be used on any host, because depends bakes the builder's absolute path into `OPENSSLDIR`. See #503 for the full reasoning and the corrections to what the issue assumed.

Failing to obtain anchors is fatal to the fetch rather than a downgrade to an unverified one, and surfaces through the existing `errors` field.

Two smaller changes come with it:

- The context asks for `tls_client` rather than `sslv23_client`. Both negotiate the best protocol both ends support, but the sslv23 spelling names methods 3.x deprecated.
- The host is named once in `strGithubHost`, so the resolver, the SNI extension, the certificate check and the `Host` header cannot drift apart.

## Testing

`src/rpc/server.cpp` and `src/node/ca_store.cpp` both syntax-check clean on this branch against the depends OpenSSL 3.5.7 headers and Boost 1.71.

`ca_store.cpp` is byte-identical to the develop file, which was verified against live endpoints in #503: `api.github.com` and `download.reddcoin.com` accepted; expired, wrong-host, self-signed and untrusted-root certificates all rejected; unreadable trust store fails closed rather than connecting unverified.

**Not verified on this branch:** no full compile or link, and depends was not rebuilt against 3.5.7 here. Doing either needs a configured 4.22.9 tree and a depends rebuild, which no functional test on this branch can exercise anyway. The `openssl.mk` is byte-identical to develop's, which builds. A guix or CI build is the right gate before merge.

**Not verified on any branch:** the Windows and macOS code paths are not compile-tested, as there is no cross toolchain built here.

YouTrack: https://reddink.youtrack.cloud/issue/RED-99