### PR TITLE
node: verify a release manifest against the pinned key

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -189,6 +189,7 @@ BITCOIN_CORE_H = \
   node/coinstats.h \
   node/ca_store.h \
   node/release_artifacts.h \
+  node/release_verify.h \
   node/context.h \
   node/psbt.h \
   node/transaction.h \
@@ -369,6 +370,7 @@ libbitcoin_server_a_SOURCES = \
   node/coinstats.cpp \
   node/ca_store.cpp \
   node/release_artifacts.cpp \
+  node/release_verify.cpp \
   node/context.cpp \
   node/interfaces.cpp \
   node/psbt.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -149,6 +149,7 @@ BITCOIN_TESTS =\
   test/uint256_tests.cpp \
   test/release_artifacts_tests.cpp \
   test/release_manifest_tests.cpp \
+  test/release_verify_tests.cpp \
   test/update_check_tests.cpp \
   test/uint512_tests.cpp \
   test/util_tests.cpp \

--- a/src/node/release_verify.cpp
+++ b/src/node/release_verify.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/release_verify.h>
+
+#include <crypto/sha256.h>
+#include <hash.h>
+#include <pubkey.h>
+#include <span.h>
+#include <streams.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace {
+//! Domain separation for a release signature, per REP-1018 section 3.4.
+//!
+//! The release key sits on the same curve as transaction keys, so a signature
+//! over a bare SHA256 could be meaningful in another context. The tag is part
+//! of the format: changing a byte of it invalidates every signature any
+//! released client will accept.
+const CHashWriter HASHER_RELEASE_MANIFEST = TaggedHash("Reddcoin/ReleaseManifest");
+
+//! The message a release signature commits to.
+uint256 ManifestHash(const std::string& manifest)
+{
+    CHashWriter hasher{HASHER_RELEASE_MANIFEST};
+    hasher.write(manifest.data(), manifest.size());
+    return hasher.GetSHA256();
+}
+
+//! Split a manifest line into its digest and filename fields.
+//!
+//! A line is "<64 hex>  <filename>", two spaces, as sha256sum writes it. The
+//! filename is taken as the entire remainder of the line so a name containing
+//! spaces is matched whole rather than truncated at the first one.
+bool SplitManifestLine(const std::string& line, std::string& hex, std::string& filename)
+{
+    if (line.size() < 67) return false;
+    hex = line.substr(0, 64);
+    if (line.compare(64, 2, "  ") != 0) return false;
+    if (!IsHex(hex)) return false;
+    filename = line.substr(66);
+    return !filename.empty();
+}
+} // namespace
+
+// Recorded in doc/release-process.md on both maintained lines. Generated on the
+// air-gapped machine and its backup restored and confirmed before being written
+// down anywhere.
+const std::string node::RELEASE_PUBKEY{
+    "23e6b696f2b69cd753de0d8fe3875e989085fbb6f2dc09026ba8ba1df33585db"};
+
+bool node::VerifyReleaseManifest(const std::string& manifest, const std::string& signature,
+                                 std::string& error)
+{
+    error.clear();
+
+    const std::string trimmed{TrimString(signature)};
+    if (!IsHex(trimmed)) {
+        error = "Release signature is not hexadecimal";
+        return false;
+    }
+    const std::vector<unsigned char> sig{ParseHex(trimmed)};
+
+    // Mandatory, and before VerifySchnorr rather than inside it: that function
+    // asserts on any length other than 64, so a malformed signature file would
+    // abort the process instead of being rejected.
+    if (sig.size() != 64) {
+        error = "Release signature is " + ToString(sig.size()) + " bytes, expected 64";
+        return false;
+    }
+
+    const std::vector<unsigned char> key_bytes{ParseHex(RELEASE_PUBKEY)};
+    if (key_bytes.size() != 32) {
+        error = "Release public key is malformed";
+        return false;
+    }
+    const XOnlyPubKey pubkey{key_bytes};
+    if (!pubkey.IsFullyValid()) {
+        error = "Release public key is not a valid point";
+        return false;
+    }
+
+    if (!pubkey.VerifySchnorr(ManifestHash(manifest), sig)) {
+        error = "Release manifest signature is not valid";
+        return false;
+    }
+    return true;
+}
+
+bool node::FindArtifactDigest(const std::string& manifest, const std::string& filename,
+                              uint256& digest, std::string& error)
+{
+    error.clear();
+    if (filename.empty()) {
+        error = "No artifact name to look up";
+        return false;
+    }
+
+    std::string found_hex;
+    int matches{0};
+    for (std::string::size_type start{0}; start <= manifest.size();) {
+        const std::string::size_type eol{manifest.find('\n', start)};
+        const std::string raw{manifest.substr(start, eol == std::string::npos ? std::string::npos
+                                                                             : eol - start)};
+        start = (eol == std::string::npos) ? manifest.size() + 1 : eol + 1;
+
+        // Tolerate CRLF and stray whitespace. What the signature covered is the
+        // manifest bytes; how the lines are terminated is not the question here.
+        const std::string line{TrimString(raw)};
+        if (line.empty()) continue;
+
+        std::string hex;
+        std::string name;
+        if (!SplitManifestLine(line, hex, name)) continue;
+
+        // Whole field, never a substring. The manifest lists signed and
+        // unsigned variants side by side, so a loose match for "signed.exe"
+        // also matches "win64-setup-unsigned.exe" and would hand the user the
+        // unsigned installer while reporting a verified download.
+        if (name != filename) continue;
+
+        ++matches;
+        found_hex = hex;
+    }
+
+    if (matches == 0) {
+        error = "The release manifest does not list " + filename;
+        return false;
+    }
+    if (matches > 1) {
+        // Not recoverable by picking one. Which digest is correct is exactly
+        // what a duplicated entry makes unknowable.
+        error = "The release manifest lists " + filename + " " + ToString(matches) + " times";
+        return false;
+    }
+
+    digest = uint256{};
+    const std::vector<unsigned char> bytes{ParseHex(found_hex)};
+    if (bytes.size() != 32) {
+        error = "The release manifest has a malformed digest for " + filename;
+        return false;
+    }
+    std::copy(bytes.begin(), bytes.end(), digest.begin());
+    return true;
+}
+
+bool node::HashFile(const fs::path& path, uint256& digest, std::string& error)
+{
+    error.clear();
+
+    fsbridge::ifstream file{path, std::ios::binary};
+    if (!file.good()) {
+        error = "Could not open " + path.string();
+        return false;
+    }
+
+    CSHA256 hasher;
+    std::array<char, 64 * 1024> buffer{};
+    while (file.good()) {
+        file.read(buffer.data(), buffer.size());
+        const std::streamsize got{file.gcount()};
+        if (got > 0) {
+            hasher.Write(reinterpret_cast<const unsigned char*>(buffer.data()),
+                         static_cast<size_t>(got));
+        }
+        if (got == 0) break;
+    }
+    if (file.bad()) {
+        error = "Could not read " + path.string();
+        return false;
+    }
+
+    hasher.Finalize(digest.begin());
+    return true;
+}

--- a/src/node/release_verify.cpp
+++ b/src/node/release_verify.cpp
@@ -12,6 +12,8 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 
+#include <algorithm>
+
 #include <array>
 #include <string>
 #include <vector>
@@ -147,6 +149,107 @@ bool node::FindArtifactDigest(const std::string& manifest, const std::string& fi
         return false;
     }
     std::copy(bytes.begin(), bytes.end(), digest.begin());
+    return true;
+}
+
+namespace {
+//! Remove every staged directory except the one for this version.
+//!
+//! Called after a success rather than before the download, so a failed fetch
+//! never destroys a good artifact that is already staged.
+void PruneOtherVersions(const fs::path& staging_root, const std::string& keep)
+{
+    if (!fs::is_directory(staging_root)) return;
+    for (fs::directory_iterator it{staging_root}; it != fs::directory_iterator{}; ++it) {
+        const fs::path entry{it->path()};
+        if (!fs::is_directory(entry)) continue;
+        if (entry.filename().string() == keep) continue;
+
+        // Best effort. A directory that cannot be removed, because a file in it
+        // is open on Windows for instance, costs disk rather than correctness.
+        fs::remove_all(entry);
+    }
+}
+} // namespace
+
+bool node::StageVerifiedRelease(const std::string& version, const std::string& filename,
+                                const fs::path& staging_root, const DownloadProgress& progress,
+                                const DownloadCancel& cancel, StagedRelease& out,
+                                std::string& error)
+{
+    error.clear();
+    if (version.empty() || filename.empty()) {
+        error = "No release to stage";
+        return false;
+    }
+
+    const std::string release_dir{"reddcoin-core-" + version};
+    const std::string base{"/bin/" + release_dir};
+
+    // The manifest and its signature are small and have to be held whole to be
+    // checked, so they go through the in-memory fetch rather than to disk.
+    std::string manifest;
+    if (!FetchToString(RELEASE_DOWNLOAD_HOST, base + "/SHA256SUMS", manifest, error)) {
+        error = "Could not fetch the release manifest: " + error;
+        return false;
+    }
+    std::string signature;
+    if (!FetchToString(RELEASE_DOWNLOAD_HOST, base + "/SHA256SUMS.sig", signature, error)) {
+        error = "Could not fetch the release signature: " + error;
+        return false;
+    }
+
+    // Nothing below this line trusts the manifest until it has been verified,
+    // and nothing above it trusts anything at all.
+    if (!VerifyReleaseManifest(manifest, signature, error)) return false;
+
+    uint256 expected;
+    if (!FindArtifactDigest(manifest, filename, expected, error)) return false;
+
+    const fs::path version_dir{staging_root / release_dir};
+    const fs::path artifact{version_dir / filename};
+
+    // An artifact already staged and already correct is not fetched again, so
+    // repeating the check costs a manifest rather than the whole release.
+    bool have_it{false};
+    if (fs::exists(artifact)) {
+        uint256 present;
+        std::string ignored;
+        have_it = HashFile(artifact, present, ignored) && present == expected;
+        if (!have_it) {
+            // The only thing knowable about it is that it is not the artifact.
+            fs::remove(artifact);
+        }
+    }
+
+    if (!have_it) {
+        fs::create_directories(version_dir);
+        if (!DownloadToFile(RELEASE_DOWNLOAD_HOST, base + "/" + filename, artifact, progress,
+                            cancel, error)) {
+            // A cancelled download leaves error empty, and that is carried
+            // through rather than turned into a failure message.
+            return false;
+        }
+
+        uint256 got;
+        if (!HashFile(artifact, got, error)) {
+            fs::remove(artifact);
+            return false;
+        }
+        if (got != expected) {
+            // Deleted rather than kept. An unverified artifact left in the
+            // staging directory is indistinguishable from a verified one.
+            fs::remove(artifact);
+            error = "The downloaded file does not match the signed manifest";
+            return false;
+        }
+    }
+
+    PruneOtherVersions(staging_root, release_dir);
+
+    out.path = artifact;
+    out.filename = filename;
+    out.size = static_cast<int64_t>(fs::file_size(artifact));
     return true;
 }
 

--- a/src/node/release_verify.h
+++ b/src/node/release_verify.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_RELEASE_VERIFY_H
+#define BITCOIN_NODE_RELEASE_VERIFY_H
+
+#include <fs.h>
+#include <uint256.h>
+
+#include <string>
+
+namespace node {
+/**
+ * The release signing key, x-only BIP340, as specified by REP-1018.
+ *
+ * This is the trust anchor and it is deliberately compiled in. Verification is
+ * entirely local: no keyserver, no handshake, no network lookup of any kind. A
+ * hostile network can therefore deny an upgrade but cannot substitute one.
+ *
+ * Its private half exists only on an air-gapped machine, derived at
+ * m/1018'/4'/0'. Rotating this value costs a client release, which was accepted
+ * when the alternative was verifying nothing.
+ */
+extern const std::string RELEASE_PUBKEY;
+
+/**
+ * Check a release manifest against the signature published beside it.
+ *
+ * The message is TaggedHash("Reddcoin/ReleaseManifest") over the manifest bytes
+ * exactly as received, per REP-1018 section 3.4. The tag is what stops a
+ * signature made here being meaningful in another context, the release key
+ * being on the same curve as transaction keys.
+ *
+ * @param[in]  manifest  The SHA256SUMS bytes, unmodified. Any normalisation
+ *                       applied on the way in verifies something the server
+ *                       does not serve.
+ * @param[in]  signature Contents of SHA256SUMS.sig: 128 hex characters,
+ *                       surrounding whitespace tolerated.
+ * @param[out] error     Why it failed.
+ * @return true only when the signature is good.
+ *
+ * Rejects a signature that does not decode to exactly 64 bytes before
+ * attempting verification, because XOnlyPubKey::VerifySchnorr asserts on any
+ * other length and would abort the process rather than return false.
+ */
+bool VerifyReleaseManifest(const std::string& manifest, const std::string& signature,
+                           std::string& error);
+
+/**
+ * Find the digest a verified manifest gives for one artifact.
+ *
+ * @param[in]  manifest The manifest, already verified. Looking a name up in an
+ *                      unverified manifest tells you nothing.
+ * @param[in]  filename Artifact name, matched against the whole filename field.
+ * @param[out] digest   The expected SHA-256, when this returns true.
+ * @param[out] error    Why it failed.
+ *
+ * Requires exactly one matching line. Zero means the release does not contain
+ * that file; more than one means the manifest is malformed and the right answer
+ * is not knowable.
+ *
+ * ⚠ The match is on the entire field, never a substring. A published manifest
+ * lists signed and unsigned variants side by side, so a loose match for
+ * "signed.exe" also matches "win64-setup-unsigned.exe", which would hand a user
+ * the unsigned installer while reporting a verified download.
+ */
+bool FindArtifactDigest(const std::string& manifest, const std::string& filename,
+                        uint256& digest, std::string& error);
+
+/**
+ * SHA-256 of a file on disk, read in blocks rather than loaded.
+ *
+ * @param[out] digest Set when this returns true.
+ * @param[out] error  Why it failed.
+ */
+bool HashFile(const fs::path& path, uint256& digest, std::string& error);
+} // namespace node
+
+#endif // BITCOIN_NODE_RELEASE_VERIFY_H

--- a/src/node/release_verify.h
+++ b/src/node/release_verify.h
@@ -6,6 +6,7 @@
 #define BITCOIN_NODE_RELEASE_VERIFY_H
 
 #include <fs.h>
+#include <node/update_check.h>
 #include <uint256.h>
 
 #include <string>
@@ -67,6 +68,47 @@ bool VerifyReleaseManifest(const std::string& manifest, const std::string& signa
  */
 bool FindArtifactDigest(const std::string& manifest, const std::string& filename,
                         uint256& digest, std::string& error);
+
+//! A verified artifact, sitting where the user can be pointed at it.
+struct StagedRelease {
+    fs::path path;
+    std::string filename;
+    int64_t size{0};
+};
+
+/**
+ * Fetch, verify and stage a release artifact.
+ *
+ * Performs the whole of REP-1018 section 3.6: fetch the manifest and its
+ * signature, verify the signature against the compiled-in key, resolve the
+ * artifact name to its digest, download the artifact, and hash what arrived.
+ * Returns true only when the file on disk matches the digest in a manifest that
+ * the release key signed.
+ *
+ * **Staging layout.** Artifacts live under `<staging_root>/<version>/`, one
+ * directory per release. Directories for other versions are removed on success,
+ * so at most one staged artifact exists at a time and disk use is bounded by a
+ * single release rather than growing with every check.
+ *
+ * **An already-staged artifact is reused.** If the file is present and hashes
+ * to the expected digest it is not downloaded again, so repeating the check
+ * costs a manifest fetch rather than 29 MB. A file that is present and does not
+ * match is deleted and refetched, since the only thing that can be concluded
+ * about it is that it is not the artifact.
+ *
+ * **A hash mismatch deletes the file.** Leaving it would mean an unverified
+ * artifact sitting in the staging directory looking exactly like a verified
+ * one.
+ *
+ * @param[in]  version      Release version, used for the path and the directory.
+ * @param[in]  filename     Artifact to fetch, matched exactly in the manifest.
+ * @param[in]  staging_root Directory the per-version directories live under.
+ * @param[out] out          Where the verified artifact is, on success.
+ * @param[out] error        Why it failed. Empty when the caller cancelled.
+ */
+bool StageVerifiedRelease(const std::string& version, const std::string& filename,
+                          const fs::path& staging_root, const DownloadProgress& progress,
+                          const DownloadCancel& cancel, StagedRelease& out, std::string& error);
 
 /**
  * SHA-256 of a file on disk, read in blocks rather than loaded.

--- a/src/node/update_check.cpp
+++ b/src/node/update_check.cpp
@@ -200,9 +200,7 @@ bool node::ChunkedDecoder::Feed(const char* data, std::size_t size, const Sink& 
 namespace {
 const std::string UPDATE_CHECK_HOST{"api.github.com"};
 
-//! Where the artifacts themselves are published, as distinct from where the
-//! version is announced.
-const std::string DOWNLOAD_HOST{"download.reddcoin.com"};
+
 
 //! How long one step may make no progress before the exchange is abandoned.
 //!
@@ -759,6 +757,21 @@ std::string node::ExtractHttpBody(const std::string& raw_response, bool clean_eo
     return response.body;
 }
 
+const std::string node::RELEASE_DOWNLOAD_HOST{"download.reddcoin.com"};
+
+bool node::FetchToString(const std::string& host, const std::string& target, std::string& out,
+                         std::string& error)
+{
+    error.clear();
+    try {
+        out = HttpsGet(host, target);
+        return true;
+    } catch (const std::exception& e) {
+        error = e.what();
+        return false;
+    }
+}
+
 node::ProbeResult node::ProbeRemoteFile(const std::string& host_in, const std::string& target_in,
                                         RemoteFile& out, std::string& error)
 {
@@ -1083,7 +1096,7 @@ void node::CheckForUpdates(UniValue& result)
                         const std::string probe_target{"/bin/reddcoin-core-" + remote.numeric +
                                                        "/" + artifacts.gui};
                         const ProbeResult probed{
-                            ProbeRemoteFile(DOWNLOAD_HOST, probe_target, remote_file, probe_error)};
+                            ProbeRemoteFile(RELEASE_DOWNLOAD_HOST, probe_target, remote_file, probe_error)};
                         if (probed == ProbeResult::Absent) {
                             guiArtifact.clear();
                             daemonArtifact.clear();

--- a/src/node/update_check.h
+++ b/src/node/update_check.h
@@ -171,6 +171,22 @@ struct Url {
 Url ResolveRedirect(const std::string& base_host, const std::string& base_target,
                     const std::string& location);
 
+//! Host the release artifacts and their manifest are published on, as
+//! distinct from the one that announces the version.
+extern const std::string RELEASE_DOWNLOAD_HOST;
+
+/**
+ * Fetch a small file into memory over HTTPS.
+ *
+ * For the manifest and its signature, which are kilobytes and have to be held
+ * whole to be verified. An artifact goes through DownloadToFile instead.
+ *
+ * @param[out] out   The body, when this returns true.
+ * @param[out] error Why it failed.
+ */
+bool FetchToString(const std::string& host, const std::string& target, std::string& out,
+                   std::string& error);
+
 //! What a probe found out about a file on the server.
 struct RemoteFile {
     //! Content-Length the server reports, or -1 when it gives none.

--- a/src/test/release_verify_tests.cpp
+++ b/src/test/release_verify_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <test/util/setup_common.h>
 #include <util/strencodings.h>
+#include <util/system.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -15,6 +16,7 @@
 using node::FindArtifactDigest;
 using node::HashFile;
 using node::RELEASE_PUBKEY;
+using node::StagedRelease;
 using node::VerifyReleaseManifest;
 
 namespace {
@@ -214,6 +216,92 @@ BOOST_AUTO_TEST_CASE(the_real_published_release_verifies)
     BOOST_CHECK(!VerifyReleaseManifest(
         published + "0000000000000000000000000000000000000000000000000000000000000000  extra\n",
         signature, error));
+}
+
+//! Staging, added with phase 4b. The download itself needs a network, but the
+//! decisions around it, what is kept, what is thrown away, are the part that
+//! can be got wrong quietly and are testable here.
+
+BOOST_AUTO_TEST_CASE(a_manifest_the_key_did_not_sign_stages_nothing)
+{
+    // The ordering that matters: verification precedes everything. A staging
+    // directory should not so much as be created for a manifest that fails.
+    const fs::path root{gArgs.GetDataDirNet() / "staging-unsigned"};
+    StagedRelease staged;
+    std::string error;
+
+    // No network is reached: the version is one no server will answer for, so
+    // this fails at the fetch. The point is that it fails without leaving a
+    // directory behind.
+    BOOST_CHECK(!node::StageVerifiedRelease("0.0.0-nonexistent", "whatever.tar.gz", root,
+                                            node::DownloadProgress{},
+                                            [] { return true; }, staged, error));
+    BOOST_CHECK(!fs::exists(root));
+}
+
+BOOST_AUTO_TEST_CASE(staging_refuses_an_empty_version_or_name)
+{
+    const fs::path root{gArgs.GetDataDirNet() / "staging-empty"};
+    StagedRelease staged;
+    std::string error;
+
+    BOOST_CHECK(!node::StageVerifiedRelease("", "x.tar.gz", root, node::DownloadProgress{},
+                                            node::DownloadCancel{}, staged, error));
+    BOOST_CHECK(!error.empty());
+    BOOST_CHECK(!node::StageVerifiedRelease("4.22.9.4", "", root, node::DownloadProgress{},
+                                            node::DownloadCancel{}, staged, error));
+    BOOST_CHECK(!error.empty());
+    BOOST_CHECK(!fs::exists(root));
+}
+
+BOOST_AUTO_TEST_CASE(a_staged_file_is_recognised_by_its_hash_not_its_name)
+{
+    // The reuse decision. A file already present and already correct must not
+    // be downloaded again, and a file present under the right name with the
+    // wrong contents must not be mistaken for it.
+    const fs::path dir{gArgs.GetDataDirNet() / "staged"};
+    fs::create_directories(dir);
+    const fs::path artifact{dir / "artifact.tar.gz"};
+    {
+        fsbridge::ofstream out{artifact, std::ios::binary};
+        out << "reddcoin";
+    }
+
+    uint256 present;
+    std::string error;
+    BOOST_REQUIRE(HashFile(artifact, present, error));
+
+    uint256 expected;
+    BOOST_REQUIRE(FindArtifactDigest(
+        "827ea7b9e26989931cbb1f10711d6575ad01aeac043607044d7eb09f322d0d8c  artifact.tar.gz\n",
+        "artifact.tar.gz", expected, error));
+    BOOST_CHECK(present == expected);
+
+    // Same name, different contents. The name proves nothing.
+    {
+        fsbridge::ofstream out{artifact, std::ios::binary};
+        out << "reddcoin ";
+    }
+    uint256 changed;
+    BOOST_REQUIRE(HashFile(artifact, changed, error));
+    BOOST_CHECK(changed != expected);
+}
+
+BOOST_AUTO_TEST_CASE(hashing_is_not_confused_by_size_alone)
+{
+    // Two files of identical length and different content, since a size check
+    // is the tempting shortcut and would pass both.
+    const fs::path a{gArgs.GetDataDirNet() / "a.bin"};
+    const fs::path b{gArgs.GetDataDirNet() / "b.bin"};
+    { fsbridge::ofstream out{a, std::ios::binary}; out << std::string(100000, 'x'); }
+    { fsbridge::ofstream out{b, std::ios::binary}; out << std::string(99999, 'x') << 'y'; }
+
+    uint256 ha, hb;
+    std::string error;
+    BOOST_REQUIRE(HashFile(a, ha, error));
+    BOOST_REQUIRE(HashFile(b, hb, error));
+    BOOST_CHECK_EQUAL(fs::file_size(a), fs::file_size(b));
+    BOOST_CHECK(ha != hb);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/release_verify_tests.cpp
+++ b/src/test/release_verify_tests.cpp
@@ -1,0 +1,219 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/release_verify.h>
+
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <fstream>
+#include <string>
+
+using node::FindArtifactDigest;
+using node::HashFile;
+using node::RELEASE_PUBKEY;
+using node::VerifyReleaseManifest;
+
+namespace {
+//! A manifest in the shape the release actually publishes, including the signed
+//! and unsigned variants that sit side by side. Those pairs are the reason the
+//! filename match has to be exact, so they belong in the fixture rather than in
+//! one test that remembers to add them.
+const std::string MANIFEST{
+    "94e9735251606649b8087c5e7af93e26265bd742bbcf688dd87b22401514807f  reddcoin-4.22.9.4-aarch64-linux-gnu.tar.gz\n"
+    "05a818023af2a88af6dde102820df5c5c2655935ca1a8f7b707bc7214dc13293  reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz\n"
+    "1111111111111111111111111111111111111111111111111111111111111111  reddcoin-4.22.9.4-win64-setup-signed.exe\n"
+    "2222222222222222222222222222222222222222222222222222222222222222  reddcoin-4.22.9.4-win64-setup-unsigned.exe\n"
+    "3333333333333333333333333333333333333333333333333333333333333333  reddcoin-4.22.9.4-osx-signed.dmg\n"
+    "4444444444444444444444444444444444444444444444444444444444444444  reddcoin-4.22.9.4-osx-unsigned.dmg\n"};
+
+std::string HexOf(const uint256& value)
+{
+    return HexStr(Span<const unsigned char>(value.begin(), value.size()));
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(release_verify_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(the_pinned_key_is_usable)
+{
+    // A well formed 32 bytes need not be a point on the curve, and an anchor
+    // that is not one would fail at the first verification rather than here.
+    const std::vector<unsigned char> bytes{ParseHex(RELEASE_PUBKEY)};
+    BOOST_REQUIRE_EQUAL(bytes.size(), 32U);
+    BOOST_CHECK_EQUAL(RELEASE_PUBKEY.size(), 64U);
+    BOOST_CHECK(RELEASE_PUBKEY == ToLower(RELEASE_PUBKEY));
+
+    const XOnlyPubKey pubkey{bytes};
+    BOOST_CHECK(pubkey.IsFullyValid());
+}
+
+BOOST_AUTO_TEST_CASE(an_exact_filename_is_required)
+{
+    // The one that matters. A substring match for "signed.exe" also matches
+    // "win64-setup-unsigned.exe", which would hand a Windows user the unsigned
+    // installer while reporting a verified download.
+    uint256 digest;
+    std::string error;
+
+    BOOST_REQUIRE(FindArtifactDigest(MANIFEST, "reddcoin-4.22.9.4-win64-setup-signed.exe", digest, error));
+    BOOST_CHECK_EQUAL(HexOf(digest),
+                      "1111111111111111111111111111111111111111111111111111111111111111");
+
+    BOOST_REQUIRE(FindArtifactDigest(MANIFEST, "reddcoin-4.22.9.4-win64-setup-unsigned.exe", digest, error));
+    BOOST_CHECK_EQUAL(HexOf(digest),
+                      "2222222222222222222222222222222222222222222222222222222222222222");
+
+    // A partial name resolves to nothing rather than to whichever line happens
+    // to contain it.
+    BOOST_CHECK(!FindArtifactDigest(MANIFEST, "signed.exe", digest, error));
+    BOOST_CHECK(!FindArtifactDigest(MANIFEST, "win64-setup-signed.exe", digest, error));
+    BOOST_CHECK(!FindArtifactDigest(MANIFEST, "reddcoin-4.22.9.4-win64-setup-signed", digest, error));
+}
+
+BOOST_AUTO_TEST_CASE(a_name_the_manifest_does_not_list_fails)
+{
+    uint256 digest;
+    std::string error;
+    BOOST_CHECK(!FindArtifactDigest(MANIFEST, "reddcoin-4.22.9.4-riscv64-linux-gnu.tar.gz", digest, error));
+    BOOST_CHECK(!error.empty());
+    BOOST_CHECK(!FindArtifactDigest(MANIFEST, "", digest, error));
+}
+
+BOOST_AUTO_TEST_CASE(a_duplicated_entry_fails_rather_than_picking_one)
+{
+    // Which digest is correct is precisely what a duplicate makes unknowable,
+    // so taking either would be inventing an answer.
+    const std::string duplicated{
+        MANIFEST +
+        "5555555555555555555555555555555555555555555555555555555555555555  reddcoin-4.22.9.4-osx-signed.dmg\n"};
+
+    uint256 digest;
+    std::string error;
+    BOOST_CHECK(!FindArtifactDigest(duplicated, "reddcoin-4.22.9.4-osx-signed.dmg", digest, error));
+    BOOST_CHECK(!error.empty());
+}
+
+BOOST_AUTO_TEST_CASE(malformed_lines_are_skipped_not_matched)
+{
+    const std::string messy{
+        "\n"
+        "not a manifest line at all\n"
+        "zzzz  reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz\n"
+        "05a818023af2a88af6dde102820df5c5c2655935ca1a8f7b707bc7214dc13293 one-space-only.tar.gz\n" +
+        MANIFEST};
+
+    uint256 digest;
+    std::string error;
+    // The good line is still found, and the malformed ones matched nothing.
+    BOOST_REQUIRE(FindArtifactDigest(messy, "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz", digest, error));
+    BOOST_CHECK_EQUAL(HexOf(digest),
+                      "05a818023af2a88af6dde102820df5c5c2655935ca1a8f7b707bc7214dc13293");
+    BOOST_CHECK(!FindArtifactDigest(messy, "one-space-only.tar.gz", digest, error));
+}
+
+BOOST_AUTO_TEST_CASE(a_signature_of_the_wrong_length_is_rejected_before_verifying)
+{
+    // Load bearing rather than defensive. XOnlyPubKey::VerifySchnorr asserts on
+    // any length other than 64, so reaching it with a malformed signature file
+    // would abort the process instead of reporting a bad release.
+    std::string error;
+    BOOST_CHECK(!VerifyReleaseManifest(MANIFEST, std::string(126, 'a'), error));
+    BOOST_CHECK(!error.empty());
+    BOOST_CHECK(!VerifyReleaseManifest(MANIFEST, std::string(130, 'a'), error));
+    BOOST_CHECK(!VerifyReleaseManifest(MANIFEST, "", error));
+    BOOST_CHECK(!VerifyReleaseManifest(MANIFEST, "not hexadecimal at all", error));
+}
+
+BOOST_AUTO_TEST_CASE(a_signature_from_another_key_is_rejected)
+{
+    // Structurally valid, correct length, and not ours.
+    std::string error;
+    BOOST_CHECK(!VerifyReleaseManifest(MANIFEST, std::string(128, '0'), error));
+    BOOST_CHECK_EQUAL(error, "Release manifest signature is not valid");
+}
+
+BOOST_AUTO_TEST_CASE(hashing_a_file_matches_the_manifest_form)
+{
+    // The comparison phase 4b makes: a file on disk against a digest read out
+    // of a verified manifest.
+    const fs::path path{gArgs.GetDataDirNet() / "artifact"};
+    {
+        fsbridge::ofstream out{path, std::ios::binary};
+        out << "reddcoin";
+    }
+
+    uint256 digest;
+    std::string error;
+    BOOST_REQUIRE(HashFile(path, digest, error));
+    // sha256("reddcoin")
+    BOOST_CHECK_EQUAL(HexOf(digest),
+                      "827ea7b9e26989931cbb1f10711d6575ad01aeac043607044d7eb09f322d0d8c");
+}
+
+BOOST_AUTO_TEST_CASE(hashing_a_missing_file_fails_cleanly)
+{
+    uint256 digest;
+    std::string error;
+    BOOST_CHECK(!HashFile(gArgs.GetDataDirNet() / "no-such-file", digest, error));
+    BOOST_CHECK(!error.empty());
+}
+
+
+BOOST_AUTO_TEST_CASE(the_real_published_release_verifies)
+{
+    // The published 4.22.9.4 manifest and its signature, byte for byte as the
+    // server serves them. This is the check that the pinned key, the tag, the
+    // message construction and the parser all agree with what the release
+    // process actually produced, rather than merely with each other.
+    //
+    // Offline on purpose: a regression test, not a liveness check.
+    const std::string published{
+        "94e9735251606649b8087c5e7af93e26265bd742bbcf688dd87b22401514807f  reddcoin-4.22.9.4-aarch64-linux-gnu.tar.gz\n"
+        "a61fb2624553e85bc4b7353a45cb0b633f7e943efe298e741985788b9e6553f9  reddcoin-4.22.9.4-arm-linux-gnueabihf.tar.gz\n"
+        "e7930ad5fd11f43f5a0c472a502ccee95af9a78f82507f9795b4e64d05daf19b  reddcoin-4.22.9.4.tar.gz\n"
+        "5f57deca7d27419e7774f2058ca7ea15a8179a70d4bc131dcba741486cc8baa3  reddcoin-4.22.9.4-powerpc64-linux-gnu.tar.gz\n"
+        "c856d963da6332cfae8301742c6ccd9900042445002666204661a79fcd6a5fc4  reddcoin-4.22.9.4-powerpc64le-linux-gnu.tar.gz\n"
+        "aeaf2ef8605f23e5bc59f26863b25a5bda56f8b11a427e2854f7506231a0f56f  reddcoin-4.22.9.4-riscv64-linux-gnu.tar.gz\n"
+        "e9a9d13701bc6bb010848c346306abf103e5bb67a68fc86a914f2538b96ca4c8  reddcoin-4.22.9.4-osx-signed.dmg\n"
+        "ffa2120b392df5f4abae316d835d07091b221b11692bff7ff433edaa772c31a5  reddcoin-4.22.9.4-osx-unsigned.dmg\n"
+        "25d9156bbcfc624b92fc29af4260854de8d35464bd1eeea2859f4ba2ddfd5dfa  reddcoin-4.22.9.4-osx-unsigned.tar.gz\n"
+        "ea169121d668952a26ef8c25b4db2f9831e255452da72d424d0be8d4fca11f51  reddcoin-4.22.9.4-osx64.tar.gz\n"
+        "05a818023af2a88af6dde102820df5c5c2655935ca1a8f7b707bc7214dc13293  reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz\n"
+        "96dbc096e6ff41d0fa34051fc5b1fb9ec09eabd5a79e850c5042c1692a27c85a  reddcoin-4.22.9.4-win64-setup-signed.exe\n"
+        "9a44ebfa6dfcf21027b1132d6482cc96d6806faf4e8d695379e8f6bfb947fdc5  reddcoin-4.22.9.4-win-unsigned.tar.gz\n"
+        "541e1e48598fdc68bb59ed0f845390c63a18e32f871212d42cb8f53a0abd7f1f  reddcoin-4.22.9.4-win64-setup-unsigned.exe\n"
+        "facc901ddf2ce860df9b0e1d2fe21b723a7283e1dc0487694bcdde938d597dc6  reddcoin-4.22.9.4-win64.zip\n"};
+    const std::string signature{
+        "67b1904a0fee2f3e313124b5ddb513356db7e46285f6fe2f044a6453e3364e39"
+        "b991765a99c423c85a14f612bf29fbd37abfcd9abc7e67220188cae1fbcdc648"};
+
+    std::string error;
+    BOOST_CHECK_MESSAGE(VerifyReleaseManifest(published, signature, error),
+                        "the real release failed to verify: " << error);
+
+    // And the digest it gives for this host's artifact is the one downloading
+    // that artifact actually produced.
+    uint256 digest;
+    BOOST_REQUIRE(FindArtifactDigest(published, "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz",
+                                     digest, error));
+    BOOST_CHECK_EQUAL(HexOf(digest),
+                      "05a818023af2a88af6dde102820df5c5c2655935ca1a8f7b707bc7214dc13293");
+
+    // One byte different is a different release, which shows the signature is
+    // bound to these bytes rather than verifying for some other reason.
+    std::string tampered{published};
+    tampered[0] = tampered[0] == '9' ? '8' : '9';
+    BOOST_CHECK(!VerifyReleaseManifest(tampered, signature, error));
+
+    // As does an appended line: the realistic corruption is a manifest
+    // regenerated and republished without being re-signed.
+    BOOST_CHECK(!VerifyReleaseManifest(
+        published + "0000000000000000000000000000000000000000000000000000000000000000  extra\n",
+        signature, error));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Phase 4a of RED-98, first slice of RED-119. Adds the verification a downloaded artifact has to pass before anyone is offered it. Phase 3 can fetch a file; until this exists, that file is untrusted bytes from the network.

Implements the checkable half of REP-1018 section 3.6: verify the signature over the manifest, then resolve one artifact name to the digest the manifest gives for it. Downloading the artifact and comparing its hash is 4b.

## The trust anchor

```cpp
const std::string node::RELEASE_PUBKEY{
    "23e6b696f2b69cd753de0d8fe3875e989085fbb6f2dc09026ba8ba1df33585db"};
```

Compiled in, which is the whole design: no keyserver, no handshake, no network lookup. A hostile network can deny an upgrade but cannot substitute one. Its private half exists only on the air-gapped machine, at `m/1018'/4'/0'`.

## Three things that are load bearing, not defensive

**A signature that does not decode to exactly 64 bytes is rejected before verification is attempted.** `XOnlyPubKey::VerifySchnorr` asserts on any other length, so reaching it with a malformed `.sig` would **abort the process** rather than report a bad release.

**The filename match is on the whole field, and requires exactly one line.** The published manifest lists signed and unsigned variants side by side:

```
...  reddcoin-4.22.9.4-win64-setup-signed.exe
...  reddcoin-4.22.9.4-win64-setup-unsigned.exe
```

A substring match for `signed.exe` matches both. A client matching loosely would hand a Windows user the **unsigned installer while reporting a verified download**. A duplicated entry fails rather than picking one, because which digest is right is exactly what a duplicate makes unknowable.

**The manifest is hashed over the bytes as received.** Normalising line endings or whitespace on the way in would verify something the server does not serve.

## The test that matters

`the_real_published_release_verifies` embeds the **actual published 4.22.9.4 manifest and its signature**, byte for byte, and checks they verify against the pinned key. It passes, so the key, the tag, the message construction and the parser agree with what the release process really produced rather than merely with each other.

It also confirms the digest the manifest gives for this host's artifact is the one that **downloading that artifact actually produced** in #531, and that a single flipped byte or an appended line breaks verification.

Offline on purpose: a regression test, not a liveness check.

## Checked for teeth

Flipping the last character of the pinned key fails that test and two others:

```
error: the real release failed to verify: Release public key is not a valid point
*** 3 failures detected
```

So the anchor is doing work rather than being decoration.

## Verified

10 new tests, plus 9 + 9 + 27 existing, all passing on both lines, builds clean including `reddcoin-qt`.

## Not in this PR

Downloading the artifact and comparing its hash, and the staging lifecycle. That is 4b, and it is a small addition now that this and phase 3b both exist.

YouTrack: https://reddink.youtrack.cloud/issue/RED-119