### PR TITLE
doc: record the production release key

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -392,7 +392,7 @@ what is served.
 
 ```
 derivation   m/1018'/4'/0'  (BIP39 mnemonic -> BIP32, all elements hardened)
-public key   (fill in when the production key is generated)
+public key   23e6b696f2b69cd753de0d8fe3875e989085fbb6f2dc09026ba8ba1df33585db
 ```
 
 Deliberately not a wallet path. Reddcoin wallets derive under `m/44'/4'/...`, and


### PR DESCRIPTION
Step 5 of RED-115. The production release key exists, and this is where its public half is recorded.

```
derivation   m/1018'/4'/0'  (BIP39 mnemonic -> BIP32, all elements hardened)
public key   23e6b696f2b69cd753de0d8fe3875e989085fbb6f2dc09026ba8ba1df33585db
```

The key was generated on the air-gapped machine with `sign-release-manifest.py generate`, and its backup was restored from the written copy and confirmed to derive this same value before it was written down here.

## Checked before recording

A well-formed 32 bytes is not necessarily a public key, and an anchor that is not a curve point would fail only at the first verification, long after it was published.

| | |
| --- | --- |
| Length | 32 bytes, 64 lowercase hex characters |
| `x < p` | Yes, below the secp256k1 field size |
| `lift_x` | Succeeds, so it is a point on the curve |
| Accepted by the verifier | Yes, `verify_schnorr` treats it as a key and rejects a bogus signature rather than rejecting the key |

## Why this matters more than a documentation change usually does

The client does not read this file. Phase 4 compiles this value into the binary, and it is the sole trust anchor for verifying a release: every future signature is checked against it, and rotating it costs a client release. This file is where the value is stated so that the compiled-in constant can be checked against something.

Nothing else changes here.

## Same change on the other line

Paired with the equivalent PR against `v4.22.9-regtest`, so `doc/release-process.md` stays identical on both.

## Next

Sign a release manifest with this key and publish `SHA256SUMS.sig`. Until that exists on the server, phase 4 has nothing valid to verify against, which is the sequencing trap RED-98 has carried from the start.

YouTrack: https://reddink.youtrack.cloud/issue/RED-115