### PR TITLE
qt: read the update check's error field under the name it is published

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -152,6 +152,17 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
                 }
             }
 
+            // The pre-release caution belongs on every outcome, not just one
+            // branch: it describes the build the user is running rather than
+            // anything the check discovered, so it is appended to whatever the
+            // text above ended up being.
+            if (!warning.isEmpty()) {
+                if (!text.isEmpty()) {
+                    text += "<br><br>";
+                }
+                text += "<font color = 'red'>" + warning + "</font>";
+            }
+
             ui->aboutMessage->setText(text);
 
         }

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -107,8 +107,8 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
             if (result.exists("officialDownloadLink")) {
                 officialDownloadLink = QString::fromStdString(result["officialDownloadLink"].get_str());
             }
-            if (result.exists("error")) {
-                errors = QString::fromStdString(result["error"].get_str());
+            if (result.exists("errors")) {
+                errors = QString::fromStdString(result["errors"].get_str());
             }
             if (result.exists("platform")) {
                 platform = QString::fromStdString(result["platform"].get_str());


### PR DESCRIPTION
Fixes RED-112. One word, but it changes a silent failure into a visible one.

## The bug

The dialog tests for `error`; the RPC publishes `errors`:

```
src/qt/utilitydialog.cpp:110   if (result.exists("error")) {
src/rpc/server.cpp:586         result.pushKV("errors", errors);
```

The key never matches, so the local string stays empty no matter what happened.

## Why it is worse than a lost message

The branch that runs instead:

```cpp
if (!errors.isEmpty()) {            // never taken
    ...
} else if (localversion == remoteversion) {
    text = "Installed version: <b>" + localversion + "</b><br>";
    text += message;
}
```

A failed check leaves both versions empty, so `"" == ""` is true and the dialog takes the **"you are up to date"** branch. `message` is empty too, so the user sees:

```
Installed version:
```

and nothing else. A network failure, a TLS failure, and a GitHub rate-limit response all render identically to a successful check on a current version. That is precisely the outcome the error field exists to distinguish.

Not hypothetical: GitHub's unauthenticated API limit is 60 requests per hour per IP, and exhausting it returns 403, which the update check reports through `errors`.

## Confirmed rather than reasoned

Forced the check to fail with a bogus `SSL_CERT_FILE`. The RPC returns exactly the state that triggers the bad branch:

```
"localversion":  "",
"remoteversion": "",
"errors": "SSL_CERT_FILE or SSL_CERT_DIR is set but no certificates could be read from it"
```

`errors` populated, both versions empty. With the old key the dialog skipped the error branch and fell into the equality test; with the fix it takes the error branch and shows the message.

`reddcoin-qt` builds on this branch.

**Not visually confirmed in a running GUI.** The dialog is behind a Help menu item. The data path is verified; the rendering is not.

## develop is unaffected

Its `UpdateCheckWorker` builds the map with the correct key and `showUpdateInfo` reads `info.value("errors")`. Checked rather than assumed.

## Left alone deliberately

`warning` is extracted in the same function and then never used, so the pre-release warning (`This is a pre-release test build...`) is never shown. **That one affects develop too**: the worker populates `info["warning"]` and the dialog never reads it. Different defect, different scope, and it wants its own issue rather than being folded in here.

## Note

Neither this mismatch nor the unused `warning` produces a compiler warning, since both are `QString` and `-Wunused-variable` does not fire for non-trivial class types. Worth knowing before assuming the build would have caught either.

YouTrack: https://reddink.youtrack.cloud/issue/RED-112
