### PR TITLE
node: bound the update check's response

### DIFF
--- a/src/node/update_check.cpp
+++ b/src/node/update_check.cpp
@@ -144,6 +144,17 @@ const std::string UPDATE_CHECK_HOST{"api.github.com"};
 //! than holding anything up for long.
 constexpr std::chrono::seconds UPDATE_CHECK_TIMEOUT{10};
 
+//! Ceiling on the whole response, headers included.
+//!
+//! The body is buffered in memory before it is parsed, so without a bound a
+//! hostile or broken server can make this allocate until the process dies. The
+//! release object this asks for runs to a few kilobytes, so a megabyte is two
+//! orders of magnitude of headroom and still nowhere near enough to hurt.
+//!
+//! This is not the size limit for downloading an artifact. That path does not
+//! exist yet, and when it does it must stream to disk rather than raise this.
+constexpr std::size_t MAX_RESPONSE_BYTES{1024 * 1024};
+
 /**
  * Minimal one-shot HTTPS GET with an overall deadline.
  *
@@ -277,7 +288,7 @@ std::string HttpsFetcher::Get(const std::string& target)
     // though, so which one arrived is carried through to the completeness check
     // rather than being flattened into success.
     bool clean_eof{false};
-    boost::asio::streambuf response;
+    boost::asio::streambuf response{MAX_RESPONSE_BYTES};
     boost::asio::async_read(m_stream, response, boost::asio::transfer_all(),
         [&](const boost::system::error_code& ec, std::size_t) {
             clean_eof = (ec == boost::asio::error::eof);
@@ -287,6 +298,20 @@ std::string HttpsFetcher::Get(const std::string& target)
             m_done = true;
         });
     Await("reading the response from " + m_host);
+
+    // A bounded streambuf does not report the bound being hit. asio's read loop
+    // simply stops once prepare() can yield nothing more and completes as though
+    // the stream had ended, so the caller is handed a truncated body with no
+    // error. Detect it here rather than let it look like a short response.
+    //
+    // A response that is exactly the ceiling is rejected along with one that
+    // exceeds it, since the two are indistinguishable from this side. Erring
+    // that way costs nothing at a limit set two orders of magnitude above the
+    // real thing.
+    if (response.size() >= MAX_RESPONSE_BYTES) {
+        throw std::runtime_error("Response from " + m_host + " exceeded " +
+                                 ToString(MAX_RESPONSE_BYTES) + " bytes");
+    }
 
     std::ostringstream raw;
     raw << &response;


### PR DESCRIPTION
Closes the first of the two faults left in blocker **B3** of the assisted-upgrade design. Phase "S" in the epic's ordering: small, independent, and a live weakness in shipped code rather than a future one.

## The problem

The response was read into an unbounded `boost::asio::streambuf` before being parsed, so a hostile or broken server could make the client allocate until the process died. Nothing limited it.

## The fix, and why the check after the read is not redundant

The streambuf is now constructed with a ceiling. That alone is not enough:

**A bounded streambuf does not report the bound being hit.** asio's read loop stops once `prepare()` can yield nothing more and completes as though the stream had ended:

```cpp
// boost/asio/impl/read.hpp
buffers_.prepare(std::min<std::size_t>(max_size, b.max_size() - b.size()));
...
if ((!ec && bytes_transferred == 0) || buffers_.empty())
  break;
```

So without the explicit test the caller is handed a **truncated body with no error**, which would surface as a parse failure or, worse, as a short but well formed response. The test after the read turns that into a clear message.

A response exactly at the ceiling is rejected along with one that exceeds it, since the two are indistinguishable from this side. At a limit set two orders of magnitude above the real thing, erring that way costs nothing.

## Why a megabyte

The release object this fetches runs to a few kilobytes. A megabyte is roughly 170x headroom and still trivial to allocate. It is deliberately not tight: the aim is to stop unbounded growth, not to police the exact size of a JSON document that GitHub may change.

**This is not the size limit for downloading an artifact.** That path does not exist yet, and when phase 3 adds it, it must stream to disk rather than raise this ceiling. Said in the code too, so nobody reaches for this constant later.

## Verified

Temporarily shrank the ceiling to 2048 bytes, below the real response, and ran against the live endpoint:

```
"remoteversion": "",
"errors": "Response from api.github.com exceeded 2048 bytes"
```

Then restored it and confirmed the check succeeds again, returning `4.22.9.4` with an empty `errors`. `update_check_tests` passes.

The property that matters is that exceeding the limit is **reported** rather than silently truncated, and that is what the shrunk-limit run demonstrates.

## Still open in B3

The deadline is a flat 10s for the whole exchange, and redirects are not followed. Both belong to the phase 3 streaming rewrite.

YouTrack: https://reddink.youtrack.cloud/issue/RED-98
