### PR TITLE
wallet: name the routine re-stake behind a coinstake conflict

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1080,6 +1080,18 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, CWalletTx::Co
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
                         WalletLogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), confirm.hashBlock.ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
+                        // reddcoin: a staking wallet re-stakes an input whenever its
+                        // previous coinstake was orphaned, so two coinstakes spending
+                        // the same input is routine. Only this wallet can sign that
+                        // input, so the earlier one can only have lost a race. Without
+                        // this line the inherited wording above reads like a double
+                        // spend in an operator's log. Deliberately narrow: a coinstake
+                        // conflicting with an ordinary spend is a real conflict and
+                        // keeps the bare message.
+                        const CWalletTx* prev_wtx = GetWalletTx(range.first->second);
+                        if (tx.IsCoinStake() && prev_wtx && prev_wtx->IsCoinStake()) {
+                            WalletLogPrintf("Re-stake of %s:%i: coinstake %s supersedes orphaned coinstake %s (expected for a staking wallet, not a double spend)\n", range.first->first.hash.ToString(), range.first->first.n, tx.GetHash().ToString(), range.first->second.ToString());
+                        }
                         MarkConflicted(confirm.hashBlock, confirm.block_height, range.first->second);
                     }
                     range.first++;


### PR DESCRIPTION
Backport of #507 to the v4.22.9 release line. Identical change.

## Problem

A staking wallet re-stakes an input whenever its previous coinstake was orphaned. That is completely routine, but the wallet reports it with the wording inherited from upstream:

```
[Main_funds] Transaction 08c9e1e566... (in block 09cc26fd...) conflicts with wallet transaction dd1c2f5875... (both spend 305ef3c2...:1)
```

Upstream Bitcoin Core has no coinstakes, so there this line can only mean a genuine conflicting spend. On Reddcoin it is the expected outcome of normal staking, and it reads like a double spend to anyone watching `debug.log`.

This matters more on the release line than on develop, because this is what node operators actually run. One mainnet node on v4.22.9.4 logged 496 of these in ten days with nothing wrong, 473 of them in the two days after the v4.22.9.4 startup swept 822 orphaned coinstakes left over from an earlier network isolation.

## Change

The inherited line is left byte-identical so it stays diffable against Core. A second line follows it only when both sides of the conflict are coinstakes:

```
Re-stake of 305ef3c2...:1: coinstake 08c9e1e566... supersedes orphaned coinstake dd1c2f5875... (expected for a staking wallet, not a double spend)
```

Two coinstakes spending the same input can only mean the earlier one was orphaned, since only this wallet can sign that input. A coinstake conflicting with an ordinary spend, such as sending a coin while it was staking, stays a real conflict and keeps the bare message.

## Testing

Log-only change, no consensus or wallet-state impact. `g++ -fsyntax-only -std=c++17 -DHAVE_CONFIG_H` passes against this branch's own `bitcoin-config.h` and depends tree, negative-controlled.

The new line has not yet been observed in a live log. The node it was written for still has roughly 366 abandoned coinstakes left to re-stake, so the path will exercise itself readily once a build carrying this runs there.

YouTrack: https://reddink.youtrack.cloud/issue/RED-108
