### PR TITLE
contrib: sign the release manifest for the client

### DIFF
--- a/contrib/release-signing/sign-release-manifest.py
+++ b/contrib/release-signing/sign-release-manifest.py
@@ -81,6 +81,16 @@ def tagged_hash(tag, data):
     return hashlib.sha256(ss + ss + data).digest()
 
 
+# Where the client keeps the English BIP39 wordlist. It sits in src/util/lang on
+# the development line and in src/wallet on the 4.22.9 release line, so both are
+# tried: this tool is copied to an air-gapped machine and should be one file that
+# works from either checkout rather than two that can drift apart.
+WORDLIST_PATHS = (
+    ('src', 'util', 'lang', 'bip39_english.h'),
+    ('src', 'wallet', 'bip39_english.h'),
+)
+
+
 def load_wordlist():
     """The English BIP39 wordlist, read from the header the client uses.
 
@@ -88,8 +98,13 @@ def load_wordlist():
     second copy here could drift from the one the wallet derives with, and the
     divergence would only ever show up as a key that does not match.
     """
-    path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                        '..', '..', 'src', 'util', 'lang', 'bip39_english.h')
+    root = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
+    tried = [os.path.join(root, *parts) for parts in WORDLIST_PATHS]
+    found = [p for p in tried if os.path.exists(p)]
+    if not found:
+        raise SystemExit("no BIP39 wordlist found, looked in:\n  " + "\n  ".join(tried))
+
+    path = found[0]
     words = re.findall(r'^\s*"([a-z]+)",?\s*$', open(path, encoding='utf8').read(), re.MULTILINE)
     if len(words) != 2048:
         raise SystemExit("expected 2048 words in {}, found {}".format(path, len(words)))

--- a/contrib/release-signing/sign-release-manifest.py
+++ b/contrib/release-signing/sign-release-manifest.py
@@ -52,13 +52,27 @@ MANIFEST_TAG = "Reddcoin/ReleaseManifest"
 
 # BIP32 path the release key is derived at.
 #
+#   m/1018'/4'/0'
+#     │      │   └── index, so a rotated key is 1' from the same backed-up seed
+#     │      └────── SLIP-0044 coin type 4, Reddcoin (chainparams nExtCoinType)
+#     └───────────── purpose
+#
 # Deliberately not a wallet path. Reddcoin wallets derive under m/44'/4'/..., and
 # a release key that could collide with a spending key is a bad idea however
 # unlikely the collision. This path exists for signing releases and nothing else.
 #
+# On the purpose value: 1018 was checked against the BIP43 registry (44, 45, 47,
+# 48, 49, 84, 86, 87) and against known unregistered users, and had no claimant.
+# Its neighbour 1017 does: lnd derives every Lightning key under
+# m/1017'/coinType'/keyFamily'/0/index, so that prefix would have described this
+# key as a Lightning multisig branch. Nothing would have collided, since this
+# seed derives nothing else, but a path is read by people and should not say
+# something untrue. Absence of a claimant is not a reservation; the REP is what
+# records this one.
+#
 # Fixed once a key has been generated: the mnemonic alone does not identify the
 # key without it, so changing the path is changing the key.
-DERIVATION_PATH = "m/1017'/4'/0'"
+DERIVATION_PATH = "m/1018'/4'/0'"
 
 
 def tagged_hash(tag, data):

--- a/contrib/release-signing/sign-release-manifest.py
+++ b/contrib/release-signing/sign-release-manifest.py
@@ -120,6 +120,18 @@ def bip39_seed(mnemonic, passphrase=""):
 
 
 def bip32_master(seed):
+    """BIP32 master key and chain code from a seed.
+
+    "Bitcoin seed" is the HMAC key BIP32 fixes for this step, in every
+    implementation and for every coin. It is not a name to localise: a coin
+    identifies itself in the derivation path, and changing this constant would
+    derive a different key from the same words while looking perfectly correct.
+    Keeping it standard is also what lets any BIP39 tool recover the release key
+    from the mnemonic, rather than this script being the only thing that can.
+
+    Matches CExtKey::SetSeed() in src/key.cpp, which spells the same constant as
+    a char array.
+    """
     i = hmac.new(b"Bitcoin seed", seed, hashlib.sha512).digest()
     return i[:32], i[32:]
 

--- a/contrib/release-signing/sign-release-manifest.py
+++ b/contrib/release-signing/sign-release-manifest.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Sign and verify a release manifest with the offline release key.
+
+The client verifies releases with a BIP340 Schnorr signature over SHA256SUMS,
+checked against a public key compiled into the binary. This produces that
+signature. It is meant to run on the air-gapped machine that holds the private
+key, so it depends on nothing outside the Python standard library and this
+repository.
+
+The signing key never leaves that machine. Only SHA256SUMS goes in and only
+SHA256SUMS.sig comes out.
+
+Subcommands:
+
+    selftest   run the official BIP340 test vectors
+    pubkey     print the x-only public key for a mnemonic
+    sign       sign a manifest
+    verify     check a signature against a manifest and a public key
+
+Run selftest first on any machine you have not used before. It proves the
+implementation on that machine reproduces the BIP340 vectors, which is worth
+knowing before it signs something users will trust.
+"""
+
+import argparse
+import hashlib
+import hmac
+import os
+import sys
+import unicodedata
+
+# The BIP340 implementation, the curve order and the official test vectors all
+# already live in the test framework. Reusing them beats a second copy of
+# signature code that nothing else exercises.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'test', 'functional'))
+from test_framework.key import (  # noqa: E402
+    SECP256K1_ORDER,
+    compute_xonly_pubkey,
+    sign_schnorr,
+    verify_schnorr,
+)
+
+# Domain separation. The release key is on the same curve as transaction keys,
+# so a signature over a bare SHA256 could be meaningful in another context. The
+# tag is part of the format: changing it invalidates every signature any
+# released client will accept.
+MANIFEST_TAG = "Reddcoin/ReleaseManifest"
+
+# BIP32 path the release key is derived at.
+#
+# Deliberately not a wallet path. Reddcoin wallets derive under m/44'/4'/..., and
+# a release key that could collide with a spending key is a bad idea however
+# unlikely the collision. This path exists for signing releases and nothing else.
+#
+# Fixed once a key has been generated: the mnemonic alone does not identify the
+# key without it, so changing the path is changing the key.
+DERIVATION_PATH = "m/1017'/4'/0'"
+
+
+def tagged_hash(tag, data):
+    """BIP340 tagged hash. Matches TaggedHash() in src/hash.h."""
+    ss = hashlib.sha256(tag.encode()).digest()
+    return hashlib.sha256(ss + ss + data).digest()
+
+
+def bip39_seed(mnemonic, passphrase=""):
+    """BIP39 mnemonic to 64-byte seed.
+
+    The mnemonic is not checksum-validated here. This signs with whatever key
+    the words produce, and the public key is what tells you it is the right one:
+    check it against the value in the release process before trusting a
+    signature.
+    """
+    mnemonic = unicodedata.normalize("NFKD", " ".join(mnemonic.split()))
+    salt = unicodedata.normalize("NFKD", "mnemonic" + passphrase)
+    return hashlib.pbkdf2_hmac("sha512", mnemonic.encode(), salt.encode(), 2048)
+
+
+def bip32_master(seed):
+    i = hmac.new(b"Bitcoin seed", seed, hashlib.sha512).digest()
+    return i[:32], i[32:]
+
+
+def bip32_derive_hardened(privkey, chaincode, index):
+    assert index >= 0x80000000, "this only derives hardened children"
+    data = b"\x00" + privkey + index.to_bytes(4, "big")
+    i = hmac.new(chaincode, data, hashlib.sha512).digest()
+    child = (int.from_bytes(i[:32], "big") + int.from_bytes(privkey, "big")) % SECP256K1_ORDER
+    if child == 0 or int.from_bytes(i[:32], "big") >= SECP256K1_ORDER:
+        raise SystemExit("derivation produced an invalid key, which should not happen")
+    return child.to_bytes(32, "big"), i[32:]
+
+
+def derive_release_key(mnemonic, passphrase=""):
+    """Private key at DERIVATION_PATH for a mnemonic."""
+    privkey, chaincode = bip32_master(bip39_seed(mnemonic, passphrase))
+    for element in DERIVATION_PATH.split("/")[1:]:
+        assert element.endswith("'"), "every path element must be hardened"
+        privkey, chaincode = bip32_derive_hardened(privkey, chaincode, int(element[:-1]) + 0x80000000)
+    return privkey
+
+
+def read_text(path):
+    with open(path, "r", encoding="utf8") as f:
+        return f.read().strip()
+
+
+def xonly_pubkey(privkey):
+    pubkey, _negated = compute_xonly_pubkey(privkey)
+    if pubkey is None:
+        raise SystemExit("could not compute a public key from that mnemonic")
+    return pubkey
+
+
+def cmd_selftest(_args):
+    """Run the official BIP340 vectors against this machine's Python."""
+    import csv
+    vectors = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                           '..', '..', 'test', 'functional', 'test_framework',
+                           'bip340_test_vectors.csv')
+    checked = 0
+    with open(vectors, newline='', encoding='utf8') as f:
+        reader = csv.reader(f)
+        next(reader)
+        for row in reader:
+            (_i, seckey, pubkey, aux, msg, sig, result, _comment) = row
+            pubkey = bytes.fromhex(pubkey)
+            msg = bytes.fromhex(msg)
+            sig = bytes.fromhex(sig)
+            if seckey:
+                seckey = bytes.fromhex(seckey)
+                actual_pubkey = xonly_pubkey(seckey)
+                if actual_pubkey != pubkey:
+                    raise SystemExit("BIP340 vector failed: public key mismatch")
+                actual_sig = sign_schnorr(seckey, msg, aux=bytes.fromhex(aux))
+                if actual_sig != sig:
+                    raise SystemExit("BIP340 vector failed: signature mismatch")
+            expected = (result == "TRUE")
+            if verify_schnorr(pubkey, sig, msg) != expected:
+                raise SystemExit("BIP340 vector failed: verification mismatch")
+            checked += 1
+    print("BIP340 self-test passed: {} vectors".format(checked))
+    return 0
+
+
+def cmd_pubkey(args):
+    privkey = derive_release_key(read_text(args.mnemonic),
+                                 read_text(args.passphrase) if args.passphrase else "")
+    print(xonly_pubkey(privkey).hex())
+    return 0
+
+
+def cmd_sign(args):
+    # Read as bytes, never as text. The signature covers the file exactly as it
+    # will be published, and any newline or encoding normalisation on the way
+    # through would sign something the server does not serve.
+    with open(args.manifest, "rb") as f:
+        manifest = f.read()
+
+    privkey = derive_release_key(read_text(args.mnemonic),
+                                 read_text(args.passphrase) if args.passphrase else "")
+    pubkey = xonly_pubkey(privkey)
+    sig = sign_schnorr(privkey, tagged_hash(MANIFEST_TAG, manifest))
+
+    # Never emit a signature this tool cannot itself verify.
+    if not verify_schnorr(pubkey, sig, tagged_hash(MANIFEST_TAG, manifest)):
+        raise SystemExit("refusing to write a signature that does not verify")
+
+    out = args.output or (args.manifest + ".sig")
+    with open(out, "w", encoding="utf8") as f:
+        f.write(sig.hex() + "\n")
+
+    print("signed   {} ({} bytes)".format(args.manifest, len(manifest)))
+    print("public   {}".format(pubkey.hex()))
+    print("wrote    {}".format(out))
+    print()
+    print("Check the public key above against the one in doc/release-process.md")
+    print("before publishing. A signature from the wrong key verifies against")
+    print("itself and against nothing a released client will accept.")
+    return 0
+
+
+def cmd_verify(args):
+    with open(args.manifest, "rb") as f:
+        manifest = f.read()
+    sig = bytes.fromhex(read_text(args.signature))
+    pubkey = bytes.fromhex(args.pubkey)
+
+    if len(sig) != 64:
+        raise SystemExit("signature is {} bytes, expected 64".format(len(sig)))
+    if len(pubkey) != 32:
+        raise SystemExit("public key is {} bytes, expected 32".format(len(pubkey)))
+
+    if not verify_schnorr(pubkey, sig, tagged_hash(MANIFEST_TAG, manifest)):
+        print("BAD signature", file=sys.stderr)
+        return 1
+    print("Good signature over {} ({} bytes)".format(args.manifest, len(manifest)))
+    print("by public key {}".format(pubkey.hex()))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("selftest", help="run the official BIP340 test vectors")
+
+    p = sub.add_parser("pubkey", help="print the x-only public key for a mnemonic")
+    p.add_argument("--mnemonic", required=True, help="file holding the BIP39 mnemonic")
+    p.add_argument("--passphrase", help="file holding the BIP39 passphrase, if any")
+
+    p = sub.add_parser("sign", help="sign a manifest")
+    p.add_argument("manifest", help="the SHA256SUMS file that will be published")
+    p.add_argument("--mnemonic", required=True, help="file holding the BIP39 mnemonic")
+    p.add_argument("--passphrase", help="file holding the BIP39 passphrase, if any")
+    p.add_argument("--output", help="signature path (default: <manifest>.sig)")
+
+    p = sub.add_parser("verify", help="check a signature against a manifest")
+    p.add_argument("manifest")
+    p.add_argument("signature")
+    p.add_argument("--pubkey", required=True, help="x-only public key, 64 hex characters")
+
+    args = parser.parse_args()
+    return {
+        "selftest": cmd_selftest,
+        "pubkey": cmd_pubkey,
+        "sign": cmd_sign,
+        "verify": cmd_verify,
+    }[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/release-signing/sign-release-manifest.py
+++ b/contrib/release-signing/sign-release-manifest.py
@@ -29,6 +29,7 @@ import argparse
 import hashlib
 import hmac
 import os
+import re
 import sys
 import unicodedata
 
@@ -66,14 +67,53 @@ def tagged_hash(tag, data):
     return hashlib.sha256(ss + ss + data).digest()
 
 
-def bip39_seed(mnemonic, passphrase=""):
-    """BIP39 mnemonic to 64-byte seed.
+def load_wordlist():
+    """The English BIP39 wordlist, read from the header the client uses.
 
-    The mnemonic is not checksum-validated here. This signs with whatever key
-    the words produce, and the public key is what tells you it is the right one:
-    check it against the value in the release process before trusting a
-    signature.
+    Parsed rather than duplicated so there is one wordlist in the repository. A
+    second copy here could drift from the one the wallet derives with, and the
+    divergence would only ever show up as a key that does not match.
     """
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                        '..', '..', 'src', 'util', 'lang', 'bip39_english.h')
+    words = re.findall(r'^\s*"([a-z]+)",?\s*$', open(path, encoding='utf8').read(), re.MULTILINE)
+    if len(words) != 2048:
+        raise SystemExit("expected 2048 words in {}, found {}".format(path, len(words)))
+    return words
+
+
+def check_mnemonic(mnemonic):
+    """Reject a mnemonic that is not a valid BIP39 phrase.
+
+    Worth doing rather than trusting the operator to eyeball the public key
+    afterwards. A single mistyped word produces a perfectly usable key for a
+    completely different wallet, so without this the tool would happily sign a
+    release with a key nothing has ever seen, and the only thing standing
+    between that and publishing it would be someone comparing 64 hex
+    characters by eye.
+    """
+    words = unicodedata.normalize("NFKD", mnemonic).split()
+    if len(words) not in (12, 15, 18, 21, 24):
+        raise SystemExit("mnemonic has {} words, expected 12, 15, 18, 21 or 24".format(len(words)))
+
+    wordlist = load_wordlist()
+    index = {w: i for i, w in enumerate(wordlist)}
+    unknown = [w for w in words if w not in index]
+    if unknown:
+        raise SystemExit("not BIP39 words: {}".format(", ".join(sorted(set(unknown)))))
+
+    bits = "".join(format(index[w], "011b") for w in words)
+    entropy_bits = len(words) * 32 // 3
+    entropy = int(bits[:entropy_bits], 2).to_bytes(entropy_bits // 8, "big")
+    expected = format(hashlib.sha256(entropy).digest()[0], "08b")[:len(words) // 3]
+    if bits[entropy_bits:] != expected:
+        raise SystemExit(
+            "mnemonic checksum is wrong. One or more words are mistyped or out of order; "
+            "this is not the phrase you think it is")
+
+
+def bip39_seed(mnemonic, passphrase=""):
+    """BIP39 mnemonic to 64-byte seed."""
     mnemonic = unicodedata.normalize("NFKD", " ".join(mnemonic.split()))
     salt = unicodedata.normalize("NFKD", "mnemonic" + passphrase)
     return hashlib.pbkdf2_hmac("sha512", mnemonic.encode(), salt.encode(), 2048)
@@ -96,6 +136,7 @@ def bip32_derive_hardened(privkey, chaincode, index):
 
 def derive_release_key(mnemonic, passphrase=""):
     """Private key at DERIVATION_PATH for a mnemonic."""
+    check_mnemonic(mnemonic)
     privkey, chaincode = bip32_master(bip39_seed(mnemonic, passphrase))
     for element in DERIVATION_PATH.split("/")[1:]:
         assert element.endswith("'"), "every path element must be hardened"

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -285,6 +285,89 @@ Both files go to the server together. Publishing `SHA256SUMS` without its
 signature leaves the manifest authenticated by nothing but TLS to the web host,
 which is the state every release up to and including 4.22.9.4 shipped in.
 
+### Sign the manifest for the client
+
+`SHA256SUMS.asc` proves the release to a person with OpenPGP tooling.
+`SHA256SUMS.sig` proves it to the client, which has no OpenPGP and, on Windows,
+no `gpgv` either. Both cover the same manifest and both are published.
+
+The client verifies against a public key compiled into it, so this signature is
+made with a key whose private half **never touches a networked machine**. It
+lives on an air-gapped box, derived from a BIP39 mnemonic held offline.
+
+`contrib/release-signing/sign-release-manifest.py` does the signing. It needs
+nothing but Python and this repository: the BIP340 implementation and the
+official test vectors it uses already live in `test/functional/test_framework`.
+
+#### First, on the air-gapped machine
+
+Prove the crypto works on that machine before it signs anything users will
+trust:
+
+```bash
+./contrib/release-signing/sign-release-manifest.py selftest
+```
+
+That runs the official BIP340 vectors and must report all of them passing.
+
+#### Sign
+
+Carry `SHA256SUMS` in, and carry `SHA256SUMS.sig` back out. Nothing else crosses
+the gap, and the mnemonic never leaves:
+
+```bash
+./contrib/release-signing/sign-release-manifest.py sign SHA256SUMS \
+    --mnemonic /path/to/mnemonic.txt
+```
+
+It prints the public key it signed with. **Check that against the release key
+below before publishing.** A signature made with the wrong key verifies happily
+against itself and against nothing any released client will accept, so this is
+the one check that cannot be skipped.
+
+#### Verify before uploading
+
+On the build host, against the manifest as it will be published:
+
+```bash
+./contrib/release-signing/sign-release-manifest.py verify SHA256SUMS SHA256SUMS.sig \
+    --pubkey "$RELEASE_PUBKEY"
+```
+
+It exits non-zero on a bad signature, so it is safe to gate an upload on.
+
+Upload `SHA256SUMS.sig` beside `SHA256SUMS` and `SHA256SUMS.asc`. The same rule
+applies as for the `.asc`: if the manifest is regenerated, **both** signatures
+have to be regenerated and re-uploaded with it, or they verify as BAD against
+what is served.
+
+#### The release key
+
+```
+derivation   m/1017'/4'/0'  (BIP39 mnemonic -> BIP32, all elements hardened)
+public key   (fill in when the production key is generated)
+```
+
+Deliberately not a wallet path. Reddcoin wallets derive under `m/44'/4'/...`, and
+a release key that could collide with a spending key is a bad idea however
+unlikely the collision.
+
+⚠ **The path is part of the key.** A mnemonic does not identify a key without
+it, so changing the path after a key exists is changing the key, and every
+client carrying the old public key stops verifying. Fix it before generating the
+production key, not after.
+
+⚠ **The tag is part of the format.** The signature is over
+`TaggedHash("Reddcoin/ReleaseManifest")` of the manifest bytes, matching
+`TaggedHash()` in `src/hash.h`. Changing the tag invalidates every signature any
+released client will accept.
+
+The public key is compiled into the client, so **rotating it requires a client
+release**. That cost was accepted deliberately: any automatic client-side
+verification needs a trust anchor, and the alternative was verifying nothing.
+Recovery from a lost signing machine is the offline mnemonic backup, not a
+delegation chain, so treat that backup with the care a wallet seed gets.
+
 ### Publishing the release key
 
 A signature is only useful to someone who can obtain the key that made it. The
@@ -361,6 +444,8 @@ gpg --export --armor "$SIGNER_KEY" > reddcoin-release-key.asc
     2. The `SHA256SUMS` file
 
     3. The `SHA256SUMS.asc` detached signature you just created and verified
+
+    4. The `SHA256SUMS.sig` Schnorr signature the client verifies
 
 ### Verify the published release
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -350,13 +350,19 @@ what is served.
 #### The release key
 
 ```
-derivation   m/1017'/4'/0'  (BIP39 mnemonic -> BIP32, all elements hardened)
+derivation   m/1018'/4'/0'  (BIP39 mnemonic -> BIP32, all elements hardened)
 public key   (fill in when the production key is generated)
 ```
 
 Deliberately not a wallet path. Reddcoin wallets derive under `m/44'/4'/...`, and
 a release key that could collide with a spending key is a bad idea however
-unlikely the collision.
+unlikely the collision. `4'` is Reddcoin's SLIP-0044 coin type, matching
+`nExtCoinType`; the trailing index is the rotation slot, so a replacement key is
+`1'` from the same backup rather than a new seed.
+
+Purpose `1018'` had no claimant when it was assigned, checked against the BIP43
+registry and against known unregistered users. Its neighbour `1017'` is lnd's,
+which derives Lightning keys under `m/1017'/coinType'/keyFamily'/0/index`.
 
 ⚠ **The path is part of the key.** A mnemonic does not identify a key without
 it, so changing the path after a key exists is changing the key, and every

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -320,10 +320,16 @@ the gap, and the mnemonic never leaves:
     --mnemonic /path/to/mnemonic.txt
 ```
 
-It prints the public key it signed with. **Check that against the release key
-below before publishing.** A signature made with the wrong key verifies happily
-against itself and against nothing any released client will accept, so this is
-the one check that cannot be skipped.
+A mistyped mnemonic is rejected rather than signed with: the words are checked
+against the BIP39 list and the phrase against its own checksum. That matters
+most when recovering onto a rebuilt machine, where a wrong word would otherwise
+derive a perfectly usable key for a wallet that has never signed anything.
+
+What the checksum cannot tell you is whether a valid phrase is the *right*
+phrase, so the tool also prints the public key it signed with. **Check that
+against the release key below before publishing.** A signature made with the
+wrong key verifies happily against itself and against nothing any released
+client will accept, so this is the one check that cannot be skipped.
 
 #### Verify before uploading
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -148,6 +148,7 @@ BITCOIN_TESTS =\
   test/txvalidation_tests.cpp \
   test/uint256_tests.cpp \
   test/release_artifacts_tests.cpp \
+  test/release_manifest_tests.cpp \
   test/update_check_tests.cpp \
   test/uint512_tests.cpp \
   test/util_tests.cpp \

--- a/src/test/release_manifest_tests.cpp
+++ b/src/test/release_manifest_tests.cpp
@@ -1,0 +1,175 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <hash.h>
+#include <pubkey.h>
+#include <span.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+//! Agreement with the signing tool, on the values REP-1018 publishes.
+//!
+//! The release signature is produced by a Python tool on an air-gapped machine
+//! and checked by this code. Nothing else forces the two to agree, and a
+//! disagreement would not show up until every release failed to verify for
+//! every user. These are the vectors from REP-1018 section 5.2, so a change on
+//! either side breaks this file.
+
+namespace {
+//! REP-1018 section 5.2. Two lines, two spaces between digest and name, each
+//! line terminated. Signed exactly as published, with no normalisation.
+const std::string MANIFEST{
+    "1f0b3ca2d0f4bd0b04ef3f0e8a3ab88a1e1b0f7a8e1d5a3b6c9d2e4f0a1b2c3d  reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz\n"
+    "9e8d7c6b5a4938271605f4e3d2c1b0a9f8e7d6c5b4a39281706f5e4d3c2b1a09  reddcoin-4.22.9.4-win64.zip\n"};
+
+//! The tag is part of the format. Changing it invalidates every signature any
+//! released client will accept, so it is spelled out here rather than shared
+//! with the implementation: this file is meant to fail if the tag moves.
+const std::string TAG{"Reddcoin/ReleaseManifest"};
+
+const std::string EXPECTED_TAGGED_HASH{"f0b197e423efe74b8898f0a7d3e51404c20beb817caf2f86de5182741dcaf480"};
+const std::string EXPECTED_BARE_SHA256{"4d363d6853b51e5734c41b13bbf6bcb16c16d8c437e1d96c270dde3a02fd080a"};
+const std::string RELEASE_PUBKEY{"53c9cbcba0ac673c841e72aa4a430206110feba034df81c58fba3917a80f6700"};
+const std::string RELEASE_SIG{
+    "d552158b18f0f68ee2c67404b70475baac9f324aaa7870c1735f6a1e7c146b03"
+    "28f7f000651917afab0e8393841985c3a1013f527b1e17a4dfe2c0d2f14f4608"};
+
+//! Raw byte order, matching what the tool prints. uint256::ToString() reverses,
+//! which would silently compare against a byte-swapped value.
+std::string RawHex(const uint256& value)
+{
+    return HexStr(Span<const unsigned char>(value.begin(), value.size()));
+}
+
+//! The message a release signature commits to: TaggedHash(tag) over the
+//! manifest bytes. This is the whole of REP-1018 section 3.4.
+uint256 ManifestHash(const std::string& tag, const std::string& manifest)
+{
+    CHashWriter hasher{TaggedHash(tag)};
+    hasher.write(manifest.data(), manifest.size());
+    return hasher.GetSHA256();
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(release_manifest_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(the_manifest_vector_is_intact)
+{
+    // Guards the vector itself. A transcription slip here would make every
+    // other case in this file agree with the wrong thing.
+    BOOST_CHECK_EQUAL(MANIFEST.size(), 202U);
+}
+
+BOOST_AUTO_TEST_CASE(cpp_and_the_signing_tool_agree_on_the_message)
+{
+    // The link nothing else checks. The Python tool computed this value; if
+    // TaggedHash() here disagrees, no release we sign will ever verify.
+    BOOST_CHECK_EQUAL(RawHex(ManifestHash(TAG, MANIFEST)), EXPECTED_TAGGED_HASH);
+}
+
+BOOST_AUTO_TEST_CASE(domain_separation_is_applied_not_merely_described)
+{
+    // A signature over a bare SHA256 of the manifest could be meaningful in
+    // another protocol context, which is the whole reason for the tag. Assert
+    // the two differ, so an implementation that quietly drops the tagged hash
+    // fails here rather than in production.
+    const uint256 tagged{ManifestHash(TAG, MANIFEST)};
+
+    uint256 bare;
+    CSHA256()
+        .Write(reinterpret_cast<const unsigned char*>(MANIFEST.data()), MANIFEST.size())
+        .Finalize(bare.begin());
+
+    BOOST_CHECK_EQUAL(RawHex(bare), EXPECTED_BARE_SHA256);
+    BOOST_CHECK(tagged != bare);
+}
+
+BOOST_AUTO_TEST_CASE(the_reference_signature_verifies)
+{
+    // End to end through the exact path a client will use: a signature made by
+    // the offline tool, checked by XOnlyPubKey::VerifySchnorr.
+    const std::vector<unsigned char> key_bytes{ParseHex(RELEASE_PUBKEY)};
+    const std::vector<unsigned char> sig{ParseHex(RELEASE_SIG)};
+    BOOST_REQUIRE_EQUAL(key_bytes.size(), 32U);
+    BOOST_REQUIRE_EQUAL(sig.size(), 64U);
+
+    const XOnlyPubKey pubkey{key_bytes};
+    BOOST_REQUIRE(pubkey.IsFullyValid());
+    BOOST_CHECK(pubkey.VerifySchnorr(ManifestHash(TAG, MANIFEST), sig));
+}
+
+BOOST_AUTO_TEST_CASE(a_modified_manifest_fails)
+{
+    const std::vector<unsigned char> key_bytes{ParseHex(RELEASE_PUBKEY)};
+    const std::vector<unsigned char> sig{ParseHex(RELEASE_SIG)};
+    const XOnlyPubKey pubkey{key_bytes};
+
+    std::string tampered{MANIFEST};
+    tampered[0] = (tampered[0] == '1') ? '2' : '1';
+
+    BOOST_CHECK(!pubkey.VerifySchnorr(ManifestHash(TAG, tampered), sig));
+}
+
+BOOST_AUTO_TEST_CASE(an_appended_line_fails)
+{
+    // The realistic failure: the manifest is regenerated and re-uploaded but
+    // the signature is not, so what is served no longer matches what was signed.
+    const std::vector<unsigned char> key_bytes{ParseHex(RELEASE_PUBKEY)};
+    const std::vector<unsigned char> sig{ParseHex(RELEASE_SIG)};
+    const XOnlyPubKey pubkey{key_bytes};
+
+    const std::string regenerated{
+        MANIFEST + "0000000000000000000000000000000000000000000000000000000000000000  extra.tar.gz\n"};
+
+    BOOST_CHECK(!pubkey.VerifySchnorr(ManifestHash(TAG, regenerated), sig));
+}
+
+BOOST_AUTO_TEST_CASE(a_modified_signature_fails)
+{
+    const std::vector<unsigned char> key_bytes{ParseHex(RELEASE_PUBKEY)};
+    const XOnlyPubKey pubkey{key_bytes};
+
+    std::vector<unsigned char> sig{ParseHex(RELEASE_SIG)};
+    sig[0] ^= 0x01;
+
+    BOOST_CHECK(!pubkey.VerifySchnorr(ManifestHash(TAG, MANIFEST), sig));
+}
+
+BOOST_AUTO_TEST_CASE(another_key_does_not_verify)
+{
+    const std::vector<unsigned char> sig{ParseHex(RELEASE_SIG)};
+
+    std::vector<unsigned char> other{ParseHex(RELEASE_PUBKEY)};
+    other[0] ^= 0x01;
+    const XOnlyPubKey pubkey{other};
+
+    BOOST_CHECK(!pubkey.VerifySchnorr(ManifestHash(TAG, MANIFEST), sig));
+}
+
+BOOST_AUTO_TEST_CASE(the_tag_is_load_bearing)
+{
+    // One character short of the real tag, then one character long. If either
+    // verified, the tag would be decoration and there would be no domain
+    // separation at all.
+    const std::vector<unsigned char> key_bytes{ParseHex(RELEASE_PUBKEY)};
+    const std::vector<unsigned char> sig{ParseHex(RELEASE_SIG)};
+    const XOnlyPubKey pubkey{key_bytes};
+
+    BOOST_CHECK(!pubkey.VerifySchnorr(ManifestHash("Reddcoin/ReleaseManifes", MANIFEST), sig));
+    BOOST_CHECK(!pubkey.VerifySchnorr(ManifestHash("Reddcoin/ReleaseManifest ", MANIFEST), sig));
+}
+
+// Note: VerifySchnorr asserts sigbytes.size() == 64, so a malformed signature
+// aborts rather than returning false. That length check is the caller's job and
+// belongs in the client code REP-1018 section 3.6 step 2 requires; it cannot be
+// exercised here without killing the test binary.
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Phase 2b of RED-98 (RED-113). Adds the signature the client will verify, alongside the `SHA256SUMS.asc` that people and third parties verify.

`SHA256SUMS.asc` proves a release to a person with OpenPGP tooling. It cannot prove it to the client, which has no OpenPGP and, on Windows, no `gpgv` either. Both signatures cover the same manifest and both get published.

The format this implements is now specified in **REP-1018**, merged into the reps repository as `docs/rep-1018.md`. The purpose value it derives under is recorded in **REP-0005**, the derivation path registry.

## The tool

`contrib/release-signing/sign-release-manifest.py`, four subcommands:

| | |
| --- | --- |
| `selftest` | run the official BIP340 test vectors |
| `pubkey` | print the x-only public key for a mnemonic |
| `sign` | sign a manifest |
| `verify` | check a signature, non-zero exit on failure |

It depends on nothing but Python and this repository. The BIP340 implementation and the official vectors already live in `test/functional/test_framework`, so this reuses them rather than carrying a second copy of signature code that nothing else exercises. That matters for an air-gapped box: no packages to install, and it can prove the implementation correct on that machine **before** it signs anything users will trust.

## Design points worth reviewing

**`sign` refuses to write a signature it cannot itself verify**, and prints the public key it used. A signature made with the wrong key verifies happily against itself and against nothing a released client accepts, so the printed key is the check that cannot be skipped.

**A mistyped mnemonic is rejected rather than signed with.** The words are checked against the BIP39 list and the phrase against its own checksum. Without this the only guard was an operator comparing 64 hex characters by eye, which fails worst during recovery onto a rebuilt machine, where one wrong word silently derives a perfectly usable key for a wallet that has never signed anything. The wordlist is parsed from `src/util/lang/bip39_english.h`, the header the client already ships, so there is one wordlist in the repository and it cannot drift from the one the wallet derives with.

**The manifest is read as bytes, never as text.** The signature covers the file exactly as it will be served; newline or encoding normalisation on the way through would sign something the server does not serve. Same class of trap as `all.SHA256SUMS` not being the published manifest.

**`verify` exits non-zero**, so an upload can be gated on it.

**The `.sig` carries only the signature, not the public key.** Including the key would invite verifying a signature against a key taken from the same file, which proves nothing. The client pins the key.

## What becomes permanent

All of it is fixed once a client ships that reads it, which is why it is specified in REP-1018 rather than left as constants in a script.

**The message** is `TaggedHash("Reddcoin/ReleaseManifest")` over the manifest bytes, matching `TaggedHash()` in `src/hash.h`. The release key sits on the same curve as transaction keys, so signing a bare `SHA256` would leave a signature that could be meaningful in another context.

**The derivation path** is `m/1018'/4'/0'`, deliberately not under the `m/44'/4'/...` wallet tree, so a release key cannot collide with a spending key.

It was `m/1017'` when this PR was opened, and that was wrong. `1017'` is lnd's: `BIP0043Purpose = 1017` in `keychain/derivation.go`, with the hierarchy `m/1017'/coinType'/keyFamily'/0/index` and `KeyFamilyMultiSig = 0`. No key would ever have collided, since the release seed derives nothing else, but the path described the release key as a Lightning multisig branch for coin type 4, and a derivation path is read by people. The replacement was checked against the BIP-allocated purposes, the SLIP-reserved 10001-19999 range, and known unregistered users.

The number matches the REP that specifies it, which is what BIP43 asks for: schemes should take the number of the document defining them, so a purpose value leads back to a specification rather than to a constant in someone's source tree. REP-1018 specifies purpose `1018'`.

This was free to change only because no production key exists yet. One step later it would have cost a client release, since a mnemonic does not identify a key without its path.

**The BIP32 HMAC key stays the literal `"Bitcoin seed"`.** It is fixed by BIP32 for every implementation and every coin, not a name to localise. Renaming it would derive a different key from the same words while looking perfectly correct, and would put the key beyond the reach of every standard BIP39 recovery tool, which matters because the threat model here is loss rather than compromise.

## The client and the tool are held to the same answer

`src/test/release_manifest_tests.cpp` is the reason the last commit exists. The signature is produced by Python on an air-gapped machine and checked by C++ in the client, and nothing forced the two to agree. A divergence would not have surfaced until every release failed to verify for every user.

It asserts REP-1018 section 5.2's published vectors against the C++ side: `TaggedHash` over the manifest, and the reference signature checked through the same `XOnlyPubKey::VerifySchnorr` call a client will make. The negative cases carry most of the value. A modified manifest, an appended line, a modified signature and a wrong key all fail, and so does a tag one character short or one character long, which is what shows the domain separation exists rather than being described in a comment.

Two traps worth naming for a reviewer, since both produce a test that passes while proving nothing:

- `uint256::ToString()` reverses byte order, so comparing it against the tool's hex tests a byte-swapped value. The test compares raw order.
- `Span`'s container constructors are lifetime-bound, so building one from a `ParseHex` temporary risks a dangling diagnostic that is fatal under `-Werror`. Every input in the test is a named local.

Deliberately not tested: `VerifySchnorr` asserts `sigbytes.size() == 64`, so a malformed `.sig` aborts the process rather than returning false. That length check is the caller's job and belongs in the client code REP-1018 section 3.6 step 2 requires. Exercising it here would kill the test binary, so there is a comment saying so instead.

## Verified

Against the live 4.22.9.4 manifest fetched from the server:

- all **15 official BIP340 vectors** pass
- sign then verify round trips, exit 0
- **five tamper cases** each exit 1: a manifest altered by one byte, a flipped signature byte, a different public key, a malformed short signature, and a manifest regenerated with an extra line
- the signature file is 129 bytes, one line, 128 lowercase hex plus a newline, as REP-1018 section 3.5 requires
- `gpg --verify` on the published `SHA256SUMS.asc` returns a good signature over the identical bytes, so the two signatures do cover the same file
- mnemonic validation rejects a bad checksum, a non-BIP39 word and a wrong length. Neutering the check makes the mistyped phrase derive a different key, which is what shows the check is load bearing rather than decorative

Exit codes checked directly rather than through a pipe, since a release script would branch on them.

## Note for phase 4

The published manifest lists signed and unsigned variants side by side, so artifact matching must be on the exact filename field with exactly one matching line, as REP-1018 section 3.6 step 6 requires. A substring match for `signed.exe` also matches `reddcoin-4.22.9.4-win64-setup-unsigned.exe`, which would hand a Windows user the unsigned installer while reporting a verified download.

## Not in this PR

The production key does not exist yet. `doc/release-process.md` has a placeholder for its public key, to be filled when it is generated on the air-gapped machine.

Client-side verification is phase 4 and consumes the format fixed here. It must not be written until a real `.sig` is published, or it will pass its own tests against synthetic data and fail in production, which is the trap B1 already posed once for the `.asc`.

YouTrack: https://reddink.youtrack.cloud/issue/RED-113
