### PR TITLE
qt: offer to download and verify the update from the dialog

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -85,6 +85,7 @@ QT_MOC_CPP = \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
   qt/moc_utilitydialog.cpp \
+  qt/moc_updatedownloadworker.cpp \
   qt/moc_walletcontroller.cpp \
   qt/moc_walletframe.cpp \
   qt/moc_walletmodel.cpp \
@@ -165,6 +166,7 @@ BITCOIN_QT_H = \
   qt/transactiontablemodel.h \
   qt/transactionview.h \
   qt/utilitydialog.h \
+  qt/updatedownloadworker.h \
   qt/walletcontroller.h \
   qt/walletframe.h \
   qt/walletmodel.h \
@@ -260,7 +262,8 @@ BITCOIN_QT_BASE_CPP = \
   qt/rpcconsole.cpp \
   qt/splashscreen.cpp \
   qt/trafficgraphwidget.cpp \
-  qt/utilitydialog.cpp
+  qt/utilitydialog.cpp \
+  qt/updatedownloadworker.cpp
 
 BITCOIN_QT_WINDOWS_CPP = qt/winshutdownmonitor.cpp
 

--- a/src/qt/updatedownloadworker.cpp
+++ b/src/qt/updatedownloadworker.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/updatedownloadworker.h>
+
+#include <node/release_verify.h>
+#include <util/system.h>
+
+#include <string>
+
+void UpdateDownloadWorker::download()
+{
+    // Whole percentage points only. The callback below is invoked on every read
+    // of the socket, roughly 180 times a second, and a queued signal per read
+    // would spend more of the GUI thread on repainting than the transfer spends
+    // on arriving.
+    int last_percent{-1};
+
+    const node::DownloadProgress progress = [&](int64_t received, int64_t total) {
+        if (total <= 0) {
+            // No Content-Length, so there is no percentage to report. Emit
+            // sparingly on a byte boundary instead, which keeps a determinate
+            // bar from being faked out of nothing.
+            if (received / (1024 * 1024) == last_percent) return;
+            last_percent = static_cast<int>(received / (1024 * 1024));
+            Q_EMIT progressed(received, -1);
+            return;
+        }
+        const int percent{static_cast<int>((received * 100) / total)};
+        if (percent == last_percent) return;
+        last_percent = percent;
+        Q_EMIT progressed(received, total);
+    };
+
+    const node::DownloadCancel cancel = [this] { return m_cancelled.load(); };
+
+    node::StagedRelease staged;
+    std::string error;
+    const bool ok = node::StageVerifiedRelease(
+        m_version.toStdString(), m_artifact.toStdString(),
+        gArgs.GetDataDirNet() / "updates", progress, cancel, staged, error);
+
+    if (!ok) {
+        // A cancelled download reports no error, because the user asking for it
+        // to stop is not a failure to explain back to them.
+        Q_EMIT finished(false, QString{}, 0, QString::fromStdString(error));
+        return;
+    }
+
+    Q_EMIT finished(true, QString::fromStdString(staged.path.string()),
+                    static_cast<qint64>(staged.size), QString{});
+}

--- a/src/qt/updatedownloadworker.h
+++ b/src/qt/updatedownloadworker.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_UPDATEDOWNLOADWORKER_H
+#define BITCOIN_QT_UPDATEDOWNLOADWORKER_H
+
+#include <QObject>
+#include <QString>
+
+#include <atomic>
+
+/**
+ * Downloads a release and verifies it, off the GUI thread.
+ *
+ * The node's staging call blocks for as long as a 29 MB transfer takes, so this
+ * must not run on the GUI thread. Move an instance onto a QThread, connect
+ * something to download() to start it, and connect to progressed() and
+ * finished() to follow it. Both cross a thread boundary, so Qt queues them.
+ *
+ * A verified file is the only thing this produces. Nothing is installed and
+ * nothing is run.
+ */
+class UpdateDownloadWorker : public QObject
+{
+    Q_OBJECT
+
+public:
+    UpdateDownloadWorker(QString version, QString artifact)
+        : m_version{std::move(version)}, m_artifact{std::move(artifact)} {}
+
+public Q_SLOTS:
+    //! Run the download on whichever thread this object lives on.
+    void download();
+
+    /**
+     * Ask the download to stop.
+     *
+     * Safe to call from the GUI thread while download() is running, which is
+     * the point: it is the only member that is. The flag is read between reads
+     * of the socket, so cancelling takes effect at the next one rather than
+     * immediately, and never tears down an in-flight operation from underneath
+     * the thread performing it.
+     */
+    void cancel() { m_cancelled = true; }
+
+Q_SIGNALS:
+    /**
+     * Progress so far, and the total when the server declared one.
+     *
+     * Throttled to whole percentage points. The underlying callback fires
+     * around 180 times a second on a 29 MB artifact, which is a reasonable rate
+     * for a callback and far too high to drive a repaint, so the thinning
+     * happens here rather than leaving every consumer to remember it.
+     */
+    void progressed(qint64 received, qint64 total);
+
+    //! path and size are set when ok is true; error explains it when false, and
+    //! is empty when the download was cancelled, since that is not a failure.
+    void finished(bool ok, const QString& path, qint64 size, const QString& error);
+
+private:
+    QString m_version;
+    QString m_artifact;
+    std::atomic<bool> m_cancelled{false};
+};
+
+#endif // BITCOIN_QT_UPDATEDOWNLOADWORKER_H

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -13,6 +13,7 @@
 
 #include <qt/guiutil.h>
 #include <qt/networkstyle.h>
+#include <qt/updatedownloadworker.h>
 
 #include <clientversion.h>
 #include <init.h>
@@ -25,6 +26,8 @@
 
 #include <QCloseEvent>
 #include <QLabel>
+#include <QProgressBar>
+#include <QPushButton>
 #include <QMainWindow>
 #include <QRegExp>
 #include <QTextCursor>
@@ -143,6 +146,8 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
                     text += "The build for this machine is:<br>";
                     text += "<a href=\"" + guiArtifactLink + "\">" + guiArtifact + "</a>";
 
+                    addDownloadControls(remoteversion, guiArtifact);
+
                     if (platform == "osx64") {
                         // Only an x86_64 macOS build is published, and it runs on
                         // Apple Silicon under Rosetta. Say which one it is rather
@@ -223,7 +228,114 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
 
 HelpMessageDialog::~HelpMessageDialog()
 {
+    // A download can be minutes from finishing, so ask it to stop before
+    // waiting rather than blocking the close on a transfer nobody wants any
+    // more. quit() alone would not do it: the worker is inside a blocking call
+    // and is not reading the event loop, so it has to be told through the flag
+    // it polls between reads.
+    if (m_download_worker) m_download_worker->cancel();
+    m_download_thread.quit();
+    m_download_thread.wait();
+
     delete ui;
+}
+
+void HelpMessageDialog::addDownloadControls(const QString& version, const QString& artifact)
+{
+    // Built here rather than in the .ui file because they exist only on the
+    // update path, and only when there is a named artifact to fetch.
+    m_download_status = new QLabel{this};
+    m_download_status->setWordWrap(true);
+    m_download_status->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+    m_download_progress = new QProgressBar{this};
+    m_download_progress->setRange(0, 100);
+    m_download_progress->setValue(0);
+    m_download_progress->setVisible(false);
+
+    m_download_button = new QPushButton{tr("Download and verify"), this};
+    m_download_button->setToolTip(
+        tr("Download %1 and check it against the signing key built into this client. "
+           "Nothing is installed.").arg(artifact));
+
+    if (QLayout* layout = this->layout()) {
+        layout->addWidget(m_download_status);
+        layout->addWidget(m_download_progress);
+        layout->addWidget(m_download_button);
+    }
+
+    m_download_worker = new UpdateDownloadWorker{version, artifact};
+    m_download_worker->moveToThread(&m_download_thread);
+
+    connect(&m_download_thread, &QThread::finished, m_download_worker, &QObject::deleteLater);
+    connect(&m_download_thread, &QThread::started, m_download_worker, &UpdateDownloadWorker::download);
+    connect(m_download_worker, &UpdateDownloadWorker::progressed,
+            this, &HelpMessageDialog::onDownloadProgress);
+    connect(m_download_worker, &UpdateDownloadWorker::finished,
+            this, &HelpMessageDialog::onDownloadFinished);
+    connect(m_download_button, &QPushButton::clicked, this, &HelpMessageDialog::onDownloadClicked);
+}
+
+void HelpMessageDialog::onDownloadClicked()
+{
+    if (m_download_thread.isRunning()) {
+        // Second click cancels. The worker checks the flag between reads, so
+        // the transfer stops at the next one rather than being torn down from
+        // under the thread performing it.
+        m_download_button->setEnabled(false);
+        m_download_button->setText(tr("Cancelling..."));
+        if (m_download_worker) m_download_worker->cancel();
+        return;
+    }
+
+    m_download_progress->setValue(0);
+    m_download_progress->setVisible(true);
+    m_download_status->setText(tr("Downloading..."));
+    m_download_button->setText(tr("Cancel"));
+    m_download_thread.start();
+}
+
+void HelpMessageDialog::onDownloadProgress(qint64 received, qint64 total)
+{
+    if (total > 0) {
+        m_download_progress->setRange(0, 100);
+        m_download_progress->setValue(static_cast<int>((received * 100) / total));
+        m_download_status->setText(tr("Downloading... %1 of %2 MB")
+                                       .arg(received / (1024 * 1024))
+                                       .arg(total / (1024 * 1024)));
+        return;
+    }
+
+    // No declared length, so there is no honest percentage to show. A busy
+    // indicator says "working" without inventing a position.
+    m_download_progress->setRange(0, 0);
+    m_download_status->setText(tr("Downloading... %1 MB so far").arg(received / (1024 * 1024)));
+}
+
+void HelpMessageDialog::onDownloadFinished(bool ok, const QString& path, qint64 size,
+                                           const QString& error)
+{
+    m_download_thread.quit();
+    m_download_progress->setVisible(false);
+    m_download_button->setEnabled(true);
+    m_download_button->setText(tr("Download and verify"));
+
+    if (ok) {
+        // Say what was actually established. "Downloaded" would undersell it
+        // and "installed" would be untrue.
+        m_download_status->setText(
+            tr("Verified against the release signing key (%1 MB).<br>Saved to: %2")
+                .arg(size / (1024 * 1024))
+                .arg(path.toHtmlEscaped()));
+        m_download_button->setVisible(false);
+        return;
+    }
+
+    if (error.isEmpty()) {
+        m_download_status->setText(tr("Download cancelled."));
+        return;
+    }
+    m_download_status->setText("<font color='red'>" + error.toHtmlEscaped() + "</font>");
 }
 
 void HelpMessageDialog::printToConsole()

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -7,9 +7,17 @@
 #define BITCOIN_QT_UTILITYDIALOG_H
 
 #include <QDialog>
+#include <QThread>
 #include <QWidget>
 
 class NetworkStyle;
+class UpdateDownloadWorker;
+
+QT_BEGIN_NAMESPACE
+class QLabel;
+class QProgressBar;
+class QPushButton;
+QT_END_NAMESPACE
 
 QT_BEGIN_NAMESPACE
 class QMainWindow;
@@ -32,11 +40,29 @@ public:
     void showOrPrint();
 
 private:
+    /** Add the download button and progress bar, once there is something to offer */
+    void addDownloadControls(const QString& version, const QString& artifact);
+
     Ui::HelpMessageDialog *ui;
     QString text;
 
+    /** Thread the download runs on, so a 29 MB transfer cannot stall the GUI */
+    QThread m_download_thread;
+    /** Owned by m_download_thread, which deletes it when it finishes */
+    UpdateDownloadWorker* m_download_worker{nullptr};
+    QPushButton* m_download_button{nullptr};
+    QProgressBar* m_download_progress{nullptr};
+    QLabel* m_download_status{nullptr};
+
 private Q_SLOTS:
     void on_okButton_accepted();
+
+    /** Start the download, or ask a running one to stop */
+    void onDownloadClicked();
+    /** Move the bar. Queued from the worker thread, already throttled there */
+    void onDownloadProgress(qint64 received, qint64 total);
+    /** Report where the verified file is, or why there is not one */
+    void onDownloadFinished(bool ok, const QString& path, qint64 size, const QString& error);
 };
 
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -8,6 +8,7 @@
 
 #include <clientversion.h>
 #include <rpc/util.h>
+#include <node/release_verify.h>
 #include <node/update_check.h>
 #include <shutdown.h>
 #include <sync.h>
@@ -316,6 +317,81 @@ void checkforupdatesinfo(UniValue& result)
     node::CheckForUpdates(result);
 }
 
+static RPCHelpMan downloadupdate()
+{
+    return RPCHelpMan{"downloadupdate",
+        "\nDownload the current release and verify it against the signing key built into this "
+        "client.\n"
+        "\nThe file is only kept if its hash matches a manifest that key signed, so a successful "
+        "call means the artifact on disk is the one the release manager published. Nothing is "
+        "installed: this client never replaces its own files.\n"
+        "\nRe-running is cheap. An artifact already downloaded and still correct is not fetched "
+        "again.\n",
+        {
+            {"artifact", RPCArg::Type::STR, RPCArg::Default{"daemon"},
+             "Which build to fetch, \"daemon\" or \"gui\". They are the same file on Linux; on "
+             "Windows and macOS the gui build is the installer and the daemon build is the archive"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "version", "Version that was downloaded"},
+                {RPCResult::Type::STR, "artifact", "Filename that was downloaded"},
+                {RPCResult::Type::STR, "path", "Where the verified file is"},
+                {RPCResult::Type::NUM, "size", "Its size in bytes"},
+                {RPCResult::Type::BOOL, "verified", "Always true. A file that did not verify is deleted rather than reported"},
+            }},
+        RPCExamples{HelpExampleCli("downloadupdate", "") +
+                    HelpExampleCli("downloadupdate", "gui") +
+                    HelpExampleRpc("downloadupdate", "\"gui\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    // Defaults to the daemon build because this is the RPC: a reddcoind
+    // operator is who reaches it. The Qt console can ask for "gui", and the
+    // GUI itself will call the node directly rather than through here.
+    const std::string which{request.params[0].isNull() ? "daemon" : request.params[0].get_str()};
+    if (which != "daemon" && which != "gui") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "artifact must be \"daemon\" or \"gui\"");
+    }
+
+    // Ask what the current release is, rather than taking a version from the
+    // caller. A caller-supplied version would let this be pointed at anything
+    // on the server, and the answer to "which release" belongs in one place.
+    UniValue check(UniValue::VOBJ);
+    node::CheckForUpdates(check);
+
+    const std::string errors{check["errors"].isNull() ? "" : check["errors"].get_str()};
+    if (!errors.empty()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Could not determine the current release: " + errors);
+    }
+
+    const std::string version{check["remoteversion"].isNull() ? "" : check["remoteversion"].get_str()};
+    const std::string field{which == "gui" ? "guiartifact" : "daemonartifact"};
+    const std::string artifact{check[field].isNull() ? "" : check[field].get_str()};
+    if (version.empty() || artifact.empty()) {
+        throw JSONRPCError(RPC_MISC_ERROR,
+                           "No published build is known for this host, so there is nothing to download");
+    }
+
+    node::StagedRelease staged;
+    std::string error;
+    if (!node::StageVerifiedRelease(version, artifact, gArgs.GetDataDirNet() / "updates",
+                                    node::DownloadProgress{}, node::DownloadCancel{}, staged,
+                                    error)) {
+        throw JSONRPCError(RPC_MISC_ERROR, error.empty() ? "Download cancelled" : error);
+    }
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("version", version);
+    result.pushKV("artifact", staged.filename);
+    result.pushKV("path", staged.path.string());
+    result.pushKV("size", staged.size);
+    result.pushKV("verified", true);
+    return result;
+}
+    };
+}
+
 // clang-format off
 static const CRPCCommand vRPCCommands[] =
 { //  category               actor (function)
@@ -326,6 +402,7 @@ static const CRPCCommand vRPCCommands[] =
     { "control",             &stop,                   },
     { "control",             &uptime,                 },
     { "control",             &checkupdates,           },
+    { "control",             &downloadupdate,         },
 };
 // clang-format on
 


### PR DESCRIPTION
Phase 5b of RED-98, second slice of RED-120. The update dialog named the build for this machine and linked to it; now it can fetch that build and prove it is the one the release key signed, without the user leaving the client.

**Nothing is installed.** The dialog ends at "here is a verified file", which is Tier 2 as agreed.

## The button appears only where an artifact was named

An up-to-date node, and a release with no artifact for this host, both keep exactly the dialog they had. The case that cannot be handled honestly is not offered, rather than being offered and failing.

## Both phase 3b assumptions were exercised, and both held

They were decided when nothing called the download API, so this is the first time they have been tested.

**The staging call blocks** for as long as a 29 MB transfer takes, so it runs on a worker thread and reaches the dialog through queued signals.

**Progress fires around 180 times a second.** That is reasonable for a callback and far too high to drive a repaint, so it is thinned to whole percentage points **in the worker**, bounding the queued signal traffic at the source rather than leaving every consumer to remember. Where the server declares no length there is no honest percentage, so the bar goes indeterminate rather than inventing a position.

## Cancelling

Sets a flag the worker polls between reads. The transfer stops at the next one rather than being torn down from under the thread performing it, which is the failure `Await()`'s shutdown dance exists to avoid and which cancel would otherwise have reintroduced.

The destructor cancels **before** waiting. `quit()` alone cannot reach a worker sitting inside a blocking call, so closing the dialog mid-download would otherwise block on a transfer nobody wants any more.

## Tests

Four Qt tests, none touching the network. They cover the wiring, which is where this goes wrong quietly: that the controls appear only when there is something to fetch, and that a dialog carrying a worker thread can be constructed and destroyed repeatedly without incident.

## Not visually confirmed

Stated plainly because it is the honest limit here. The Qt built by `depends` ships only the `xcb` platform plugin, so there is no headless mode to drive the dialog in. The automated tests cover the wiring; what they cannot cover is whether it looks right. Worth a look in a running client before merge.

YouTrack: https://reddink.youtrack.cloud/issue/RED-120

---

## Backport, with two differences worth knowing

`updatedownloadworker.{h,cpp}` are **byte identical** to develop's, so the download behaves the same on both lines.

**The dialog around it could not be copied.** This line builds the update text inline in the constructor and performs the check **synchronously on the GUI thread**, where develop moved that onto a worker and fills the dialog from a signal. The controls are grafted onto the constructor's artifact branch instead, which is the same place develop offers them.

**The Qt test is not brought across** for the same reason: it delivers a synthetic result to the dialog and inspects what appeared, which needs the slot this line does not have. Constructing the dialog here performs a real network request instead.

⚠ Separately: `test_reddcoin-qt` aborts in `WalletTests` with "double free or corruption" on this line. **Pre-existing and unrelated** - confirmed by stashing these changes, rebuilding, and reproducing it identically.