### PR TITLE
contrib: add the missing key generation step

### DIFF
--- a/contrib/release-signing/sign-release-manifest.py
+++ b/contrib/release-signing/sign-release-manifest.py
@@ -16,6 +16,7 @@ SHA256SUMS.sig comes out.
 Subcommands:
 
     selftest   run the official BIP340 test vectors
+    generate   create a new release key and print its mnemonic
     pubkey     print the x-only public key for a mnemonic
     sign       sign a manifest
     verify     check a signature against a manifest and a public key
@@ -30,6 +31,7 @@ import hashlib
 import hmac
 import os
 import re
+import secrets
 import sys
 import unicodedata
 
@@ -141,6 +143,24 @@ def check_mnemonic(mnemonic):
             "this is not the phrase you think it is")
 
 
+def mnemonic_from_entropy(entropy):
+    """BIP39 mnemonic for a block of entropy.
+
+    The inverse of the checksum test in check_mnemonic: append the first
+    len(entropy)/4 bits of SHA256(entropy), then read the result 11 bits at a
+    time as indices into the wordlist.
+    """
+    if len(entropy) not in (16, 20, 24, 28, 32):
+        raise SystemExit("entropy must be 16, 20, 24, 28 or 32 bytes, got {}".format(len(entropy)))
+
+    checksum_bits = len(entropy) * 8 // 32
+    bits = "".join(format(b, "08b") for b in entropy)
+    bits += format(hashlib.sha256(entropy).digest()[0], "08b")[:checksum_bits]
+
+    wordlist = load_wordlist()
+    return " ".join(wordlist[int(bits[i:i + 11], 2)] for i in range(0, len(bits), 11))
+
+
 def bip39_seed(mnemonic, passphrase=""):
     """BIP39 mnemonic to 64-byte seed."""
     mnemonic = unicodedata.normalize("NFKD", " ".join(mnemonic.split()))
@@ -228,6 +248,65 @@ def cmd_selftest(_args):
     return 0
 
 
+def cmd_generate(args):
+    """Create a release key and print the words that reproduce it.
+
+    Deliberately writes nothing to disk. A file holding the mnemonic is a file
+    that gets backed up, synced, or left behind on a machine that was supposed
+    to be wiped, and this tool is not in a position to know which. Transcribe
+    the words onto paper, then type them into a file when there is a manifest to
+    sign, and remove that file afterwards.
+    """
+    if args.entropy_hex:
+        # For entropy generated off the machine: dice, coin flips, a hardware
+        # source. Worth supporting for a key with no expiry, where trusting one
+        # CSPRNG on one box is a choice rather than a default.
+        try:
+            entropy = bytes.fromhex(args.entropy_hex.strip())
+        except ValueError:
+            raise SystemExit("--entropy-hex is not valid hexadecimal")
+        expected = args.words * 32 // 24
+        if len(entropy) != expected:
+            raise SystemExit(
+                "a {}-word mnemonic needs {} bytes of entropy, got {}".format(
+                    args.words, expected, len(entropy)))
+        source = "supplied with --entropy-hex"
+    else:
+        entropy = secrets.token_bytes(args.words * 32 // 24)
+        source = "secrets.token_bytes, the platform CSPRNG"
+
+    mnemonic = mnemonic_from_entropy(entropy)
+
+    # Prove the words reproduce a key before showing them to anyone. A
+    # generation bug that produced an unusable phrase would otherwise surface
+    # months later, when the backup is the only copy left.
+    check_mnemonic(mnemonic)
+    pubkey = xonly_pubkey(derive_release_key(mnemonic))
+
+    words = mnemonic.split()
+    print("Release key, {} words, entropy from {}.\n".format(len(words), source))
+    for row in range(0, len(words), 3):
+        print("   " + "".join("{:>3}. {:<12}".format(row + col + 1, words[row + col])
+                              for col in range(min(3, len(words) - row))))
+    print()
+    print("path        {}".format(DERIVATION_PATH))
+    print("public key  {}".format(pubkey.hex()))
+    print()
+    print("Write the words down now, on paper, and keep at least one copy away from")
+    print("this machine. Nothing was saved to disk. There is no delegation chain and")
+    print("no recovery other than these words: losing them ends the ability to sign")
+    print("for every client that ships the public key above.")
+    print()
+    print("Then check the recovery works before trusting it, from the written copy")
+    print("rather than from this screen:")
+    print()
+    print("    {} pubkey --mnemonic <file>".format(os.path.basename(__file__)))
+    print()
+    print("It must print the same public key. A backup that has never been restored")
+    print("is a hypothesis.")
+    return 0
+
+
 def cmd_pubkey(args):
     privkey = derive_release_key(read_text(args.mnemonic),
                                  read_text(args.passphrase) if args.passphrase else "")
@@ -291,6 +370,13 @@ def main():
 
     sub.add_parser("selftest", help="run the official BIP340 test vectors")
 
+    p = sub.add_parser("generate", help="create a new release key and print its mnemonic")
+    p.add_argument("--words", type=int, default=24, choices=[12, 15, 18, 21, 24],
+                   help="mnemonic length (default: 24, for 256 bits of entropy)")
+    p.add_argument("--entropy-hex",
+                   help="use this entropy instead of the platform CSPRNG, for dice or "
+                        "another off-machine source")
+
     p = sub.add_parser("pubkey", help="print the x-only public key for a mnemonic")
     p.add_argument("--mnemonic", required=True, help="file holding the BIP39 mnemonic")
     p.add_argument("--passphrase", help="file holding the BIP39 passphrase, if any")
@@ -309,6 +395,7 @@ def main():
     args = parser.parse_args()
     return {
         "selftest": cmd_selftest,
+        "generate": cmd_generate,
         "pubkey": cmd_pubkey,
         "sign": cmd_sign,
         "verify": cmd_verify,

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -310,6 +310,47 @@ trust:
 
 That runs the official BIP340 vectors and must report all of them passing.
 
+#### Generate the key, once
+
+Only for the first release signed with a given key, or for a rotation. Skip this
+if a key already exists; the public key below tells you whether it does.
+
+```bash
+./contrib/release-signing/sign-release-manifest.py generate
+```
+
+That prints twenty four words and the public key they derive. Nothing is written
+to disk, deliberately: a file holding the mnemonic is a file that gets backed up,
+synced, or left on a machine that was supposed to be wiped, and the tool is not
+in a position to know which. Write the words on paper.
+
+Entropy comes from the platform CSPRNG. For a key with no expiry you may prefer
+not to trust one generator on one machine, in which case supply your own from
+dice or coin flips:
+
+```bash
+./contrib/release-signing/sign-release-manifest.py generate --entropy-hex "$(cat dice.hex)"
+```
+
+That takes 32 bytes as 64 hex characters for a 24-word phrase. 256 dice rolls
+recorded in base 6 and converted, or 256 coin flips, both work.
+
+⚠ **Restore the backup before trusting it.** Type the words from the paper copy,
+not from the screen, into a scratch file and check they derive the same key:
+
+```bash
+./contrib/release-signing/sign-release-manifest.py pubkey --mnemonic /path/to/scratch.txt
+```
+
+It must print the public key `generate` showed. A transcription error is caught
+here or it is caught years later when the backup is the only copy left. Remove
+the scratch file afterwards.
+
+⚠ **Then record the public key in the release process**, in "The release key"
+below, on both maintained lines. The client is built with that value compiled in,
+so it is the anchor for every verification; a key that exists but is written down
+nowhere is not usable by anyone else.
+
 #### Sign
 
 Carry `SHA256SUMS` in, and carry `SHA256SUMS.sig` back out. Nothing else crosses


### PR DESCRIPTION
Backport of #525. This line is where releases are actually cut from, so a procedure with a hole at step one matters more here than on develop.

`doc/release-process.md` said to run `selftest`, then sign with `--mnemonic /path/to/mnemonic.txt`, and never said where that mnemonic comes from. The tool had no way to make one:

```
{selftest, pubkey, sign, verify}
```

So the action that must precede any release ever being signed was the one thing nothing described.

## What comes across

`generate`, producing 24 words and the public key they derive.

- **Writes nothing to disk.** A file holding the mnemonic gets backed up, synced, or left on a machine that was supposed to be wiped, and the tool cannot know which. The words go on paper.
- **`--entropy-hex`** for dice or coin flips, since trusting one CSPRNG on one machine for a key with no expiry should be a deliberate choice.
- **Self-verifies before printing**: the generated phrase goes through the same checksum validation as a hand-typed one and a key is derived from it, so a generation bug fails immediately rather than years later when the paper copy is the only one left.

Plus the documented step that was missing entirely: restore the backup from paper, confirm it derives the same key, then record that key in "The release key" below.

## Verified on this branch

| | |
| --- | --- |
| Same words, same key as develop | `d2cb88008883d3aed8e56f08db6e023ed319be07f91ed1fc38f8c02cdf895bf5` from both |
| Wordlist resolution | Resolves through `src/wallet/bip39_english.h` here, `src/util/lang/` on develop |
| Entropy length guard | `--words 12` with 32 bytes rejected, exit 1 |
| `selftest` | 15 BIP340 vectors pass |

The 12-word all-zeros case reproduces `53c9cbcb...`, the same key as the BIP39 vector 1 mnemonic the existing tests use, which is the expected result since that vector *is* all-zero entropy.

Both files are byte identical to develop's, so the two lines do not drift.

YouTrack: https://reddink.youtrack.cloud/issue/RED-115
