### PR TITLE
rpc: bound the update check's response

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -67,6 +67,18 @@ static std::string strGithubLink = "/repos/reddcoin-project/reddcoin/releases/la
 //! Host header cannot drift apart from one another.
 static const std::string strGithubHost = "api.github.com";
 
+//! Ceiling on the update check's response body.
+//!
+//! The body is accumulated in memory before it is parsed, so without a bound a
+//! hostile or broken server can make this allocate until the process dies. The
+//! release object this asks for runs to a few kilobytes, so a megabyte is two
+//! orders of magnitude of headroom and still nowhere near enough to hurt.
+//!
+//! This is not the size limit for downloading an artifact. That path does not
+//! exist here, and if it is ever added it must stream to disk rather than raise
+//! this ceiling.
+static const size_t MAX_RESPONSE_BYTES = 1024 * 1024;
+
 struct RPCCommandExecutionInfo
 {
     std::string method;
@@ -435,6 +447,15 @@ void checkforupdatesinfo(UniValue& result)
             if (!error) {
                 if (n) {
                     ostringstream_content << &response;
+
+                    // Checked as it accumulates rather than afterwards: the
+                    // point is to stop allocating, so noticing at the end would
+                    // be too late to be worth anything.
+                    if (static_cast<size_t>(ostringstream_content.tellp()) > MAX_RESPONSE_BYTES) {
+                        errors = "Response from " + strGithubHost + " exceeded " +
+                                 std::to_string(MAX_RESPONSE_BYTES) + " bytes";
+                        break;
+                    }
                 }
             }
             if (error == boost::asio::error::eof) {


### PR DESCRIPTION
Backport of #521 to the 4.22.9 release line. Bounds the update check's response so a hostile or broken server cannot make the client allocate until the process dies.

## Adapted, not copied

The weakness is the same on both lines; the code is not, so the fix differs in shape.

**develop** reads into a `boost::asio::streambuf` in one call, so it bounds the streambuf and tests afterwards. It has to test explicitly, because a bounded streambuf reports nothing when the bound is hit: asio's read loop stops and completes as though the stream had ended, handing back a truncated body with no error.

**This branch** reads in chunks and appends to an `ostringstream` as it goes:

```cpp
size_t n = boost::asio::read(ssock, response, boost::asio::transfer_at_least(1), error);
if (!error) {
    if (n) {
        ostringstream_content << &response;
```

so the ceiling is enforced **as it accumulates**, inside the loop. That is the right place regardless of implementation: the point is to stop allocating, so noticing at the end would be too late to be worth anything.

## Why a megabyte

The release object this fetches runs to a few kilobytes. A megabyte is roughly 170x headroom and still trivial to allocate. It is deliberately not tight: the aim is to stop unbounded growth, not to police the exact size of a JSON document GitHub may change.

**This is not the size limit for downloading an artifact.** No such path exists on this branch, and if one is ever added it must stream to disk rather than raise this ceiling. Stated in the code so nobody reaches for the constant later.

## Verified on this branch

Temporarily shrank the ceiling to 2048 bytes, below the real response, and ran against the live endpoint:

```
"remoteversion": "",
"errors": "Response from api.github.com exceeded 2048 bytes"
```

Then restored it and confirmed the check succeeds again, returning `4.22.9.4` with an empty `errors` and the artifact fields populated.

Built and run here rather than inferred from develop.

YouTrack: https://reddink.youtrack.cloud/issue/RED-98
