### PR TITLE
qt: name the build this machine needs in the update dialog

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -162,12 +162,33 @@ void HelpMessageDialog::showUpdateInfo(const QVariantMap& info)
         text = "Installed version: <b>" + localversion + "</b><br>";
         text += info.value("message").toString();
     } else {
-        const QString link{info.value("officialDownloadLink").toString()};
-        QString url = "<a href=\"" + link + "\">" + link + "</a>";
+        const QString artifact{info.value("guiartifact").toString()};
+        const QString artifact_link{info.value("guiartifactlink").toString()};
 
         text = "Installed version: <b>" + localversion + "</b><br>";
         text += "Latest repository version: <b>" + remoteversion + "</b><br><br>";
-        text += "Please download the latest version from our official website <br>(" + url + ").";
+
+        if (artifact.isEmpty() || artifact_link.isEmpty()) {
+            // Either no build is published for this host, or the release is a
+            // prerelease, whose artifact naming has never been exercised. Point
+            // at the directory and let the user choose, rather than name a file
+            // that may not be there.
+            const QString link{info.value("officialDownloadLink").toString()};
+            const QString url{"<a href=\"" + link + "\">" + link + "</a>"};
+            text += "Please download the latest version from our official website <br>(" + url + ").";
+        } else {
+            // The build this machine needs, rather than the directory holding
+            // fifteen files it would have to choose between.
+            text += "The build for this machine is:<br>";
+            text += "<a href=\"" + artifact_link + "\">" + artifact + "</a>";
+
+            if (info.value("platform").toString() == "osx64") {
+                // Only an x86_64 macOS build is published, and it runs on Apple
+                // Silicon under Rosetta. Say which one it is rather than let an
+                // arm64 user assume it is native.
+                text += "<br><br>This is the Intel build. It runs on Apple Silicon under Rosetta.";
+            }
+        }
     }
 
     ui->aboutMessage->setText(text);


### PR DESCRIPTION
Last commit of RED-110 (assisted upgrade, phase 1). Completes the phase: the update notice now names the file this machine needs instead of pointing at a directory.

## Before and after

Before, the dialog said a newer version existed and linked to the directory holding it, leaving the user to work out which of the **fifteen** files there was theirs:

```
Installed version: 4.22.9.0
Latest repository version: 4.22.9.4

Please download the latest version from our official website
(https://download.reddcoin.com/bin/reddcoin-core-4.22.9.4).
```

After, on this host, driven by the live values `checkupdates` returns:

```
Installed version: 4.22.9.0
Latest repository version: 4.22.9.4

The build for this machine is:
reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz
```

linking straight to the file. That link answers 200; the one an unnormalised mapping would produce answers 404, which is what the vendor stripping in #513 was for.

## Which artifact, and why no flag is needed

The `guiartifact` fields are the right ones here by construction. This is `reddcoin-qt`, so the user wants the installer or the disk image rather than the archive a `reddcoind` operator would take. The RPC reports both and the presenter picks, which is exactly why it was built that way rather than with an "am I a GUI" flag on the node.

## macOS says it is the Intel build

Only an x86_64 macOS build is published and it runs on Apple Silicon under Rosetta. The dialog names it as the Intel build rather than letting an arm64 user assume it is native. This is the presentation half of RED-98's Apple Silicon decision; the mapping side needed no special case, since `HOST_TRIPLET` is fixed at build time and a Mac running this binary is by definition running the x86_64 one.

## The directory link is still the fallback

Kept for the two cases where no filename can be trusted:

- a host nobody publishes a build for
- a prerelease, whose artifact naming has never been exercised

Pointing at a directory is a worse experience than naming a file, and a much better one than naming a file that is not there.

## Verified

- `utilitydialog.cpp` compiles; `reddcoin-qt` links
- both new strings are present in the built binary
- the rendering above is the actual `checkupdates` output on this host, run through the same branch the dialog takes, not a mock

**Not visually confirmed in a running GUI.** The dialog is reached through Help and needs a person to look at it. Happy to do that on the built binary if wanted; the logic and the values feeding it are verified, the layout is not.

Nothing downloads anything yet. Phases 3 to 5 cover that.

YouTrack: https://reddink.youtrack.cloud/issue/RED-110
