### PR TITLE
miner: use the template's parent when rewriting the coinbase height

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -686,7 +686,6 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
             // StakingWallet. No lock is held here, which is what this needs.
             staking_wallet.blockUntilSyncedToCurrentChain();
 
-            CBlockIndex* pindexPrev = chainman->ActiveChain().Tip();
             bool fPoSCancel = false;
             CScript scriptPubKey = GetScriptForDestination(dest);
             CBlock *pblock;
@@ -715,6 +714,17 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
                 return;
             }
             pblock = &pblocktemplate->block;
+
+            // reddcoin: take the parent from the template we actually got, not
+            // from a tip sampled before the call. CreateNewBlock() re-reads the
+            // tip under cs_main and builds on whatever it finds there, so an
+            // earlier sample can already be one block behind by the time it
+            // returns. IncrementExtraNonce() rewrites the coinbase height from
+            // whichever index it is handed, and a stale one leaves a block whose
+            // coinbase claims its parent's height instead of its own. This node
+            // then rejects its own block as bad-cb-height and the stake is lost.
+            CBlockIndex* pindexPrev = WITH_LOCK(::cs_main, return chainman->m_blockman.LookupBlockIndex(pblock->hashPrevBlock));
+            assert(pindexPrev != nullptr);
             IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
 
             staking_wallet.notifyStakingStatusChanged();


### PR DESCRIPTION
## Problem

The staker samples the chain tip before calling `CreateNewBlock()` and without holding `cs_main`, then hands that pointer to `IncrementExtraNonce()`, which rewrites the coinbase scriptSig with `pindexPrev->nHeight + 1`.

`CreateNewBlock()` re-reads the tip under `LOCK2(cs_main, m_mempool.cs)` and sets `hashPrevBlock` from what it finds there. When the tip advances between the two reads, the block is built on height H while its coinbase claims H, where `ContextualCheckBlock()` requires H + 1. The node then rejects a block it has just staked and signed:

```
Staker thread [125960328853056]: proof-of-stake block found 1bf42d7411e6f610...
ERROR: AcceptBlock: bad-cb-height, block height mismatch in coinbase
ERROR: ProcessNewBlock: AcceptBlock FAILED (bad-cb-height, block height mismatch in coinbase)
ERROR: ProcessNewBlock, block not accepted
```

Every occurrence is a stake reward silently discarded.

## Evidence

Two occurrences in ten days of `debug.log` on a mainnet staker, both with the coinbase height equal to the parent's height:

| date | staked block | coinbase claims | parent | parent height | should have claimed |
|---|---|---|---|---|---|
| 2026-08-25T03:44:34Z | `749a9523...` | 6,578,995 | `e78df6e1...` | 6,578,995 | 6,578,996 |
| 2026-09-01T14:23:10Z | `1bf42d74...` | 6,589,636 | `85ff6a4b...` | 6,589,636 | 6,589,637 |

Rate: 2 of 2311 staked blocks, about 0.09%. Both parents are in the main chain, so the blocks were otherwise valid and would have been accepted.

## Fix

Look the parent up from the template that `CreateNewBlock()` actually returned, using the `WITH_LOCK(::cs_main, return chainman->m_blockman.LookupBlockIndex(...))` idiom already present in `RegenerateCommitments()` in the same file.

The pre-call tip sample had no other use anywhere in the staker loop, so it is removed rather than left in place as a second source of truth.

Considered and rejected: skipping `IncrementExtraNonce()` for PoS blocks. There is no nonce grinding in PoS and `CreateNewBlock()` already sets a correct coinbase and merkle root, so it would work, but it changes the coinbase scriptSig format of every PoS block for no benefit.

## Testing

`g++ -fsyntax-only -std=c++17 -DHAVE_CONFIG_H` passes against this branch's own `bitcoin-config.h` and depends tree. The check was negative-controlled: renaming `LookupBlockIndex` to a bogus symbol makes it fail, so a clean exit means something.

Not runtime-verified. The race needs the tip to advance inside the window between the two tip reads, which surfaced twice in ten days on a busy mainnet staker, so it is not practical to reproduce on demand. Correctness here rests on the code reading.

The same change for the release line is in the v4.22.9-regtest PR.

YouTrack: https://reddink.youtrack.cloud/issue/RED-107
