### PR TITLE
miner: use the template's parent when rewriting the coinbase height

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -652,7 +652,6 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
             //
             // Create new block
             //
-            CBlockIndex* pindexPrev = chainman->ActiveChain().Tip();
             bool fPoSCancel = false;
             CScript scriptPubKey = GetScriptForDestination(dest);
             CBlock *pblock;
@@ -681,6 +680,17 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
                 return;
             }
             pblock = &pblocktemplate->block;
+
+            // reddcoin: take the parent from the template we actually got, not
+            // from a tip sampled before the call. CreateNewBlock() re-reads the
+            // tip under cs_main and builds on whatever it finds there, so an
+            // earlier sample can already be one block behind by the time it
+            // returns. IncrementExtraNonce() rewrites the coinbase height from
+            // whichever index it is handed, and a stale one leaves a block whose
+            // coinbase claims its parent's height instead of its own. This node
+            // then rejects its own block as bad-cb-height and the stake is lost.
+            CBlockIndex* pindexPrev = WITH_LOCK(::cs_main, return chainman->m_blockman.LookupBlockIndex(pblock->hashPrevBlock));
+            assert(pindexPrev != nullptr);
             IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
 
             pwallet->NotifyWalletStakingStatusChanged();


### PR DESCRIPTION
Backport of #505 to the v4.22.9 release line. Identical change, same line shape.

## Problem

The staker samples the chain tip before calling `CreateNewBlock()` and without holding `cs_main`, then hands that pointer to `IncrementExtraNonce()`, which rewrites the coinbase scriptSig with `pindexPrev->nHeight + 1`.

`CreateNewBlock()` re-reads the tip under `LOCK2(cs_main, m_mempool.cs)` and sets `hashPrevBlock` from what it finds there. When the tip advances between the two reads, the block is built on height H while its coinbase claims H, where `ContextualCheckBlock()` requires H + 1. The node then rejects a block it has just staked and signed with `bad-cb-height`, and the stake is lost.

## Evidence

Found on a live mainnet node running v4.22.9.4. Two occurrences in ten days of `debug.log`, both with the coinbase height equal to the parent's height:

| date | staked block | coinbase claims | parent | parent height | should have claimed |
|---|---|---|---|---|---|
| 2026-08-25T03:44:34Z | `749a9523...` | 6,578,995 | `e78df6e1...` | 6,578,995 | 6,578,996 |
| 2026-09-01T14:23:10Z | `1bf42d74...` | 6,589,636 | `85ff6a4b...` | 6,589,636 | 6,589,637 |

Rate: 2 of 2311 staked blocks, about 0.09%. Both parents are in the main chain, so the blocks were otherwise valid and would have been accepted.

## Fix

Look the parent up from the template that `CreateNewBlock()` actually returned, using the `WITH_LOCK(::cs_main, return chainman->m_blockman.LookupBlockIndex(...))` idiom already present in `RegenerateCommitments()` in the same file. The pre-call tip sample had no other use anywhere in the staker loop and is removed.

## Testing

`g++ -fsyntax-only -std=c++17 -DHAVE_CONFIG_H` passes against this branch's own `bitcoin-config.h` and depends tree, negative-controlled by renaming `LookupBlockIndex` to a bogus symbol and confirming it fails.

Not runtime-verified, and no functional test accompanies it: the race needs the tip to advance inside a very narrow window, so it is not practical to reproduce on demand, and the functional suite does not run on this branch anyway.

YouTrack: https://reddink.youtrack.cloud/issue/RED-107
