### PR TITLE
qt: show the pre-release warning in the update dialog

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -154,6 +154,7 @@ void HelpMessageDialog::showUpdateInfo(const QVariantMap& info)
     const QString localversion{info.value("localversion").toString()};
     const QString remoteversion{info.value("remoteversion").toString()};
     const QString errors{info.value("errors").toString()};
+    const QString warning{info.value("warning").toString()};
 
     if (!errors.isEmpty()) {
         text = "<font color = 'red'>Error: </font>";
@@ -189,6 +190,16 @@ void HelpMessageDialog::showUpdateInfo(const QVariantMap& info)
                 text += "<br><br>This is the Intel build. It runs on Apple Silicon under Rosetta.";
             }
         }
+    }
+
+    // The pre-release caution belongs on every outcome, not just one branch: it
+    // describes the build the user is running rather than anything the check
+    // discovered, so it is appended to whatever the text above ended up being.
+    if (!warning.isEmpty()) {
+        if (!text.isEmpty()) {
+            text += "<br><br>";
+        }
+        text += "<font color = 'red'>" + warning + "</font>";
     }
 
     ui->aboutMessage->setText(text);


### PR DESCRIPTION
`UpdateCheckWorker` copies `warning` out of the update check's result into the map it hands the dialog, and `showUpdateInfo` never reads it. So the caution it carries has never been shown:

```
This is a pre-release test build - use at your own risk - do not use for
staking or merchant applications
```

That is not a cosmetic omission. It tells the user not to stake or take payments on the build they are running, and a pre-release client displayed nothing at all.

## Where it goes

Appended after the rest of the text rather than folded into one branch, because it describes the build the user is running rather than anything the check discovered. A pre-release that also fails its update check should say both, and a pre-release that is up to date should still say it.

## Not runtime verified, and why

`warning` is only non-empty when `CLIENT_VERSION_IS_RELEASE` is false. `configure.ac:7` defines it `true`, so no release build can exercise this path, and reconfiguring the tree as a pre-release purely to see one string felt like a poor trade.

What was confirmed instead:

- the field arrives **empty** on a release build, which is consistent with the condition
- `node::CheckForUpdates` populates it under exactly `if (!CLIENT_VERSION_IS_RELEASE)`
- `utilitydialog.cpp` compiles with the change

So the wiring is verified and the rendered result is not. A pre-release or rc build is what will actually exercise it, which is fitting, since that is the only build the message is for.

## Why the compiler never caught it

`warning` is a `QString`, and `-Wunused-variable` does not fire for non-trivial class types. The same reason the sibling defect on the 4.22.9 line went unnoticed. Worth knowing before assuming a build would catch this class of bug.

## Relationship to the 4.22.9 line

That branch has the same gap plus a second defect this one does not: its dialog reads the error field as `error` while the RPC publishes `errors`, so a failed check renders as a successful one with blank versions. Both are fixed there in #519 under RED-112.

Here the fix is only the warning, since develop's error handling already reads the correct key.

YouTrack: https://reddink.youtrack.cloud/issue/RED-112
