### PR TITLE
qt: name the build this machine needs in the update dialog

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -88,6 +88,9 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
             QString warning = "";
             QString officialDownloadLink = "";
             QString errors = "";
+            QString platform = "";
+            QString guiArtifact = "";
+            QString guiArtifactLink = "";
 
             if (result.exists("localversion")) {
                 localversion = QString::fromStdString(result["localversion"].get_str());
@@ -107,6 +110,15 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
             if (result.exists("error")) {
                 errors = QString::fromStdString(result["error"].get_str());
             }
+            if (result.exists("platform")) {
+                platform = QString::fromStdString(result["platform"].get_str());
+            }
+            if (result.exists("guiartifact")) {
+                guiArtifact = QString::fromStdString(result["guiartifact"].get_str());
+            }
+            if (result.exists("guiartifactlink")) {
+                guiArtifactLink = QString::fromStdString(result["guiartifactlink"].get_str());
+            }
 
             if (!errors.isEmpty()) {
                 text = "<font color = 'red'>Error: </font>";
@@ -115,11 +127,29 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
                 text = "Installed version: <b>" + localversion  + "</b><br>";
                 text += message;
             } else {
-                QString url = "<a href=\""+ officialDownloadLink +"\">"+ officialDownloadLink +"</a>";
-
                 text = "Installed version: <b>" + localversion  + "</b><br>";
                 text += "Latest repository version: <b>" + remoteversion + "</b><br><br>";
-                text += "Please download the latest version from our official website <br>(" + url + ").";
+
+                if (guiArtifact.isEmpty() || guiArtifactLink.isEmpty()) {
+                    // Either no build is published for this host, or the release
+                    // is a prerelease, whose artifact naming has never been
+                    // exercised. Point at the directory and let the user choose,
+                    // rather than name a file that may not be there.
+                    QString url = "<a href=\""+ officialDownloadLink +"\">"+ officialDownloadLink +"</a>";
+                    text += "Please download the latest version from our official website <br>(" + url + ").";
+                } else {
+                    // The build this machine needs, rather than the directory
+                    // holding fifteen files it would have to choose between.
+                    text += "The build for this machine is:<br>";
+                    text += "<a href=\"" + guiArtifactLink + "\">" + guiArtifact + "</a>";
+
+                    if (platform == "osx64") {
+                        // Only an x86_64 macOS build is published, and it runs on
+                        // Apple Silicon under Rosetta. Say which one it is rather
+                        // than let an arm64 user assume it is native.
+                        text += "<br><br>This is the Intel build. It runs on Apple Silicon under Rosetta.";
+                    }
+                }
             }
 
             ui->aboutMessage->setText(text);


### PR DESCRIPTION
Backport of #517 to the 4.22.9 release line. Last commit of RED-110 (assisted upgrade, phase 1) on this branch.

## What

The dialog told the user a newer version existed and linked to the directory holding it, leaving them to work out which of the **fifteen** files there was theirs. It now names the one built for this machine and links straight to it, using the `guiartifact` fields `checkupdates` gained in #516.

The GUI artifact is the right one here by construction: this is `reddcoin-qt`, so the user wants the installer or the disk image rather than the archive a `reddcoind` operator would take. The RPC reports both and the presenter picks.

On macOS it says the build is the Intel one, since only an x86_64 macOS build is published and it runs on Apple Silicon under Rosetta. Naming it plainly beats letting an arm64 user assume it is native.

The directory link stays as the fallback for the two cases where no filename can be trusted: a host nobody publishes a build for, and a prerelease, whose artifact naming has never been exercised.

## Adapted, not copied

This is the change that needed real adaptation, as expected. develop receives the result as a `QVariantMap` from a worker thread and reads it with `info.value(...)`. This branch reads a `UniValue` inline and guards every field with `result.exists(...)`, so the three new fields are unpacked the same way the existing ones already are:

```cpp
if (result.exists("guiartifact")) {
    guiArtifact = QString::fromStdString(result["guiartifact"].get_str());
}
```

The rendering logic below that point is identical to develop's.

## An unrelated defect found here, deliberately not fixed

While editing this function I noticed the error branch never fires on this branch:

```cpp
src/qt/utilitydialog.cpp:110:   if (result.exists("error")) {
src/rpc/server.cpp:586:         result.pushKV("errors", errors);
```

The dialog tests `error`, the RPC publishes `errors`. So an update check that fails is currently rendered as though it succeeded, with empty version strings, rather than showing the error. develop does not have this: its worker builds the map with the correct key.

It is a one-word fix, but it changes what users see when the check fails, so it deserves its own review rather than riding along inside a backport. Happy to raise it separately. Recorded in the commit message too, so it is not lost with this PR.

## Verified

- `reddcoin-qt` builds and links on this branch
- both new strings are present in the built binary
- the field names match what `checkupdates` publishes here, checked against `rpc/server.cpp` rather than assumed from develop

**Not visually confirmed in a running GUI.** The dialog sits behind a Help menu item and needs a person to look at it. The logic and the values feeding it are verified; the layout is not.

YouTrack: https://reddink.youtrack.cloud/issue/RED-110
