### PR TITLE
node: check the artifact is there before naming it

### DIFF
--- a/src/node/update_check.cpp
+++ b/src/node/update_check.cpp
@@ -200,6 +200,10 @@ bool node::ChunkedDecoder::Feed(const char* data, std::size_t size, const Sink& 
 namespace {
 const std::string UPDATE_CHECK_HOST{"api.github.com"};
 
+//! Where the artifacts themselves are published, as distinct from where the
+//! version is announced.
+const std::string DOWNLOAD_HOST{"download.reddcoin.com"};
+
 //! How long one step may make no progress before the exchange is abandoned.
 //!
 //! Reset by progress rather than counted from the start, so a slow but moving
@@ -258,10 +262,10 @@ enum class StreamResult {
 
 //! The request line and headers this client sends. Shared so a streamed request
 //! is byte for byte the one the in-memory path sends.
-std::string RequestFor(const std::string& host, const std::string& target)
+std::string RequestFor(const std::string& method, const std::string& host, const std::string& target)
 {
     std::ostringstream request;
-    request << "GET " << target << " HTTP/1.1\r\n";
+    request << method << " " << target << " HTTP/1.1\r\n";
     request << "Host: " << host << "\r\n";
     request << "User-Agent: " << PACKAGE_NAME << "/" << PACKAGE_VERSION << "\r\n";
     request << "Accept: */*\r\n";
@@ -327,7 +331,8 @@ public:
     //! Send the request and read only as far as the end of the headers, leaving
     //! the body unread on the stream. What arrived past the header terminator is
     //! returned in leftover, since a single read does not stop on a boundary.
-    node::HttpHeaders GetHeaders(const std::string& target, std::string& leftover);
+    node::HttpHeaders GetHeaders(const std::string& method, const std::string& target,
+                                 std::string& leftover);
 
     //! Stream the body that GetHeaders left on the stream into sink.
     StreamResult ReadBodyToSink(const node::HttpHeaders& headers, const std::string& leftover,
@@ -413,7 +418,7 @@ std::string HttpsConnection::Get(const std::string& target, bool& clean_eof)
 {
     Connect();
 
-    const std::string request_text{RequestFor(m_host, target)};
+    const std::string request_text{RequestFor("GET", m_host, target)};
     boost::asio::streambuf request;
     std::ostream request_stream(&request);
     request_stream << request_text;
@@ -476,11 +481,12 @@ std::string HttpsConnection::Get(const std::string& target, bool& clean_eof)
     return raw;
 }
 
-node::HttpHeaders HttpsConnection::GetHeaders(const std::string& target, std::string& leftover)
+node::HttpHeaders HttpsConnection::GetHeaders(const std::string& method, const std::string& target,
+                                              std::string& leftover)
 {
     Connect();
 
-    const std::string request_text{RequestFor(m_host, target)};
+    const std::string request_text{RequestFor(method, m_host, target)};
     boost::asio::streambuf request;
     std::ostream request_stream(&request);
     request_stream << request_text;
@@ -753,6 +759,55 @@ std::string node::ExtractHttpBody(const std::string& raw_response, bool clean_eo
     return response.body;
 }
 
+node::ProbeResult node::ProbeRemoteFile(const std::string& host_in, const std::string& target_in,
+                                        RemoteFile& out, std::string& error)
+{
+    error.clear();
+
+    // A probe is a question, not a transfer, so it gets the short ceiling
+    // rather than the download one.
+    const auto hard_deadline{std::chrono::steady_clock::now() + TOTAL_TIMEOUT};
+    std::string host{host_in};
+    std::string target{target_in};
+
+    try {
+        for (int hop{0}; hop <= MAX_REDIRECTS; ++hop) {
+            HttpsConnection connection{host, hard_deadline};
+            std::string leftover;
+            const HttpHeaders headers{connection.GetHeaders("HEAD", target, leftover)};
+
+            if (headers.status >= 300 && headers.status < 400) {
+                if (headers.location.empty()) {
+                    error = "Response returned status code " + ToString(headers.status) +
+                            " without a Location header";
+                    return ProbeResult::Unknown;
+                }
+                const Url next{ResolveRedirect(host, target, headers.location)};
+                host = next.host;
+                target = next.target;
+                continue;
+            }
+
+            if (headers.status == 200) {
+                // Content-Length on a HEAD describes the body that a GET would
+                // return, which is exactly the size being asked about.
+                out.size = headers.content_length;
+                return ProbeResult::Present;
+            }
+            if (headers.status == 404 || headers.status == 410) {
+                return ProbeResult::Absent;
+            }
+
+            error = "Response returned with status code " + ToString(headers.status);
+            return ProbeResult::Unknown;
+        }
+        error = "Gave up after " + ToString(MAX_REDIRECTS) + " redirects";
+    } catch (const std::exception& e) {
+        error = e.what();
+    }
+    return ProbeResult::Unknown;
+}
+
 bool node::DownloadToFile(const std::string& host_in, const std::string& target_in,
                           const fs::path& destination, const DownloadProgress& progress,
                           const DownloadCancel& cancel, std::string& error)
@@ -772,7 +827,7 @@ bool node::DownloadToFile(const std::string& host_in, const std::string& target_
         for (int hop{0}; hop <= MAX_REDIRECTS; ++hop) {
             HttpsConnection connection{host, hard_deadline};
             std::string leftover;
-            const HttpHeaders headers{connection.GetHeaders(target, leftover)};
+            const HttpHeaders headers{connection.GetHeaders("GET", target, leftover)};
 
             if (headers.status >= 300 && headers.status < 400) {
                 if (headers.location.empty()) {
@@ -894,6 +949,7 @@ void node::CheckForUpdates(UniValue& result)
     std::string guiArtifactLink = "";
     std::string daemonArtifact = "";
     std::string daemonArtifactLink = "";
+    int64_t artifactBytes = -1;
 
     try {
         const std::string str_response{HttpsGet(UPDATE_CHECK_HOST, strGithubLink)};
@@ -1002,6 +1058,32 @@ void node::CheckForUpdates(UniValue& result)
                         daemonArtifact = artifacts.daemon;
                         guiArtifactLink = officialDownloadLink + "/" + artifacts.gui;
                         daemonArtifactLink = officialDownloadLink + "/" + artifacts.daemon;
+
+                        // Confirm the file is actually there before naming it.
+                        // The name is derived from a convention rather than read
+                        // from the server, so a release published under a
+                        // different scheme would otherwise produce a confident
+                        // link to nothing.
+                        //
+                        // Fails open, deliberately. Only a definite 404 withdraws
+                        // the name; a timeout or a 500 leaves it in place, since
+                        // a probe that could not reach the server is no evidence
+                        // that the artifact is missing, and degrading a working
+                        // notice on a network hiccup would be the worse error.
+                        std::string probe_error;
+                        RemoteFile remote_file;
+                        const std::string probe_target{"/bin/reddcoin-core-" + remote.numeric +
+                                                       "/" + artifacts.gui};
+                        const ProbeResult probed{
+                            ProbeRemoteFile(DOWNLOAD_HOST, probe_target, remote_file, probe_error)};
+                        if (probed == ProbeResult::Absent) {
+                            guiArtifact.clear();
+                            daemonArtifact.clear();
+                            guiArtifactLink.clear();
+                            daemonArtifactLink.clear();
+                        } else if (probed == ProbeResult::Present) {
+                            artifactBytes = remote_file.size;
+                        }
                     }
                 }
             }
@@ -1028,6 +1110,10 @@ void node::CheckForUpdates(UniValue& result)
     // check did not get far enough to know, so the shape of the result does not
     // depend on whether it succeeded.
     result.pushKV("hosttriplet", HostTriplet());
+    // -1 when the probe did not run, could not reach the server, or the server
+    // gave no Content-Length. A size of zero would be a real answer, so absence
+    // needs its own value rather than being folded into it.
+    result.pushKV("artifactbytes", artifactBytes);
     result.pushKV("platform", platform);
     result.pushKV("guiartifact", guiArtifact);
     result.pushKV("guiartifactlink", guiArtifactLink);

--- a/src/node/update_check.h
+++ b/src/node/update_check.h
@@ -160,6 +160,43 @@ struct Url {
 Url ResolveRedirect(const std::string& base_host, const std::string& base_target,
                     const std::string& location);
 
+//! What a probe found out about a file on the server.
+struct RemoteFile {
+    //! Content-Length the server reports, or -1 when it gives none.
+    int64_t size{-1};
+};
+
+/**
+ * Answer to "is this file actually there?".
+ *
+ * Absent and Unknown are kept apart deliberately. A 404 is the server saying
+ * the file is not there; a timeout or a 500 is the client failing to find out.
+ * Collapsing the two would let a broken network be reported to the user as a
+ * missing release, which is a different problem with a different remedy.
+ */
+enum class ProbeResult {
+    Present,  //!< the server answered 200
+    Absent,   //!< the server answered 404
+    Unknown,  //!< could not be established
+};
+
+/**
+ * Ask whether a file exists, without downloading it.
+ *
+ * Issues a HEAD request, following redirects on the same terms as everything
+ * else here. Used to avoid naming an artifact that would 404, and to learn its
+ * size before offering to fetch it.
+ *
+ * @param[out] out   Filled in when the result is Present.
+ * @param[out] error Why the result is Unknown. Empty otherwise.
+ *
+ * A server is not obliged to answer HEAD the way it answers GET, so a Present
+ * result is good evidence rather than a guarantee. It is the difference between
+ * offering a link that is probably right and one that is probably wrong.
+ */
+ProbeResult ProbeRemoteFile(const std::string& host, const std::string& target,
+                            RemoteFile& out, std::string& error);
+
 //! Called as a download proceeds. total is -1 when the server gave no length.
 using DownloadProgress = std::function<void(int64_t received, int64_t total)>;
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -289,6 +289,7 @@ static RPCHelpMan checkupdates()
                 {RPCResult::Type::STR, "warning", "Any warning messages"},
                 {RPCResult::Type::STR, "officialDownloadLink", "Official direct download link"},
                 {RPCResult::Type::STR, "hosttriplet", "The host triplet this build targets, empty if the build did not record one"},
+                {RPCResult::Type::NUM, "artifactbytes", "Size of the GUI artifact in bytes, or -1 if not established"},
                 {RPCResult::Type::STR, "platform", "Short platform name used in artifact filenames, empty if no build is published for this host"},
                 {RPCResult::Type::STR, "guiartifact", "Filename of the build a reddcoin-qt user should install, empty if unknown"},
                 {RPCResult::Type::STR, "guiartifactlink", "Direct download link for guiartifact, empty if unknown"},


### PR DESCRIPTION
Phase 3c of RED-98, the last slice of RED-116. Adds a HEAD probe and uses it to confirm the file the update notice names actually exists.

## Why

The artifact name is derived from the guix naming convention, not read from the server. A release published under a different scheme would produce a confident link to nothing. Naming one file instead of a directory of fifteen is only an improvement while the file is there.

## The distinction that carries the design

```cpp
enum class ProbeResult { Present, Absent, Unknown };
```

`Absent` and `Unknown` are kept apart deliberately. A **404 is the server saying the file is not there**. A **timeout or a 500 is this client failing to find out**. Collapsing them would let a network problem be reported to the user as a missing release, which is a different problem with a different remedy.

**So the probe fails open.** Only a definite 404 withdraws the name; anything else leaves the notice exactly as it would have been. A probe that could not reach the server is no evidence about the artifact, and breaking a working notice on a hiccup is the worse error.

## New field

`artifactbytes`, from the `Content-Length` a HEAD reports, which is the length a GET would return. Phase 5 needs it to show progress against something.

It is `-1` when the probe did not run, could not reach the server, or the server gave no length. Zero would be a real answer, so absence needs its own value rather than being folded into it.

## The cost, stated plainly

This adds **a second network request to the update check, and a second host**. That is a real cost for a background nicety, and it is the reason the probe is constrained never to make the result worse than it would have been without it. If that trade is unwanted, the probe is one call to remove.

## Verified against the live server

A temporary network test, removed before commit:

```
existing artifact -> Present  size=30603976  err=''
missing artifact  -> Absent   err=''
unreachable host  -> Unknown  err='Failed while resolving no-such-host.reddcoin.invalid:
                                   Host not found (authoritative)'
```

30603976 is the size downloading the artifact actually produced in #531, so the probe and the download agree. And `checkupdates` end to end:

```
"artifactbytes": 30603976,
"guiartifact": "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz",
"errors": ""
```

27 + 9 + 9 unit tests pass, build clean including `reddcoin-qt`.

## This completes phase 3

3a reshaped the fetcher, 3b made it stream to disk, 3c makes it check first. Phase 4 is next, and is what makes a downloaded file trustworthy.

YouTrack: https://reddink.youtrack.cloud/issue/RED-116

---

**Backport**, keeping the two lines aligned: `update_check.{h,cpp}` still differ by only the two forced changes, and `update_check_tests.cpp` is byte identical. Verified on this branch, including `artifactbytes: 30603976` from `checkupdates` against the live host.