### PR TITLE
build: export the host triplet to C++ as HOST_TRIPLET

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,15 @@ fi
 
 AC_CANONICAL_HOST
 
+dnl The autoconf host triplet this build targets, exported to C++.
+dnl
+dnl The update check needs it to name the release artifact built for this
+dnl platform: guix names every output after the triplet, so the triplet is what
+dnl maps a running binary to its download. TARGET_OS, derived further down, is
+dnl too coarse for that. It cannot tell x86_64 Linux from aarch64 Linux, and the
+dnl published artifacts differ per triplet.
+AC_DEFINE_UNQUOTED([HOST_TRIPLET], ["$host"], [The autoconf host triplet this build targets])
+
 AH_TOP([#ifndef BITCOIN_CONFIG_H])
 AH_TOP([#define BITCOIN_CONFIG_H])
 AH_BOTTOM([#endif //BITCOIN_CONFIG_H])


### PR DESCRIPTION
Closes blocker **B4** of the assisted-upgrade design. First commit of RED-110 (phase 1).

## Why

`configure.ac` derives `TARGET_OS` for automake conditionals but never makes the autoconf host triplet available to the code, so nothing can tell at runtime which platform's build it is.

The update check needs exactly that. guix names every release artifact after the triplet it was built for (`contrib/guix/libexec/build.sh:406,431`), so the triplet is what maps a running binary to the file a user should download.

`TARGET_OS` is too coarse for this. It cannot distinguish `x86_64-linux-gnu` from `aarch64-linux-gnu`, and those are separate published artifacts.

## What

`AC_CANONICAL_HOST` already computes `$host` at the top of `configure.ac`, so this is a define placed next to it rather than any new detection:

```m4
AC_DEFINE_UNQUOTED([HOST_TRIPLET], ["$host"], [The autoconf host triplet this build targets])
```

## Verified

End to end on `x86_64-pc-linux-gnu`, rather than just checking the macro is present:

- the autoheader stanza reaches `src/config/bitcoin-config.h.in`
- a full `configure` run produces `#define HOST_TRIPLET "x86_64-pc-linux-gnu"`
- a program including that header compiles and prints the value

Nothing consumes it yet. The artifact mapping that uses it is the next commit of RED-110, kept separate so this stands on its own.

YouTrack: https://reddink.youtrack.cloud/issue/RED-110