### PR TITLE
rpc: add downloadupdate, which fetches and verifies a release

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -8,6 +8,7 @@
 
 #include <clientversion.h>
 #include <rpc/util.h>
+#include <node/release_verify.h>
 #include <node/update_check.h>
 #include <shutdown.h>
 #include <sync.h>
@@ -316,6 +317,81 @@ void checkforupdatesinfo(UniValue& result)
     node::CheckForUpdates(result);
 }
 
+static RPCHelpMan downloadupdate()
+{
+    return RPCHelpMan{"downloadupdate",
+        "\nDownload the current release and verify it against the signing key built into this "
+        "client.\n"
+        "\nThe file is only kept if its hash matches a manifest that key signed, so a successful "
+        "call means the artifact on disk is the one the release manager published. Nothing is "
+        "installed: this client never replaces its own files.\n"
+        "\nRe-running is cheap. An artifact already downloaded and still correct is not fetched "
+        "again.\n",
+        {
+            {"artifact", RPCArg::Type::STR, RPCArg::Default{"daemon"},
+             "Which build to fetch, \"daemon\" or \"gui\". They are the same file on Linux; on "
+             "Windows and macOS the gui build is the installer and the daemon build is the archive"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "version", "Version that was downloaded"},
+                {RPCResult::Type::STR, "artifact", "Filename that was downloaded"},
+                {RPCResult::Type::STR, "path", "Where the verified file is"},
+                {RPCResult::Type::NUM, "size", "Its size in bytes"},
+                {RPCResult::Type::BOOL, "verified", "Always true. A file that did not verify is deleted rather than reported"},
+            }},
+        RPCExamples{HelpExampleCli("downloadupdate", "") +
+                    HelpExampleCli("downloadupdate", "gui") +
+                    HelpExampleRpc("downloadupdate", "\"gui\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    // Defaults to the daemon build because this is the RPC: a reddcoind
+    // operator is who reaches it. The Qt console can ask for "gui", and the
+    // GUI itself will call the node directly rather than through here.
+    const std::string which{request.params[0].isNull() ? "daemon" : request.params[0].get_str()};
+    if (which != "daemon" && which != "gui") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "artifact must be \"daemon\" or \"gui\"");
+    }
+
+    // Ask what the current release is, rather than taking a version from the
+    // caller. A caller-supplied version would let this be pointed at anything
+    // on the server, and the answer to "which release" belongs in one place.
+    UniValue check(UniValue::VOBJ);
+    node::CheckForUpdates(check);
+
+    const std::string errors{check["errors"].isNull() ? "" : check["errors"].get_str()};
+    if (!errors.empty()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Could not determine the current release: " + errors);
+    }
+
+    const std::string version{check["remoteversion"].isNull() ? "" : check["remoteversion"].get_str()};
+    const std::string field{which == "gui" ? "guiartifact" : "daemonartifact"};
+    const std::string artifact{check[field].isNull() ? "" : check[field].get_str()};
+    if (version.empty() || artifact.empty()) {
+        throw JSONRPCError(RPC_MISC_ERROR,
+                           "No published build is known for this host, so there is nothing to download");
+    }
+
+    node::StagedRelease staged;
+    std::string error;
+    if (!node::StageVerifiedRelease(version, artifact, gArgs.GetDataDirNet() / "updates",
+                                    node::DownloadProgress{}, node::DownloadCancel{}, staged,
+                                    error)) {
+        throw JSONRPCError(RPC_MISC_ERROR, error.empty() ? "Download cancelled" : error);
+    }
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("version", version);
+    result.pushKV("artifact", staged.filename);
+    result.pushKV("path", staged.path.string());
+    result.pushKV("size", staged.size);
+    result.pushKV("verified", true);
+    return result;
+}
+    };
+}
+
 // clang-format off
 static const CRPCCommand vRPCCommands[] =
 { //  category               actor (function)
@@ -326,6 +402,7 @@ static const CRPCCommand vRPCCommands[] =
     { "control",             &stop,                   },
     { "control",             &uptime,                 },
     { "control",             &checkupdates,           },
+    { "control",             &downloadupdate,         },
 };
 // clang-format on
 


### PR DESCRIPTION
Phase 5a of RED-98, first slice of RED-120. Phase 4 produces a verified artifact on disk; this is the first thing that asks it to.

A `reddcoind` operator previously got a link and nothing else. `downloadupdate` fetches the current release, checks it against the signing key built into the binary, and reports where the file is.

```
$ reddcoin-cli downloadupdate
{
  "version": "4.22.9.4",
  "artifact": "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz",
  "path": ".../updates/reddcoin-core-4.22.9.4/reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz",
  "size": 30603976,
  "verified": true
}
```

**It installs nothing.** This client never replaces its own files, which was settled when Tier 3 was rejected and is not revisited here.

## Two design choices worth reviewing

**The version is not a parameter.** It asks the update check what the current release is. A caller-supplied version would let this be pointed at anything on the server, and the answer to "which release" belongs in one place rather than in every caller.

**The artifact argument defaults to `daemon`.** This is the RPC, so a `reddcoind` operator is who reaches it. The Qt console can pass `gui`, and the GUI itself will call the node directly rather than through here.

## Argument validation precedes the network

A mistyped argument costs an error, not a download. The functional test asserts exactly that, and asserts it by timing: the rejection has to complete faster than a network round trip could, which is what makes "before touching the network" an assertion rather than a claim.

## What the functional test deliberately does not do

The happy path fetches 29 MB. Doing that on every suite run would be a bad neighbour to CI and to anyone on a metered connection, so it is verified by hand against the live server instead:

- first call returns the verified path in 12 seconds
- a second returns in under 4 with no refetch, because phase 4b recognises the staged file by hash
- the file on disk hashes to `05a818023af2a88af6dde102820df5c5c2655935ca1a8f7b707bc7214dc13293`, its entry in the signed manifest

## Next

5b is the GUI progress dialog, and it is where the two assumptions baked into the download API before it had a caller finally get tested: `StageVerifiedRelease` is blocking, and progress fires around 180 times a second.

YouTrack: https://reddink.youtrack.cloud/issue/RED-120

---

**Backport.** The RPC is identical to develop's.

The functional test is **deliberately not brought across**. The framework on this line looks for `src/bitcoind`, which is never built here, so a test added would not run and would only look like coverage. Verified by hand on this branch instead: the argument is rejected before any network access, and a real call returns the verified path with the file hashing to its entry in the signed manifest.