### PR TITLE
rpc: name the exact artifact this host needs in checkupdates

### DIFF
--- a/src/node/release_artifacts.cpp
+++ b/src/node/release_artifacts.cpp
@@ -105,6 +105,15 @@ bool node::GetReleaseArtifacts(const std::string& host_triplet, const std::strin
     return false;
 }
 
+std::string node::HostTriplet()
+{
+#if defined(HOST_TRIPLET)
+    return HOST_TRIPLET;
+#else
+    return "";
+#endif
+}
+
 bool node::GetReleaseArtifactsForThisHost(const std::string& version, ReleaseArtifacts& out)
 {
 #if defined(HOST_TRIPLET)

--- a/src/node/release_artifacts.h
+++ b/src/node/release_artifacts.h
@@ -58,6 +58,16 @@ bool GetReleaseArtifacts(const std::string& host_triplet, const std::string& ver
  * HOST_TRIPLET recorded by configure.
  */
 bool GetReleaseArtifactsForThisHost(const std::string& version, ReleaseArtifacts& out);
+
+/**
+ * The host triplet this binary was built for, or an empty string if the build
+ * did not record one.
+ *
+ * Kept here so the one dependency on the generated config header stays in this
+ * translation unit rather than spreading to every caller that wants to report
+ * the triplet.
+ */
+std::string HostTriplet();
 } // namespace node
 
 #endif // BITCOIN_NODE_RELEASE_ARTIFACTS_H

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -7,6 +7,7 @@
 #include <rpc/server.h>
 
 #include <clientversion.h>
+#include <node/release_artifacts.h>
 #include <node/ca_store.h>
 #include <rpc/util.h>
 #include <rpc/semver.h>
@@ -296,6 +297,12 @@ static RPCHelpMan checkupdates()
                 {RPCResult::Type::STR, "message", "Message confirming if you are on latest release version and where to download the latest version from"},
                 {RPCResult::Type::STR, "warning", "Any warning messages"},
                 {RPCResult::Type::STR, "officialDownloadLink", "Official direct download link"},
+                {RPCResult::Type::STR, "hosttriplet", "The host triplet this build targets, empty if the build did not record one"},
+                {RPCResult::Type::STR, "platform", "Short platform name used in artifact filenames, empty if no build is published for this host"},
+                {RPCResult::Type::STR, "guiartifact", "Filename of the build a reddcoin-qt user should install, empty if unknown"},
+                {RPCResult::Type::STR, "guiartifactlink", "Direct download link for guiartifact, empty if unknown"},
+                {RPCResult::Type::STR, "daemonartifact", "Filename of the build a reddcoind user should install, empty if unknown. Equal to guiartifact on Linux, where one tarball carries both"},
+                {RPCResult::Type::STR, "daemonartifactlink", "Direct download link for daemonartifact, empty if unknown"},
                 {RPCResult::Type::STR, "errors", "Any error messages"},
             }},
         RPCExamples{HelpExampleCli("checkupdates", "") + HelpExampleRpc("checkupdates", "")},
@@ -319,6 +326,11 @@ void checkforupdatesinfo(UniValue& result)
     std::string message = "";
     std::string warning = "";
     std::string officialDownloadLink = "";
+    std::string platform = "";
+    std::string guiArtifact = "";
+    std::string guiArtifactLink = "";
+    std::string daemonArtifact = "";
+    std::string daemonArtifactLink = "";
     std::string errors = "";
 
     try {
@@ -524,6 +536,24 @@ void checkforupdatesinfo(UniValue& result)
                 if (remote.core.is_prerelease()) {
                     officialDownloadLink += "/" + remote.prerelease_tag + remote.prerelease_num;
                 }
+
+                // Name the exact file this host needs, so a caller can offer a
+                // download rather than a directory to read.
+                //
+                // Not attempted for a prerelease. No prerelease has ever been
+                // published, so the naming convention for one is unverified,
+                // and naming a file that does not exist is worse than naming
+                // none: it turns a working notice into a broken link.
+                if (!remote.core.is_prerelease()) {
+                    node::ReleaseArtifacts artifacts;
+                    if (node::GetReleaseArtifactsForThisHost(remote.numeric, artifacts)) {
+                        platform = artifacts.platform;
+                        guiArtifact = artifacts.gui;
+                        daemonArtifact = artifacts.daemon;
+                        guiArtifactLink = officialDownloadLink + "/" + artifacts.gui;
+                        daemonArtifactLink = officialDownloadLink + "/" + artifacts.daemon;
+                    }
+                }
             }
         }
 
@@ -544,6 +574,15 @@ void checkforupdatesinfo(UniValue& result)
     result.pushKV("message", message);
     result.pushKV("warning", warning);
     result.pushKV("officialDownloadLink", officialDownloadLink);
+    // Empty rather than absent when the host publishes no build, or when the
+    // check did not get far enough to know, so the shape of the result does not
+    // depend on whether it succeeded.
+    result.pushKV("hosttriplet", node::HostTriplet());
+    result.pushKV("platform", platform);
+    result.pushKV("guiartifact", guiArtifact);
+    result.pushKV("guiartifactlink", guiArtifactLink);
+    result.pushKV("daemonartifact", daemonArtifact);
+    result.pushKV("daemonartifactlink", daemonArtifactLink);
     result.pushKV("errors", errors);
 }
 


### PR DESCRIPTION
Backport of #515 to the 4.22.9 release line. Third commit of RED-110 (assisted upgrade, phase 1), following the mapping merged here in #514.

## What

`checkupdates` could say a newer version exists and point at the directory holding it, but not say which of the **fifteen** files in that directory the machine asking actually needs. Six fields close that gap:

| Field | |
| --- | --- |
| `hosttriplet` | the host triplet this build targets |
| `platform` | short platform name used in artifact filenames |
| `guiartifact` | the file a `reddcoin-qt` user should install |
| `guiartifactlink` | its direct download link |
| `daemonartifact` | the file a `reddcoind` user should install |
| `daemonartifactlink` | its direct download link |

Both surfaces are reported rather than the node guessing which the caller is. On Linux the two are equal: one tarball carries both binaries. Every field is present and empty rather than absent when unknown, matching how the existing fields behave.

Artifacts are not named for a prerelease: none has ever been published, so the convention is unverified, and naming a file that does not exist turns a working notice into a broken link.

## Adapted, not copied

Two differences from #515, both worth a reviewer's attention:

**1. The field population sits beside the RPC definition.** This branch keeps the update check in `rpc/server.cpp` rather than develop's `node/update_check.cpp`, so there is no separate translation unit to put it in. Same code, different home.

**2. It also adds `HostTriplet()` to `node/release_artifacts`.** On develop that accessor was part of this same commit, but the mapping was backported here in #514 *before* it existed, so this branch had the mapping without it. The build caught this rather than it slipping through:

```
rpc/server.cpp:580:40: error: 'HostTriplet' is not a member of 'node'
```

After this commit the two `release_artifacts` files are byte-identical to develop's again, verified with `cmp`.

## Verified on this branch

Built and run here rather than inferred from develop:

```
"hosttriplet":     "x86_64-pc-linux-gnu",
"platform":        "x86_64-linux-gnu",
"guiartifactlink": "https://download.reddcoin.com/bin/reddcoin-core-4.22.9.4/reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz",
```

That link answers **200**. The link a mapping without the vendor normalisation would have produced answers **404**. `hosttriplet` and `platform` legitimately differ there: the first is what configure recorded, the second is what the artifact is named after, and that gap applies to every Linux host.

Nothing user-visible yet. The GUI change is the last commit of this phase, and is the one that will need the most adaptation on this branch.

YouTrack: https://reddink.youtrack.cloud/issue/RED-110
