### PR TITLE
node: map the host triplet to its published release artifacts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -185,6 +185,7 @@ BITCOIN_CORE_H = \
   netmessagemaker.h \
   node/blockstorage.h \
   node/ca_store.h \
+  node/release_artifacts.h \
   node/coin.h \
   node/coinstats.h \
   node/context.h \
@@ -362,6 +363,7 @@ libbitcoin_server_a_SOURCES = \
   net_processing.cpp \
   node/blockstorage.cpp \
   node/ca_store.cpp \
+  node/release_artifacts.cpp \
   node/coin.cpp \
   node/coinstats.cpp \
   node/context.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -144,6 +144,7 @@ BITCOIN_TESTS =\
   test/txrequest_tests.cpp \
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \
+  test/release_artifacts_tests.cpp \
   test/uint256_tests.cpp \
   test/util_tests.cpp \
   test/validation_block_tests.cpp \

--- a/src/node/release_artifacts.cpp
+++ b/src/node/release_artifacts.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <node/release_artifacts.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+//! Split a host triplet on '-'.
+std::vector<std::string> SplitTriplet(const std::string& host_triplet)
+{
+    std::vector<std::string> fields;
+    std::string::size_type start{0};
+    while (true) {
+        const std::string::size_type dash{host_triplet.find('-', start)};
+        if (dash == std::string::npos) {
+            fields.push_back(host_triplet.substr(start));
+            return fields;
+        }
+        fields.push_back(host_triplet.substr(start, dash - start));
+        start = dash + 1;
+    }
+}
+
+//! Reduce a host triplet to the form the release artifacts are named after.
+//!
+//! guix is invoked with the three-field alias, so that is what ends up in the
+//! filename, while configure records the four-field form config.sub expands it
+//! to. Dropping the vendor turns one into the other:
+//!
+//!   x86_64-pc-linux-gnu           -> x86_64-linux-gnu
+//!   arm-unknown-linux-gnueabihf   -> arm-linux-gnueabihf
+//!
+//! A triplet that is already in the alias form is returned unchanged, so a
+//! build configured either way names the same file.
+std::string NormaliseTriplet(const std::string& host_triplet)
+{
+    const std::vector<std::string> fields{SplitTriplet(host_triplet)};
+    if (fields.size() < 4) return host_triplet;
+
+    std::string normalised{fields[0]};
+    for (std::vector<std::string>::size_type i = 2; i < fields.size(); ++i) {
+        normalised += "-" + fields[i];
+    }
+    return normalised;
+}
+
+//! Does host_triplet name this operating system? Matched on the whole field
+//! rather than as a substring, so an architecture that happens to contain the
+//! name cannot be mistaken for it.
+bool HostIs(const std::string& host_triplet, const std::string& os_prefix)
+{
+    for (const std::string& field : SplitTriplet(host_triplet)) {
+        if (field.compare(0, os_prefix.size(), os_prefix) == 0) return true;
+    }
+    return false;
+}
+} // namespace
+
+bool node::GetReleaseArtifacts(const std::string& host_triplet, const std::string& version, ReleaseArtifacts& out)
+{
+    if (host_triplet.empty() || version.empty()) return false;
+
+    // Every artifact is named after the release, then the platform.
+    const std::string prefix{"reddcoin-" + version + "-"};
+
+    if (HostIs(host_triplet, "mingw")) {
+        // A reddcoin-qt user wants the installer, which is the artifact that
+        // carries an Authenticode signature. A reddcoind user wants the archive.
+        out.platform = "win64";
+        out.gui = prefix + "win64-setup-signed.exe";
+        out.daemon = prefix + "win64.zip";
+        return true;
+    }
+
+    if (HostIs(host_triplet, "darwin")) {
+        // Only an x86_64 build is published. An arm64 Mac runs it under Rosetta
+        // and needs no special case here: HOST_TRIPLET is fixed at build time,
+        // so a Mac running this binary is by definition running the x86_64 one
+        // and already reports x86_64-apple-darwin18. Naming it as the Intel
+        // build is the presentation layer's job.
+        out.platform = "osx64";
+        out.gui = prefix + "osx-signed.dmg";
+        out.daemon = prefix + "osx64.tar.gz";
+        return true;
+    }
+
+    if (HostIs(host_triplet, "linux")) {
+        // One tarball carries both binaries; no separate installer is published,
+        // because the install shape on Linux is not knowable from here.
+        out.platform = NormaliseTriplet(host_triplet);
+        out.gui = prefix + out.platform + ".tar.gz";
+        out.daemon = out.gui;
+        return true;
+    }
+
+    // A host nobody publishes a build for. Saying nothing is better than naming
+    // a file that will 404.
+    return false;
+}
+
+bool node::GetReleaseArtifactsForThisHost(const std::string& version, ReleaseArtifacts& out)
+{
+#if defined(HOST_TRIPLET)
+    return GetReleaseArtifacts(HOST_TRIPLET, version, out);
+#else
+    (void)version;
+    (void)out;
+    return false;
+#endif
+}

--- a/src/node/release_artifacts.h
+++ b/src/node/release_artifacts.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_RELEASE_ARTIFACTS_H
+#define BITCOIN_NODE_RELEASE_ARTIFACTS_H
+
+#include <string>
+
+namespace node {
+/**
+ * The release files published for one host.
+ *
+ * A release publishes a separate build per host, named after the host it was
+ * built for, so a running binary can name the file its own machine needs
+ * instead of pointing the user at a directory listing.
+ */
+struct ReleaseArtifacts {
+    //! Short platform name as it appears in artifact filenames: "win64",
+    //! "osx64", or the normalised host triplet on everything else.
+    std::string platform;
+
+    //! The file a reddcoin-qt user should install. An installer on Windows, a
+    //! disk image on macOS.
+    std::string gui;
+
+    //! The file a reddcoind user should install. An archive everywhere.
+    //!
+    //! Equal to gui on Linux, where one tarball carries both binaries and no
+    //! separate installer is published.
+    std::string daemon;
+};
+
+/**
+ * Name the release artifacts for a host triplet and version.
+ *
+ * @param[in]  host_triplet An autoconf host triplet, in either the canonical
+ *                          four-field form or the three-field alias. See the
+ *                          note on normalisation below.
+ * @param[in]  version      Release version without a leading "v", for example
+ *                          "4.22.9.4".
+ * @param[out] out          Filled in only when this returns true.
+ * @return false if no build is published for that host, or if either argument
+ *         is unusable.
+ *
+ * **On host triplet forms.** The published Linux artifacts are named after the
+ * triplet guix was invoked with, which is the three-field alias
+ * (`x86_64-linux-gnu`). `HOST_TRIPLET` holds autoconf's `$host`, which config.sub
+ * has canonicalised to four fields (`x86_64-pc-linux-gnu`). The two differ for
+ * every Linux host and agree for Windows and macOS, so the vendor field is
+ * dropped before a Linux name is built. Both forms are accepted, since a build
+ * from source legitimately produces the canonical one.
+ */
+bool GetReleaseArtifacts(const std::string& host_triplet, const std::string& version, ReleaseArtifacts& out);
+
+/**
+ * Name the release artifacts for the host this binary was built for, using the
+ * HOST_TRIPLET recorded by configure.
+ */
+bool GetReleaseArtifactsForThisHost(const std::string& version, ReleaseArtifacts& out);
+} // namespace node
+
+#endif // BITCOIN_NODE_RELEASE_ARTIFACTS_H

--- a/src/test/release_artifacts_tests.cpp
+++ b/src/test/release_artifacts_tests.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/release_artifacts.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+using node::GetReleaseArtifacts;
+using node::ReleaseArtifacts;
+
+namespace {
+//! The release the expectations below were taken from. Every filename in this
+//! file appears in the published SHA256SUMS for it, so if the guix naming
+//! scheme changes these tests fail rather than quietly encoding a stale
+//! convention.
+const std::string VERSION{"4.22.9.4"};
+
+ReleaseArtifacts Resolve(const std::string& host)
+{
+    ReleaseArtifacts artifacts;
+    BOOST_REQUIRE_MESSAGE(GetReleaseArtifacts(host, VERSION, artifacts),
+                          "no artifacts resolved for host " << host);
+    return artifacts;
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(release_artifacts_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(windows_offers_the_installer_to_the_gui)
+{
+    const ReleaseArtifacts a{Resolve("x86_64-w64-mingw32")};
+    BOOST_CHECK_EQUAL(a.platform, "win64");
+    // The installer is the artifact that carries an Authenticode signature; the
+    // zip is what a reddcoind user wants.
+    BOOST_CHECK_EQUAL(a.gui, "reddcoin-4.22.9.4-win64-setup-signed.exe");
+    BOOST_CHECK_EQUAL(a.daemon, "reddcoin-4.22.9.4-win64.zip");
+}
+
+BOOST_AUTO_TEST_CASE(macos_offers_the_signed_dmg_to_the_gui)
+{
+    const ReleaseArtifacts a{Resolve("x86_64-apple-darwin18")};
+    BOOST_CHECK_EQUAL(a.platform, "osx64");
+    BOOST_CHECK_EQUAL(a.gui, "reddcoin-4.22.9.4-osx-signed.dmg");
+    BOOST_CHECK_EQUAL(a.daemon, "reddcoin-4.22.9.4-osx64.tar.gz");
+}
+
+BOOST_AUTO_TEST_CASE(linux_serves_one_tarball_to_both)
+{
+    // No separate installer is published for Linux: a single tarball carries
+    // both binaries, so the two must resolve to the same file rather than the
+    // gui entry being left empty.
+    const ReleaseArtifacts a{Resolve("x86_64-linux-gnu")};
+    BOOST_CHECK_EQUAL(a.platform, "x86_64-linux-gnu");
+    BOOST_CHECK_EQUAL(a.gui, "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz");
+    BOOST_CHECK_EQUAL(a.daemon, a.gui);
+}
+
+BOOST_AUTO_TEST_CASE(every_published_host_resolves)
+{
+    // The guix HOSTS list, in the alias form the artifact names are built from.
+    // Each expected filename appears in the published 4.22.9.4 SHA256SUMS.
+    const struct { const char* host; const char* daemon; } cases[]{
+        {"x86_64-linux-gnu", "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz"},
+        {"arm-linux-gnueabihf", "reddcoin-4.22.9.4-arm-linux-gnueabihf.tar.gz"},
+        {"aarch64-linux-gnu", "reddcoin-4.22.9.4-aarch64-linux-gnu.tar.gz"},
+        {"riscv64-linux-gnu", "reddcoin-4.22.9.4-riscv64-linux-gnu.tar.gz"},
+        {"powerpc64-linux-gnu", "reddcoin-4.22.9.4-powerpc64-linux-gnu.tar.gz"},
+        {"powerpc64le-linux-gnu", "reddcoin-4.22.9.4-powerpc64le-linux-gnu.tar.gz"},
+        {"x86_64-w64-mingw32", "reddcoin-4.22.9.4-win64.zip"},
+        {"x86_64-apple-darwin18", "reddcoin-4.22.9.4-osx64.tar.gz"},
+    };
+
+    for (const auto& c : cases) {
+        BOOST_CHECK_EQUAL(Resolve(c.host).daemon, c.daemon);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(canonical_and_alias_triplets_agree)
+{
+    // The regression this guards. configure records autoconf's $host, which
+    // config.sub has expanded to four fields, while the artifacts are named
+    // after the three-field alias guix was invoked with. Keying the mapping on
+    // the canonical form without normalising would name
+    // reddcoin-4.22.9.4-x86_64-pc-linux-gnu.tar.gz, which does not exist.
+    const struct { const char* canonical; const char* alias; } pairs[]{
+        {"x86_64-pc-linux-gnu", "x86_64-linux-gnu"},
+        {"arm-unknown-linux-gnueabihf", "arm-linux-gnueabihf"},
+        {"aarch64-unknown-linux-gnu", "aarch64-linux-gnu"},
+        {"riscv64-unknown-linux-gnu", "riscv64-linux-gnu"},
+        {"powerpc64-unknown-linux-gnu", "powerpc64-linux-gnu"},
+        {"powerpc64le-unknown-linux-gnu", "powerpc64le-linux-gnu"},
+    };
+
+    for (const auto& p : pairs) {
+        const ReleaseArtifacts from_canonical{Resolve(p.canonical)};
+        const ReleaseArtifacts from_alias{Resolve(p.alias)};
+        BOOST_CHECK_EQUAL(from_canonical.platform, from_alias.platform);
+        BOOST_CHECK_EQUAL(from_canonical.gui, from_alias.gui);
+        BOOST_CHECK_EQUAL(from_canonical.daemon, from_alias.daemon);
+        // And specifically that the vendor is gone, not merely consistent.
+        BOOST_CHECK(from_canonical.gui.find("-pc-") == std::string::npos);
+        BOOST_CHECK(from_canonical.gui.find("-unknown-") == std::string::npos);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(windows_and_macos_are_not_normalised)
+{
+    // Their vendor fields are load bearing: x86_64-w64-mingw32 and
+    // x86_64-apple-darwin18 are the forms guix uses, so stripping the vendor
+    // from them would be wrong. They are matched by OS, not rebuilt from
+    // fields, but assert it so a change to NormaliseTriplet cannot leak in.
+    BOOST_CHECK_EQUAL(Resolve("x86_64-w64-mingw32").platform, "win64");
+    BOOST_CHECK_EQUAL(Resolve("x86_64-apple-darwin18").platform, "osx64");
+}
+
+BOOST_AUTO_TEST_CASE(unpublished_hosts_resolve_to_nothing)
+{
+    // Naming a file that will 404 is worse than saying nothing.
+    ReleaseArtifacts artifacts;
+    for (const char* host : {"sparc-sun-solaris2.11", "x86_64-unknown-freebsd13", "wasm32-unknown-emscripten"}) {
+        BOOST_CHECK_MESSAGE(!GetReleaseArtifacts(host, VERSION, artifacts),
+                            "unexpectedly resolved artifacts for " << host);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(empty_arguments_are_rejected)
+{
+    ReleaseArtifacts artifacts;
+    BOOST_CHECK(!GetReleaseArtifacts("", VERSION, artifacts));
+    BOOST_CHECK(!GetReleaseArtifacts("x86_64-linux-gnu", "", artifacts));
+}
+
+BOOST_AUTO_TEST_CASE(version_is_interpolated_not_assumed)
+{
+    ReleaseArtifacts artifacts;
+    BOOST_REQUIRE(GetReleaseArtifacts("x86_64-w64-mingw32", "5.0.0", artifacts));
+    BOOST_CHECK_EQUAL(artifacts.gui, "reddcoin-5.0.0-win64-setup-signed.exe");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Backport of #513 to the 4.22.9 release line. Second commit of RED-110 (assisted upgrade, phase 1), following the `HOST_TRIPLET` define that merged here in #511.

Nothing user-visible yet.

## What

Maps a host triplet to the release artifacts published for it. A pure function, no I/O, no network:

```
x86_64-w64-mingw32     -> -win64-setup-signed.exe / -win64.zip
x86_64-apple-darwin18  -> -osx-signed.dmg         / -osx64.tar.gz
<arch>-linux-<abi>     -> -<triplet>.tar.gz       (both)
```

## The trap this exists to avoid

The host triplet **cannot be used verbatim** to build a filename. The artifacts are named after the three-field alias guix is invoked with, while `HOST_TRIPLET` records autoconf's `$host`, which `config.sub` has already expanded to four fields. They agree for Windows and macOS and differ for **every** Linux host:

| guix `HOST` (artifact name) | `$host` (`HOST_TRIPLET`) |
| --- | --- |
| `x86_64-linux-gnu` | `x86_64-pc-linux-gnu` |
| `arm-linux-gnueabihf` | `arm-unknown-linux-gnueabihf` |
| `aarch64-linux-gnu` | `aarch64-unknown-linux-gnu` |
| `riscv64-linux-gnu` | `riscv64-unknown-linux-gnu` |
| `powerpc64-linux-gnu` | `powerpc64-unknown-linux-gnu` |
| `powerpc64le-linux-gnu` | `powerpc64le-unknown-linux-gnu` |

guix never passes `--host`; it relies on `CONFIG_SITE` alone, and `depends/config.site.in` sets `host_alias="@HOST@"`, which autoconf then canonicalises. Keying on `$host` without dropping the vendor would name `reddcoin-<version>-x86_64-pc-linux-gnu.tar.gz`, which does not exist. Both forms are accepted, since a build from source legitimately produces the canonical one.

## Why it returns both artifacts

The choice is a function of `(host, is_gui)`, not host alone. This code is shared by both binaries and the update check is reachable from either surface, so a single "am I a GUI" flag set at startup would be wrong whenever it is consulted from the other one. Both are returned and the presenter chooses.

On Linux the two are equal: one tarball carries both binaries and no separate installer is published.

Apple Silicon needs no special case. `HOST_TRIPLET` is fixed at build time and no arm64 Darwin build is published, so a Mac running this binary is by definition running the x86_64 one and already reports `x86_64-apple-darwin18`.

## How this differs from #513

The three source files are **byte-identical** to develop's, verified with `cmp`. Only the Makefile anchors differ: this branch has no `test/update_check_tests.cpp`, since the truncated-body and chunked-encoding fixes were deliberately not backported. Its older synchronous fetcher in `rpc/server.cpp` already reports a truncated stream through `errors` rather than swallowing it, and was not observed hitting the chunked path.

The mapping ports cleanly because it depends only on `<string>`, `<vector>` and `HOST_TRIPLET`.

**The presentation layer will not port so cleanly.** This branch has the older synchronous update check rather than develop's `HttpsFetcher`, and a different Qt path, so the RPC and GUI changes that follow will need adapting rather than copying. Same structural split that made RED-99 and RED-100 two different patches on each line.

## Tests

`release_artifacts_tests`, 9 cases, table driven over every host in the guix `HOSTS` list, with each expected filename taken from the published 4.22.9.4 `SHA256SUMS`.

**Built and run on this branch**, not inferred from develop: 9 cases, all passing. `configure` here produces `#define HOST_TRIPLET "x86_64-pc-linux-gnu"`, so the normalisation path is the one actually exercised.

YouTrack: https://reddink.youtrack.cloud/issue/RED-110
