### PR TITLE
qt: hand the verified build to the platform

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -85,6 +85,7 @@ QT_MOC_CPP = \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
   qt/moc_utilitydialog.cpp \
+  qt/moc_updatedownloadworker.cpp \
   qt/moc_walletcontroller.cpp \
   qt/moc_walletframe.cpp \
   qt/moc_walletmodel.cpp \
@@ -165,6 +166,7 @@ BITCOIN_QT_H = \
   qt/transactiontablemodel.h \
   qt/transactionview.h \
   qt/utilitydialog.h \
+  qt/updatedownloadworker.h \
   qt/walletcontroller.h \
   qt/walletframe.h \
   qt/walletmodel.h \
@@ -260,7 +262,8 @@ BITCOIN_QT_BASE_CPP = \
   qt/rpcconsole.cpp \
   qt/splashscreen.cpp \
   qt/trafficgraphwidget.cpp \
-  qt/utilitydialog.cpp
+  qt/utilitydialog.cpp \
+  qt/updatedownloadworker.cpp
 
 BITCOIN_QT_WINDOWS_CPP = qt/winshutdownmonitor.cpp
 

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -86,6 +86,7 @@ QT_MOC_CPP = \
   qt/moc_transactionview.cpp \
   qt/moc_utilitydialog.cpp \
   qt/moc_updatedownloadworker.cpp \
+  qt/moc_updatecheckworker.cpp \
   qt/moc_walletcontroller.cpp \
   qt/moc_walletframe.cpp \
   qt/moc_walletmodel.cpp \
@@ -167,6 +168,7 @@ BITCOIN_QT_H = \
   qt/transactionview.h \
   qt/utilitydialog.h \
   qt/updatedownloadworker.h \
+  qt/updatecheckworker.h \
   qt/walletcontroller.h \
   qt/walletframe.h \
   qt/walletmodel.h \
@@ -263,7 +265,8 @@ BITCOIN_QT_BASE_CPP = \
   qt/splashscreen.cpp \
   qt/trafficgraphwidget.cpp \
   qt/utilitydialog.cpp \
-  qt/updatedownloadworker.cpp
+  qt/updatedownloadworker.cpp \
+  qt/updatecheckworker.cpp
 
 BITCOIN_QT_WINDOWS_CPP = qt/winshutdownmonitor.cpp
 

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -8,8 +8,8 @@ TESTS += qt/test/test_reddcoin-qt
 TEST_QT_MOC_CPP = \
   qt/test/moc_apptests.cpp \
   qt/test/moc_rpcnestedtests.cpp \
-  qt/test/moc_uritests.cpp
-
+  qt/test/moc_uritests.cpp \
+  qt/test/moc_updatedialogtests.cpp
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += \
   qt/test/moc_addressbooktests.cpp \
@@ -20,8 +20,8 @@ TEST_QT_H = \
   qt/test/addressbooktests.h \
   qt/test/apptests.h \
   qt/test/rpcnestedtests.h \
-  qt/test/uritests.h \
-  qt/test/util.h \
+  qt/test/uritests.h \ \
+  qt/test/updatedialogtests.h \  qt/test/util.h \
   qt/test/wallettests.h
 
 qt_test_test_reddcoin_qt_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_QT_INCLUDES) \
@@ -31,8 +31,8 @@ qt_test_test_reddcoin_qt_SOURCES = \
   qt/test/apptests.cpp \
   qt/test/rpcnestedtests.cpp \
   qt/test/test_main.cpp \
-  qt/test/uritests.cpp \
-  qt/test/util.cpp \
+  qt/test/uritests.cpp \ \
+  qt/test/updatedialogtests.cpp \  qt/test/util.cpp \
   $(TEST_QT_H)
 if ENABLE_WALLET
 qt_test_test_reddcoin_qt_SOURCES += \

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -13,6 +13,7 @@
 #include <qt/guiutil.h>
 #include <qt/modaloverlay.h>
 #include <qt/networkstyle.h>
+#include <qt/updatecheckworker.h>
 #include <qt/notificator.h>
 #include <qt/openuridialog.h>
 #include <qt/optionsdialog.h>
@@ -240,6 +241,8 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     connect(timer, &QTimer::timeout, this, &BitcoinGUI::checkUpdates);
     timer->start(CHECK_UPDATE_DELAY);
 
+    startUpdateCheckWorker();
+
     // check update on initial start
     checkUpdates();
 
@@ -265,46 +268,54 @@ BitcoinGUI::~BitcoinGUI()
     MacDockIconHandler::cleanup();
 #endif
 
+    // An in flight check must not outlive the widgets its answer updates.
+    m_update_check_thread.quit();
+    m_update_check_thread.wait();
+
     delete rpcConsole;
+}
+
+void BitcoinGUI::startUpdateCheckWorker()
+{
+    UpdateCheckWorker* worker = new UpdateCheckWorker();
+    worker->moveToThread(&m_update_check_thread);
+
+    // Requests from this object must go to the worker, and its answers must come
+    // back here. Both connections cross threads, so Qt queues them.
+    connect(this, &BitcoinGUI::updateCheckRequested, worker, &UpdateCheckWorker::check);
+    connect(worker, &UpdateCheckWorker::checked, this, &BitcoinGUI::updateCheckFinished);
+
+    // Make sure the worker is deleted in its own thread.
+    connect(&m_update_check_thread, &QThread::finished, worker, &UpdateCheckWorker::deleteLater);
+
+    // The default QThread::run() spins up an event loop, which is what is needed
+    // here so the worker can receive queued calls.
+    m_update_check_thread.start();
 }
 
 void BitcoinGUI::checkUpdates()
 {
 #ifdef ENABLE_WALLET
-
     QSettings settings;
     if (settings.value("bCheckGithub").toBool()) {
-        // Get checkforupdatesinfo from rpc server
-        UniValue result(UniValue::VOBJ);
-        checkforupdatesinfo(result);
-
-        std::string localversion = "";
-        std::string remoteversion = "";
-        bool updateavailable = false;
-        std::string message = "";
-        std::string warning = "";
-        std::string officialDownloadLink = "";
-        std::string errors = "";
-
-        if (result.exists("localversion")) {
-            localversion = result["localversion"].get_str();
-        }
-        if (result.exists("remoteversion")) {
-            remoteversion = result["remoteversion"].get_str();
-        }
-        if (result.exists("updateavailable")) {
-            updateavailable = result["updateavailable"].get_bool();
-        }
-
-        if (updateavailable) {
-            labelCheckUpdate->setText(tr("Update to %1 is available.").arg(QString::fromStdString(remoteversion)));
-            labelCheckUpdate->setVisible(true);
-        } else {
-            labelCheckUpdate->setVisible(false);
-            labelCheckUpdate->setText(QString(""));
-        }
+        // The check performs network requests, so hand it to the worker thread
+        // and pick the answer up in updateCheckFinished(). Doing it here froze
+        // the window, and did so during construction on the first call, before
+        // it had even been shown.
+        Q_EMIT updateCheckRequested();
     }
 #endif
+}
+
+void BitcoinGUI::updateCheckFinished(const QVariantMap& info)
+{
+    if (info.value("updateavailable").toBool()) {
+        labelCheckUpdate->setText(tr("Update to %1 is available.").arg(info.value("remoteversion").toString()));
+        labelCheckUpdate->setVisible(true);
+    } else {
+        labelCheckUpdate->setVisible(false);
+        labelCheckUpdate->setText(QString(""));
+    }
 }
 
 void BitcoinGUI::createActions()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -16,6 +16,8 @@
 #include <amount.h>
 
 #include <QLabel>
+#include <QVariantMap>
+#include <QThread>
 #include <QMainWindow>
 #include <QMap>
 #include <QMenu>
@@ -124,6 +126,13 @@ protected:
     bool eventFilter(QObject *object, QEvent *event) override;
 
 private:
+
+    /** Create the update check worker and start the thread it runs on */
+    void startUpdateCheckWorker();
+
+    /** Thread the update check runs on, so its network requests cannot stall the GUI */
+    QThread m_update_check_thread;
+
     interfaces::Node& m_node;
     WalletController* m_wallet_controller{nullptr};
     std::unique_ptr<interfaces::Handler> m_handler_message_box;
@@ -248,11 +257,19 @@ private:
     void openOptionsDialogWithTab(OptionsDialog::Tab tab);
 
 Q_SIGNALS:
+    /** Ask the worker thread to run a check */
+    void updateCheckRequested();
+
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString &uri);
     /** Signal raised when RPC console shown */
     void consoleShown(RPCConsole* console);
     void setPrivacy(bool privacy);
+
+
+private Q_SLOTS:
+    /** Update the status bar label once the check has an answer */
+    void updateCheckFinished(const QVariantMap& info);
 
 public Q_SLOTS:
     /** Set number of connections shown in the UI */
@@ -408,7 +425,6 @@ private:
     /** Creates context menu, its actions, and wires up all the relevant signals for mouse events. */
     void createContextMenu();
 
-private Q_SLOTS:
     /** When Display Units are changed on OptionsModel it will refresh the display text of the control on the status bar */
     void updateDisplayUnit(int newUnits);
     /** Tells underlying optionsModel to update its current display unit. */

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -11,6 +11,7 @@
 #include <qt/bitcoin.h>
 #include <qt/test/apptests.h>
 #include <qt/test/rpcnestedtests.h>
+#include <qt/test/updatedialogtests.h>
 #include <qt/test/uritests.h>
 #include <test/util/setup_common.h>
 
@@ -86,6 +87,10 @@ int main(int argc, char* argv[])
     }
     URITests test1;
     if (QTest::qExec(&test1) != 0) {
+        fInvalid = true;
+    }
+    UpdateDialogTests update_dialog_tests;
+    if (QTest::qExec(&update_dialog_tests) != 0) {
         fInvalid = true;
     }
     RPCNestedTests test3(app.node());

--- a/src/qt/test/updatedialogtests.cpp
+++ b/src/qt/test/updatedialogtests.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/updatedialogtests.h>
+
+#include <qt/networkstyle.h>
+#include <qt/updatecheckworker.h>
+#include <qt/utilitydialog.h>
+
+#include <univalue.h>
+
+#include <QPushButton>
+#include <QVariantMap>
+
+namespace {
+//! An update-check result, as showUpdateInfo receives it.
+QVariantMap Result(const QString& local, const QString& remote, const QString& artifact)
+{
+    QVariantMap info;
+    info["localversion"] = local;
+    info["remoteversion"] = remote;
+    info["updateavailable"] = local != remote;
+    info["message"] = QString{};
+    info["warning"] = QString{};
+    info["errors"] = QString{};
+    const QString base{QStringLiteral("https://download.reddcoin.com/bin/reddcoin-core-%1").arg(remote)};
+    info["officialDownloadLink"] = base;
+    info["platform"] = "x86_64-linux-gnu";
+    info["guiartifact"] = artifact;
+    info["guiartifactlink"] =
+        artifact.isEmpty() ? QString{} : QStringLiteral("%1/%2").arg(base, artifact);
+    return info;
+}
+
+//! Feed a result to the dialog the way the worker thread does.
+void Deliver(HelpMessageDialog& dialog, const QVariantMap& info)
+{
+    QMetaObject::invokeMethod(&dialog, "showUpdateInfo", Qt::DirectConnection,
+                              Q_ARG(QVariantMap, info));
+}
+
+int DownloadButtons(const HelpMessageDialog& dialog)
+{
+    int found{0};
+    for (const QPushButton* button : dialog.findChildren<QPushButton*>()) {
+        if (button->text().contains("Download")) ++found;
+    }
+    return found;
+}
+} // namespace
+
+void UpdateDialogTests::everyFieldTheDialogReadsSurvivesTheWorker()
+{
+    // The contract the other tests cannot see. They hand the dialog a map built
+    // in this file, which proves the dialog reads a map correctly and proves
+    // nothing about whether the worker ever puts those keys in one.
+    //
+    // It did not. The worker named seven fields while the dialog had grown to
+    // read ten, so guiartifact arrived empty and the dialog silently took its
+    // "no artifact published" branch on every update. The named-file notice
+    // phase 1 added never appeared through the real path, and no test noticed,
+    // because every test supplied its own map.
+    UniValue result{UniValue::VOBJ};
+    result.pushKV("localversion", "4.22.9.0");
+    result.pushKV("remoteversion", "4.22.9.4");
+    result.pushKV("updateavailable", true);
+    result.pushKV("message", "a message");
+    result.pushKV("warning", "");
+    result.pushKV("officialDownloadLink", "https://download.reddcoin.com/bin/reddcoin-core-4.22.9.4");
+    result.pushKV("hosttriplet", "x86_64-pc-linux-gnu");
+    result.pushKV("artifactbytes", 30603976);
+    result.pushKV("platform", "x86_64-linux-gnu");
+    result.pushKV("guiartifact", "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz");
+    result.pushKV("guiartifactlink", "https://download.reddcoin.com/x.tar.gz");
+    result.pushKV("daemonartifact", "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz");
+    result.pushKV("daemonartifactlink", "https://download.reddcoin.com/x.tar.gz");
+    result.pushKV("errors", "");
+
+    const QVariantMap info{UpdateInfoToVariantMap(result)};
+
+    // Nothing the node reports may be dropped on the way to the GUI.
+    for (const std::string& key : result.getKeys()) {
+        QVERIFY2(info.contains(QString::fromStdString(key)),
+                 qPrintable(QString{"the worker dropped '%1'"}.arg(QString::fromStdString(key))));
+    }
+
+    QCOMPARE(info.value("guiartifact").toString(),
+             QString{"reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz"});
+    QCOMPARE(info.value("platform").toString(), QString{"x86_64-linux-gnu"});
+    QCOMPARE(info.value("updateavailable").toBool(), true);
+    QCOMPARE(info.value("artifactbytes").toLongLong(), 30603976LL);
+
+    // And the dialog, fed what the worker actually produces rather than a map
+    // written to suit it, offers the download.
+    std::unique_ptr<const NetworkStyle> style{NetworkStyle::instantiate("regtest")};
+    QVERIFY(style);
+    HelpMessageDialog dialog{nullptr, style.get(), false, true, /*auto_check=*/false};
+    Deliver(dialog, info);
+    QCOMPARE(DownloadButtons(dialog), 1);
+}
+
+void UpdateDialogTests::downloadOfferedOnlyWithAnArtifact()
+{
+    std::unique_ptr<const NetworkStyle> style{NetworkStyle::instantiate("regtest")};
+    QVERIFY(style);
+
+    // Up to date: nothing to download, so nothing to offer.
+    {
+        HelpMessageDialog dialog{nullptr, style.get(), false, true, /*auto_check=*/false};
+        Deliver(dialog, Result("4.22.9.4", "4.22.9.4", ""));
+        QCOMPARE(DownloadButtons(dialog), 0);
+    }
+
+    // An update exists but no artifact is named for this host, which is the
+    // prerelease and unpublished-host case. Offering a download would mean
+    // offering a file whose name was never established.
+    {
+        HelpMessageDialog dialog{nullptr, style.get(), false, true, /*auto_check=*/false};
+        Deliver(dialog, Result("4.22.9.0", "4.22.9.4", ""));
+        QCOMPARE(DownloadButtons(dialog), 0);
+    }
+
+    // An update with a named artifact: this is the only case that gets a button.
+    {
+        HelpMessageDialog dialog{nullptr, style.get(), false, true, /*auto_check=*/false};
+        Deliver(dialog, Result("4.22.9.0", "4.22.9.4", "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz"));
+        QCOMPARE(DownloadButtons(dialog), 1);
+    }
+}
+
+void UpdateDialogTests::destroyingTheDialogIsSafe()
+{
+    // The worker lives on a thread the dialog owns and holds a reference to
+    // nothing the dialog deletes first, but the destructor still has to stop it
+    // before the widgets its signals update are gone. Constructing and
+    // destroying repeatedly is what would surface a mistake there.
+    std::unique_ptr<const NetworkStyle> style{NetworkStyle::instantiate("regtest")};
+    QVERIFY(style);
+
+    for (int i{0}; i < 5; ++i) {
+        HelpMessageDialog dialog{nullptr, style.get(), false, true, /*auto_check=*/false};
+        Deliver(dialog, Result("4.22.9.0", "4.22.9.4", "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz"));
+        QCOMPARE(DownloadButtons(dialog), 1);
+        // Destroyed here, with a worker created and its thread never started.
+    }
+    QVERIFY(true);
+}

--- a/src/qt/test/updatedialogtests.cpp
+++ b/src/qt/test/updatedialogtests.cpp
@@ -129,6 +129,43 @@ void UpdateDialogTests::downloadOfferedOnlyWithAnArtifact()
     }
 }
 
+void UpdateDialogTests::handOffWordingMatchesThePlatform()
+{
+    // The hand-off is the last step and it differs by platform, so what the
+    // button says has to match what pressing it does. Getting this wrong means
+    // telling a Linux user an installer will run when a file manager opens.
+    std::unique_ptr<const NetworkStyle> style{NetworkStyle::instantiate("regtest")};
+    QVERIFY(style);
+    HelpMessageDialog dialog{nullptr, style.get(), false, true, /*auto_check=*/false};
+    Deliver(dialog, Result("4.22.9.0", "4.22.9.4", "reddcoin-4.22.9.4-x86_64-linux-gnu.tar.gz"));
+
+    QPushButton* button{nullptr};
+    for (QPushButton* candidate : dialog.findChildren<QPushButton*>()) {
+        if (candidate->text().contains("Download")) button = candidate;
+    }
+    QVERIFY(button);
+
+    // Before a download there is nothing to hand off, so the button still
+    // offers the download rather than an action with no file behind it.
+    QVERIFY(button->text().contains("Download"));
+
+    // The wording after a successful download is the platform's, and on Linux
+    // it must not promise to install anything: B5 says the install shape there
+    // is not knowable at runtime, so the sequence ends at revealing the file.
+    QMetaObject::invokeMethod(&dialog, "onDownloadFinished", Qt::DirectConnection,
+                              Q_ARG(bool, true), Q_ARG(QString, "/tmp/artifact.tar.gz"),
+                              Q_ARG(qint64, 30603976), Q_ARG(QString, QString{}));
+
+#if defined(Q_OS_WIN)
+    QCOMPARE(button->text(), QString{"Run installer"});
+#elif defined(Q_OS_MACOS)
+    QCOMPARE(button->text(), QString{"Open disk image"});
+#else
+    QCOMPARE(button->text(), QString{"Show in folder"});
+    QVERIFY(!button->text().contains("install", Qt::CaseInsensitive));
+#endif
+}
+
 void UpdateDialogTests::destroyingTheDialogIsSafe()
 {
     // The worker lives on a thread the dialog owns and holds a reference to

--- a/src/qt/test/updatedialogtests.h
+++ b/src/qt/test/updatedialogtests.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_UPDATEDIALOGTESTS_H
+#define BITCOIN_QT_TEST_UPDATEDIALOGTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+/**
+ * The update dialog's download controls.
+ *
+ * None of these touch the network. What they cover is the wiring around the
+ * download, which is where this can go wrong quietly: whether the controls
+ * appear only when there is something to fetch, and whether a dialog carrying a
+ * worker thread can be destroyed safely.
+ */
+class UpdateDialogTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void everyFieldTheDialogReadsSurvivesTheWorker();
+    void downloadOfferedOnlyWithAnArtifact();
+    void destroyingTheDialogIsSafe();
+};
+
+#endif // BITCOIN_QT_TEST_UPDATEDIALOGTESTS_H

--- a/src/qt/test/updatedialogtests.h
+++ b/src/qt/test/updatedialogtests.h
@@ -23,6 +23,7 @@ class UpdateDialogTests : public QObject
 private Q_SLOTS:
     void everyFieldTheDialogReadsSurvivesTheWorker();
     void downloadOfferedOnlyWithAnArtifact();
+    void handOffWordingMatchesThePlatform();
     void destroyingTheDialogIsSafe();
 };
 

--- a/src/qt/updatecheckworker.cpp
+++ b/src/qt/updatecheckworker.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/updatecheckworker.h>
+
+#include <rpc/server.h>
+#include <univalue.h>
+
+#include <string>
+#include <vector>
+
+QVariantMap UpdateInfoToVariantMap(const UniValue& result)
+{
+    QVariantMap info;
+    if (!result.isObject()) return info;
+
+    // Every key, rather than the ones this happens to know about. The reader
+    // asks for what it needs; anything it does not need costs a map entry.
+    const std::vector<std::string>& keys{result.getKeys()};
+    const std::vector<UniValue>& values{result.getValues()};
+    for (size_t i = 0; i < keys.size() && i < values.size(); ++i) {
+        const QString key{QString::fromStdString(keys[i])};
+        switch (values[i].getType()) {
+        case UniValue::VBOOL:
+            info[key] = values[i].get_bool();
+            break;
+        case UniValue::VNUM:
+            info[key] = static_cast<qlonglong>(values[i].get_int64());
+            break;
+        case UniValue::VSTR:
+            info[key] = QString::fromStdString(values[i].get_str());
+            break;
+        default:
+            // Nothing else appears in an update check result today. Skipping is
+            // right rather than stringifying: a reader asking for a key that is
+            // not there gets an empty value, which is what it would have got
+            // from a field this could not represent anyway.
+            break;
+        }
+    }
+    return info;
+}
+
+void UpdateCheckWorker::check()
+{
+    // This line reaches the check through the RPC function directly rather than
+    // through interfaces::Node, which it does not route this call through.
+    UniValue result{UniValue::VOBJ};
+    checkforupdatesinfo(result);
+    Q_EMIT checked(UpdateInfoToVariantMap(result));
+}

--- a/src/qt/updatecheckworker.h
+++ b/src/qt/updatecheckworker.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_UPDATECHECKWORKER_H
+#define BITCOIN_QT_UPDATECHECKWORKER_H
+
+#include <QObject>
+#include <QVariantMap>
+
+class UniValue;
+
+/**
+ * Convert an update check result into the map the GUI reads.
+ *
+ * Copies every field rather than naming the ones wanted. An allow-list here
+ * drifts the moment the node reports something new: the reader goes on asking
+ * for a key nobody puts in, gets an empty string, and takes whichever branch
+ * empty means. That is not hypothetical, it is what happened when phase 1 added
+ * the artifact fields.
+ *
+ * Free and exposed so the mapping can be tested without constructing a node.
+ */
+QVariantMap UpdateInfoToVariantMap(const UniValue& result);
+
+/**
+ * Asks the node whether a newer release is available.
+ *
+ * The node performs a network request that can take seconds, so this must not
+ * run on the GUI thread. Move an instance onto a QThread, connect something to
+ * check() to start it and connect to checked() to receive the outcome. Both
+ * connections cross a thread boundary, so Qt queues them automatically.
+ */
+class UpdateCheckWorker : public QObject
+{
+    Q_OBJECT
+
+public:
+    UpdateCheckWorker() = default;
+
+public Q_SLOTS:
+    //! Run the check on whichever thread this object lives on.
+    void check();
+
+Q_SIGNALS:
+    //! Carries the fields of the checkupdates RPC, keyed by their RPC names.
+    void checked(const QVariantMap& info);
+};
+
+#endif // BITCOIN_QT_UPDATECHECKWORKER_H

--- a/src/qt/updatedownloadworker.cpp
+++ b/src/qt/updatedownloadworker.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/updatedownloadworker.h>
+
+#include <node/release_verify.h>
+#include <util/system.h>
+
+#include <string>
+
+void UpdateDownloadWorker::download()
+{
+    // Whole percentage points only. The callback below is invoked on every read
+    // of the socket, roughly 180 times a second, and a queued signal per read
+    // would spend more of the GUI thread on repainting than the transfer spends
+    // on arriving.
+    int last_percent{-1};
+
+    const node::DownloadProgress progress = [&](int64_t received, int64_t total) {
+        if (total <= 0) {
+            // No Content-Length, so there is no percentage to report. Emit
+            // sparingly on a byte boundary instead, which keeps a determinate
+            // bar from being faked out of nothing.
+            if (received / (1024 * 1024) == last_percent) return;
+            last_percent = static_cast<int>(received / (1024 * 1024));
+            Q_EMIT progressed(received, -1);
+            return;
+        }
+        const int percent{static_cast<int>((received * 100) / total)};
+        if (percent == last_percent) return;
+        last_percent = percent;
+        Q_EMIT progressed(received, total);
+    };
+
+    const node::DownloadCancel cancel = [this] { return m_cancelled.load(); };
+
+    node::StagedRelease staged;
+    std::string error;
+    const bool ok = node::StageVerifiedRelease(
+        m_version.toStdString(), m_artifact.toStdString(),
+        gArgs.GetDataDirNet() / "updates", progress, cancel, staged, error);
+
+    if (!ok) {
+        // A cancelled download reports no error, because the user asking for it
+        // to stop is not a failure to explain back to them.
+        Q_EMIT finished(false, QString{}, 0, QString::fromStdString(error));
+        return;
+    }
+
+    Q_EMIT finished(true, QString::fromStdString(staged.path.string()),
+                    static_cast<qint64>(staged.size), QString{});
+}

--- a/src/qt/updatedownloadworker.h
+++ b/src/qt/updatedownloadworker.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2014-2026 The Reddcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_UPDATEDOWNLOADWORKER_H
+#define BITCOIN_QT_UPDATEDOWNLOADWORKER_H
+
+#include <QObject>
+#include <QString>
+
+#include <atomic>
+
+/**
+ * Downloads a release and verifies it, off the GUI thread.
+ *
+ * The node's staging call blocks for as long as a 29 MB transfer takes, so this
+ * must not run on the GUI thread. Move an instance onto a QThread, connect
+ * something to download() to start it, and connect to progressed() and
+ * finished() to follow it. Both cross a thread boundary, so Qt queues them.
+ *
+ * A verified file is the only thing this produces. Nothing is installed and
+ * nothing is run.
+ */
+class UpdateDownloadWorker : public QObject
+{
+    Q_OBJECT
+
+public:
+    UpdateDownloadWorker(QString version, QString artifact)
+        : m_version{std::move(version)}, m_artifact{std::move(artifact)} {}
+
+public Q_SLOTS:
+    //! Run the download on whichever thread this object lives on.
+    void download();
+
+    /**
+     * Ask the download to stop.
+     *
+     * Safe to call from the GUI thread while download() is running, which is
+     * the point: it is the only member that is. The flag is read between reads
+     * of the socket, so cancelling takes effect at the next one rather than
+     * immediately, and never tears down an in-flight operation from underneath
+     * the thread performing it.
+     */
+    void cancel() { m_cancelled = true; }
+
+Q_SIGNALS:
+    /**
+     * Progress so far, and the total when the server declared one.
+     *
+     * Throttled to whole percentage points. The underlying callback fires
+     * around 180 times a second on a 29 MB artifact, which is a reasonable rate
+     * for a callback and far too high to drive a repaint, so the thinning
+     * happens here rather than leaving every consumer to remember it.
+     */
+    void progressed(qint64 received, qint64 total);
+
+    //! path and size are set when ok is true; error explains it when false, and
+    //! is empty when the download was cancelled, since that is not a failure.
+    void finished(bool ok, const QString& path, qint64 size, const QString& error);
+
+private:
+    QString m_version;
+    QString m_artifact;
+    std::atomic<bool> m_cancelled{false};
+};
+
+#endif // BITCOIN_QT_UPDATEDOWNLOADWORKER_H

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2011-2020 The Bitcoin Core developers
-// Copyright (c) 2014-2024 The Reddcoin Core developers
+// Copyright (c) 2014-2023 The Reddcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,17 +18,18 @@
 
 #include <clientversion.h>
 #include <init.h>
-#include <rpc/server.h>
-#include <univalue.h>
 #include <util/system.h>
 #include <util/strencodings.h>
 
 #include <stdio.h>
 
 #include <QCloseEvent>
+#include <QDesktopServices>
+#include <QFileInfo>
 #include <QLabel>
 #include <QProgressBar>
 #include <QPushButton>
+#include <QUrl>
 #include <QMainWindow>
 #include <QRegExp>
 #include <QTextCursor>
@@ -81,11 +82,9 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
             text = "Checking for updates. Please wait...";
             ui->aboutMessage->setText(text);
 
-            // The check performs a network request, and since phase 3c that is
-            // two of them, so it runs on a worker thread and showUpdateInfo()
-            // fills the dialog in once the answer arrives. Until then the
-            // "please wait" text above stands. Doing it here would freeze the
-            // window for as long as the slower of the two takes.
+            // The node performs a network request for this, so it runs on a
+            // worker thread and showUpdateInfo() fills the dialog in once the
+            // answer arrives. Until then the "please wait" text above stands.
             if (auto_check) startUpdateCheck();
         }
 
@@ -143,24 +142,6 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
     GUIUtil::handleCloseWindowShortcut(this);
 }
 
-HelpMessageDialog::~HelpMessageDialog()
-{
-    // An in flight request must not outlive the widgets its reply updates.
-    m_update_check_thread.quit();
-    m_update_check_thread.wait();
-
-    // A download can be minutes from finishing, so ask it to stop before
-    // waiting rather than blocking the close on a transfer nobody wants any
-    // more. quit() alone would not do it: the worker is inside a blocking call
-    // and is not reading the event loop, so it has to be told through the flag
-    // it polls between reads.
-    if (m_download_worker) m_download_worker->cancel();
-    m_download_thread.quit();
-    m_download_thread.wait();
-
-    delete ui;
-}
-
 void HelpMessageDialog::startUpdateCheck()
 {
     UpdateCheckWorker* worker = new UpdateCheckWorker();
@@ -171,64 +152,6 @@ void HelpMessageDialog::startUpdateCheck()
     connect(&m_update_check_thread, &QThread::started, worker, &UpdateCheckWorker::check);
 
     m_update_check_thread.start();
-}
-
-void HelpMessageDialog::showUpdateInfo(const QVariantMap& info)
-{
-    const QString localversion{info.value("localversion").toString()};
-    const QString remoteversion{info.value("remoteversion").toString()};
-    const QString errors{info.value("errors").toString()};
-    const QString warning{info.value("warning").toString()};
-
-    if (!errors.isEmpty()) {
-        text = "<font color = 'red'>Error: </font>";
-        text += errors;
-    } else if (localversion == remoteversion) {
-        text = "Installed version: <b>" + localversion + "</b><br>";
-        text += info.value("message").toString();
-    } else {
-        const QString artifact{info.value("guiartifact").toString()};
-        const QString artifact_link{info.value("guiartifactlink").toString()};
-
-        text = "Installed version: <b>" + localversion + "</b><br>";
-        text += "Latest repository version: <b>" + remoteversion + "</b><br><br>";
-
-        if (artifact.isEmpty() || artifact_link.isEmpty()) {
-            // Either no build is published for this host, or the release is a
-            // prerelease, whose artifact naming has never been exercised. Point
-            // at the directory and let the user choose, rather than name a file
-            // that may not be there.
-            const QString link{info.value("officialDownloadLink").toString()};
-            const QString url{"<a href=\"" + link + "\">" + link + "</a>"};
-            text += "Please download the latest version from our official website <br>(" + url + ").";
-        } else {
-            // The build this machine needs, rather than the directory holding
-            // fifteen files it would have to choose between.
-            text += "The build for this machine is:<br>";
-            text += "<a href=\"" + artifact_link + "\">" + artifact + "</a>";
-
-            addDownloadControls(remoteversion, artifact);
-
-            if (info.value("platform").toString() == "osx64") {
-                // Only an x86_64 macOS build is published, and it runs on Apple
-                // Silicon under Rosetta. Say which one it is rather than let an
-                // arm64 user assume it is native.
-                text += "<br><br>This is the Intel build. It runs on Apple Silicon under Rosetta.";
-            }
-        }
-    }
-
-    // The pre-release caution belongs on every outcome, not just one branch: it
-    // describes the build the user is running rather than anything the check
-    // discovered, so it is appended to whatever the text above ended up being.
-    if (!warning.isEmpty()) {
-        if (!text.isEmpty()) {
-            text += "<br><br>";
-        }
-        text += "<font color = 'red'>" + warning + "</font>";
-    }
-
-    ui->aboutMessage->setText(text);
 }
 
 void HelpMessageDialog::addDownloadControls(const QString& version, const QString& artifact)
@@ -318,7 +241,17 @@ void HelpMessageDialog::onDownloadFinished(bool ok, const QString& path, qint64 
             tr("Verified against the release signing key (%1 MB).<br>Saved to: %2")
                 .arg(size / (1024 * 1024))
                 .arg(path.toHtmlEscaped()));
-        m_download_button->setVisible(false);
+
+        // Hand it to the platform rather than acting on it. The client does not
+        // install anything and does not replace its own files, so the last step
+        // is always the user's.
+        m_downloaded_path = path;
+        m_download_button->setText(handOffLabel());
+        m_download_button->setToolTip(handOffTooltip());
+        disconnect(m_download_button, &QPushButton::clicked, this,
+                   &HelpMessageDialog::onDownloadClicked);
+        connect(m_download_button, &QPushButton::clicked, this,
+                &HelpMessageDialog::onHandOffClicked);
         return;
     }
 
@@ -327,6 +260,130 @@ void HelpMessageDialog::onDownloadFinished(bool ok, const QString& path, qint64 
         return;
     }
     m_download_status->setText("<font color='red'>" + error.toHtmlEscaped() + "</font>");
+}
+
+QString HelpMessageDialog::handOffLabel()
+{
+#if defined(Q_OS_WIN)
+    return tr("Run installer");
+#elif defined(Q_OS_MACOS)
+    return tr("Open disk image");
+#else
+    return tr("Show in folder");
+#endif
+}
+
+QString HelpMessageDialog::handOffTooltip()
+{
+#if defined(Q_OS_WIN)
+    return tr("Start the installer. %1 will not close itself; quit it before installing.")
+        .arg(PACKAGE_NAME);
+#elif defined(Q_OS_MACOS)
+    return tr("Open the disk image so the application can be dragged into Applications. "
+              "%1 will not close itself; quit it before replacing it.").arg(PACKAGE_NAME);
+#else
+    return tr("Open the folder containing the verified archive.");
+#endif
+}
+
+void HelpMessageDialog::onHandOffClicked()
+{
+    if (m_downloaded_path.isEmpty()) return;
+
+    // On Linux the install shape is not knowable from here. A tarball, a distro
+    // package, a Snap, a Flatpak and a container are all plausible and nothing
+    // in the client can tell which one this user is running, so opening the
+    // containing folder is the honest end of the sequence. Opening the archive
+    // itself would hand it to an archive manager, which is a guess.
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
+    const QUrl target{QUrl::fromLocalFile(m_downloaded_path)};
+#else
+    const QUrl target{QUrl::fromLocalFile(QFileInfo{m_downloaded_path}.absolutePath())};
+#endif
+
+    if (!QDesktopServices::openUrl(target)) {
+        // Do not leave the user with a button that silently does nothing. The
+        // file is verified and its path is already on screen above.
+        m_download_status->setText(
+            m_download_status->text() + "<br><font color='red'>" +
+            tr("Could not open it. The file is at the path above.").toHtmlEscaped() + "</font>");
+    }
+}
+
+void HelpMessageDialog::showUpdateInfo(const QVariantMap& info)
+{
+    const QString localversion{info.value("localversion").toString()};
+    const QString remoteversion{info.value("remoteversion").toString()};
+    const QString errors{info.value("errors").toString()};
+    const QString warning{info.value("warning").toString()};
+
+    if (!errors.isEmpty()) {
+        text = "<font color = 'red'>Error: </font>";
+        text += errors;
+    } else if (localversion == remoteversion) {
+        text = "Installed version: <b>" + localversion + "</b><br>";
+        text += info.value("message").toString();
+    } else {
+        const QString artifact{info.value("guiartifact").toString()};
+        const QString artifact_link{info.value("guiartifactlink").toString()};
+
+        text = "Installed version: <b>" + localversion + "</b><br>";
+        text += "Latest repository version: <b>" + remoteversion + "</b><br><br>";
+
+        if (artifact.isEmpty() || artifact_link.isEmpty()) {
+            // Either no build is published for this host, or the release is a
+            // prerelease, whose artifact naming has never been exercised. Point
+            // at the directory and let the user choose, rather than name a file
+            // that may not be there.
+            const QString link{info.value("officialDownloadLink").toString()};
+            const QString url{"<a href=\"" + link + "\">" + link + "</a>"};
+            text += "Please download the latest version from our official website <br>(" + url + ").";
+        } else {
+            // The build this machine needs, rather than the directory holding
+            // fifteen files it would have to choose between.
+            text += "The build for this machine is:<br>";
+            text += "<a href=\"" + artifact_link + "\">" + artifact + "</a>";
+
+            addDownloadControls(remoteversion, artifact);
+
+            if (info.value("platform").toString() == "osx64") {
+                // Only an x86_64 macOS build is published, and it runs on Apple
+                // Silicon under Rosetta. Say which one it is rather than let an
+                // arm64 user assume it is native.
+                text += "<br><br>This is the Intel build. It runs on Apple Silicon under Rosetta.";
+            }
+        }
+    }
+
+    // The pre-release caution belongs on every outcome, not just one branch: it
+    // describes the build the user is running rather than anything the check
+    // discovered, so it is appended to whatever the text above ended up being.
+    if (!warning.isEmpty()) {
+        if (!text.isEmpty()) {
+            text += "<br><br>";
+        }
+        text += "<font color = 'red'>" + warning + "</font>";
+    }
+
+    ui->aboutMessage->setText(text);
+}
+
+HelpMessageDialog::~HelpMessageDialog()
+{
+    // An in flight request must not outlive the widgets its reply updates.
+    m_update_check_thread.quit();
+    m_update_check_thread.wait();
+
+    // A download can be minutes from finishing, so ask it to stop before
+    // waiting rather than blocking the close on a transfer nobody wants any
+    // more. quit() alone would not do it: the worker is inside a blocking call
+    // and is not reading the event loop, so it has to be told through the flag
+    // it polls between reads.
+    if (m_download_worker) m_download_worker->cancel();
+    m_download_thread.quit();
+    m_download_thread.wait();
+
+    delete ui;
 }
 
 void HelpMessageDialog::printToConsole()

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -13,6 +13,7 @@
 
 #include <qt/guiutil.h>
 #include <qt/networkstyle.h>
+#include <qt/updatecheckworker.h>
 #include <qt/updatedownloadworker.h>
 
 #include <clientversion.h>
@@ -35,7 +36,7 @@
 #include <QVBoxLayout>
 
 /** "Help message" or "About" dialog box */
-HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networkStyle, bool about, bool checkUpdates) :
+HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networkStyle, bool about, bool checkUpdates, bool auto_check) :
     QDialog(parent, GUIUtil::dialog_flags),
     ui(new Ui::HelpMessageDialog)
 {
@@ -80,96 +81,12 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
             text = "Checking for updates. Please wait...";
             ui->aboutMessage->setText(text);
 
-            // Get checkforupdatesinfo from rpc server
-            UniValue result(UniValue::VOBJ);
-            checkforupdatesinfo(result);
-
-            //json_spirit::Object jsonObject = result.get_obj();
-            QString localversion = "";
-            QString remoteversion = "";
-            QString message = "";
-            QString warning = "";
-            QString officialDownloadLink = "";
-            QString errors = "";
-            QString platform = "";
-            QString guiArtifact = "";
-            QString guiArtifactLink = "";
-
-            if (result.exists("localversion")) {
-                localversion = QString::fromStdString(result["localversion"].get_str());
-            }
-            if (result.exists("remoteversion")) {
-                remoteversion = QString::fromStdString(result["remoteversion"].get_str());
-            }
-            if (result.exists("message")) {
-                message = QString::fromStdString(result["message"].get_str());
-            }
-            if (result.exists("warning")) {
-                warning = QString::fromStdString(result["warning"].get_str());
-            }
-            if (result.exists("officialDownloadLink")) {
-                officialDownloadLink = QString::fromStdString(result["officialDownloadLink"].get_str());
-            }
-            if (result.exists("errors")) {
-                errors = QString::fromStdString(result["errors"].get_str());
-            }
-            if (result.exists("platform")) {
-                platform = QString::fromStdString(result["platform"].get_str());
-            }
-            if (result.exists("guiartifact")) {
-                guiArtifact = QString::fromStdString(result["guiartifact"].get_str());
-            }
-            if (result.exists("guiartifactlink")) {
-                guiArtifactLink = QString::fromStdString(result["guiartifactlink"].get_str());
-            }
-
-            if (!errors.isEmpty()) {
-                text = "<font color = 'red'>Error: </font>";
-                text += errors;
-            } else if (localversion == remoteversion) {
-                text = "Installed version: <b>" + localversion  + "</b><br>";
-                text += message;
-            } else {
-                text = "Installed version: <b>" + localversion  + "</b><br>";
-                text += "Latest repository version: <b>" + remoteversion + "</b><br><br>";
-
-                if (guiArtifact.isEmpty() || guiArtifactLink.isEmpty()) {
-                    // Either no build is published for this host, or the release
-                    // is a prerelease, whose artifact naming has never been
-                    // exercised. Point at the directory and let the user choose,
-                    // rather than name a file that may not be there.
-                    QString url = "<a href=\""+ officialDownloadLink +"\">"+ officialDownloadLink +"</a>";
-                    text += "Please download the latest version from our official website <br>(" + url + ").";
-                } else {
-                    // The build this machine needs, rather than the directory
-                    // holding fifteen files it would have to choose between.
-                    text += "The build for this machine is:<br>";
-                    text += "<a href=\"" + guiArtifactLink + "\">" + guiArtifact + "</a>";
-
-                    addDownloadControls(remoteversion, guiArtifact);
-
-                    if (platform == "osx64") {
-                        // Only an x86_64 macOS build is published, and it runs on
-                        // Apple Silicon under Rosetta. Say which one it is rather
-                        // than let an arm64 user assume it is native.
-                        text += "<br><br>This is the Intel build. It runs on Apple Silicon under Rosetta.";
-                    }
-                }
-            }
-
-            // The pre-release caution belongs on every outcome, not just one
-            // branch: it describes the build the user is running rather than
-            // anything the check discovered, so it is appended to whatever the
-            // text above ended up being.
-            if (!warning.isEmpty()) {
-                if (!text.isEmpty()) {
-                    text += "<br><br>";
-                }
-                text += "<font color = 'red'>" + warning + "</font>";
-            }
-
-            ui->aboutMessage->setText(text);
-
+            // The check performs a network request, and since phase 3c that is
+            // two of them, so it runs on a worker thread and showUpdateInfo()
+            // fills the dialog in once the answer arrives. Until then the
+            // "please wait" text above stands. Doing it here would freeze the
+            // window for as long as the slower of the two takes.
+            if (auto_check) startUpdateCheck();
         }
 
 
@@ -228,6 +145,10 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
 
 HelpMessageDialog::~HelpMessageDialog()
 {
+    // An in flight request must not outlive the widgets its reply updates.
+    m_update_check_thread.quit();
+    m_update_check_thread.wait();
+
     // A download can be minutes from finishing, so ask it to stop before
     // waiting rather than blocking the close on a transfer nobody wants any
     // more. quit() alone would not do it: the worker is inside a blocking call
@@ -238,6 +159,76 @@ HelpMessageDialog::~HelpMessageDialog()
     m_download_thread.wait();
 
     delete ui;
+}
+
+void HelpMessageDialog::startUpdateCheck()
+{
+    UpdateCheckWorker* worker = new UpdateCheckWorker();
+    worker->moveToThread(&m_update_check_thread);
+
+    connect(worker, &UpdateCheckWorker::checked, this, &HelpMessageDialog::showUpdateInfo);
+    connect(&m_update_check_thread, &QThread::finished, worker, &UpdateCheckWorker::deleteLater);
+    connect(&m_update_check_thread, &QThread::started, worker, &UpdateCheckWorker::check);
+
+    m_update_check_thread.start();
+}
+
+void HelpMessageDialog::showUpdateInfo(const QVariantMap& info)
+{
+    const QString localversion{info.value("localversion").toString()};
+    const QString remoteversion{info.value("remoteversion").toString()};
+    const QString errors{info.value("errors").toString()};
+    const QString warning{info.value("warning").toString()};
+
+    if (!errors.isEmpty()) {
+        text = "<font color = 'red'>Error: </font>";
+        text += errors;
+    } else if (localversion == remoteversion) {
+        text = "Installed version: <b>" + localversion + "</b><br>";
+        text += info.value("message").toString();
+    } else {
+        const QString artifact{info.value("guiartifact").toString()};
+        const QString artifact_link{info.value("guiartifactlink").toString()};
+
+        text = "Installed version: <b>" + localversion + "</b><br>";
+        text += "Latest repository version: <b>" + remoteversion + "</b><br><br>";
+
+        if (artifact.isEmpty() || artifact_link.isEmpty()) {
+            // Either no build is published for this host, or the release is a
+            // prerelease, whose artifact naming has never been exercised. Point
+            // at the directory and let the user choose, rather than name a file
+            // that may not be there.
+            const QString link{info.value("officialDownloadLink").toString()};
+            const QString url{"<a href=\"" + link + "\">" + link + "</a>"};
+            text += "Please download the latest version from our official website <br>(" + url + ").";
+        } else {
+            // The build this machine needs, rather than the directory holding
+            // fifteen files it would have to choose between.
+            text += "The build for this machine is:<br>";
+            text += "<a href=\"" + artifact_link + "\">" + artifact + "</a>";
+
+            addDownloadControls(remoteversion, artifact);
+
+            if (info.value("platform").toString() == "osx64") {
+                // Only an x86_64 macOS build is published, and it runs on Apple
+                // Silicon under Rosetta. Say which one it is rather than let an
+                // arm64 user assume it is native.
+                text += "<br><br>This is the Intel build. It runs on Apple Silicon under Rosetta.";
+            }
+        }
+    }
+
+    // The pre-release caution belongs on every outcome, not just one branch: it
+    // describes the build the user is running rather than anything the check
+    // discovered, so it is appended to whatever the text above ended up being.
+    if (!warning.isEmpty()) {
+        if (!text.isEmpty()) {
+            text += "<br><br>";
+        }
+        text += "<font color = 'red'>" + warning + "</font>";
+    }
+
+    ui->aboutMessage->setText(text);
 }
 
 void HelpMessageDialog::addDownloadControls(const QString& version, const QString& artifact)

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -13,6 +13,7 @@
 
 #include <qt/guiutil.h>
 #include <qt/networkstyle.h>
+#include <qt/updatedownloadworker.h>
 
 #include <clientversion.h>
 #include <init.h>
@@ -25,6 +26,8 @@
 
 #include <QCloseEvent>
 #include <QLabel>
+#include <QProgressBar>
+#include <QPushButton>
 #include <QMainWindow>
 #include <QRegExp>
 #include <QTextCursor>
@@ -143,6 +146,8 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
                     text += "The build for this machine is:<br>";
                     text += "<a href=\"" + guiArtifactLink + "\">" + guiArtifact + "</a>";
 
+                    addDownloadControls(remoteversion, guiArtifact);
+
                     if (platform == "osx64") {
                         // Only an x86_64 macOS build is published, and it runs on
                         // Apple Silicon under Rosetta. Say which one it is rather
@@ -223,7 +228,114 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, const NetworkStyle* networ
 
 HelpMessageDialog::~HelpMessageDialog()
 {
+    // A download can be minutes from finishing, so ask it to stop before
+    // waiting rather than blocking the close on a transfer nobody wants any
+    // more. quit() alone would not do it: the worker is inside a blocking call
+    // and is not reading the event loop, so it has to be told through the flag
+    // it polls between reads.
+    if (m_download_worker) m_download_worker->cancel();
+    m_download_thread.quit();
+    m_download_thread.wait();
+
     delete ui;
+}
+
+void HelpMessageDialog::addDownloadControls(const QString& version, const QString& artifact)
+{
+    // Built here rather than in the .ui file because they exist only on the
+    // update path, and only when there is a named artifact to fetch.
+    m_download_status = new QLabel{this};
+    m_download_status->setWordWrap(true);
+    m_download_status->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+    m_download_progress = new QProgressBar{this};
+    m_download_progress->setRange(0, 100);
+    m_download_progress->setValue(0);
+    m_download_progress->setVisible(false);
+
+    m_download_button = new QPushButton{tr("Download and verify"), this};
+    m_download_button->setToolTip(
+        tr("Download %1 and check it against the signing key built into this client. "
+           "Nothing is installed.").arg(artifact));
+
+    if (QLayout* layout = this->layout()) {
+        layout->addWidget(m_download_status);
+        layout->addWidget(m_download_progress);
+        layout->addWidget(m_download_button);
+    }
+
+    m_download_worker = new UpdateDownloadWorker{version, artifact};
+    m_download_worker->moveToThread(&m_download_thread);
+
+    connect(&m_download_thread, &QThread::finished, m_download_worker, &QObject::deleteLater);
+    connect(&m_download_thread, &QThread::started, m_download_worker, &UpdateDownloadWorker::download);
+    connect(m_download_worker, &UpdateDownloadWorker::progressed,
+            this, &HelpMessageDialog::onDownloadProgress);
+    connect(m_download_worker, &UpdateDownloadWorker::finished,
+            this, &HelpMessageDialog::onDownloadFinished);
+    connect(m_download_button, &QPushButton::clicked, this, &HelpMessageDialog::onDownloadClicked);
+}
+
+void HelpMessageDialog::onDownloadClicked()
+{
+    if (m_download_thread.isRunning()) {
+        // Second click cancels. The worker checks the flag between reads, so
+        // the transfer stops at the next one rather than being torn down from
+        // under the thread performing it.
+        m_download_button->setEnabled(false);
+        m_download_button->setText(tr("Cancelling..."));
+        if (m_download_worker) m_download_worker->cancel();
+        return;
+    }
+
+    m_download_progress->setValue(0);
+    m_download_progress->setVisible(true);
+    m_download_status->setText(tr("Downloading..."));
+    m_download_button->setText(tr("Cancel"));
+    m_download_thread.start();
+}
+
+void HelpMessageDialog::onDownloadProgress(qint64 received, qint64 total)
+{
+    if (total > 0) {
+        m_download_progress->setRange(0, 100);
+        m_download_progress->setValue(static_cast<int>((received * 100) / total));
+        m_download_status->setText(tr("Downloading... %1 of %2 MB")
+                                       .arg(received / (1024 * 1024))
+                                       .arg(total / (1024 * 1024)));
+        return;
+    }
+
+    // No declared length, so there is no honest percentage to show. A busy
+    // indicator says "working" without inventing a position.
+    m_download_progress->setRange(0, 0);
+    m_download_status->setText(tr("Downloading... %1 MB so far").arg(received / (1024 * 1024)));
+}
+
+void HelpMessageDialog::onDownloadFinished(bool ok, const QString& path, qint64 size,
+                                           const QString& error)
+{
+    m_download_thread.quit();
+    m_download_progress->setVisible(false);
+    m_download_button->setEnabled(true);
+    m_download_button->setText(tr("Download and verify"));
+
+    if (ok) {
+        // Say what was actually established. "Downloaded" would undersell it
+        // and "installed" would be untrue.
+        m_download_status->setText(
+            tr("Verified against the release signing key (%1 MB).<br>Saved to: %2")
+                .arg(size / (1024 * 1024))
+                .arg(path.toHtmlEscaped()));
+        m_download_button->setVisible(false);
+        return;
+    }
+
+    if (error.isEmpty()) {
+        m_download_status->setText(tr("Download cancelled."));
+        return;
+    }
+    m_download_status->setText("<font color='red'>" + error.toHtmlEscaped() + "</font>");
 }
 
 void HelpMessageDialog::printToConsole()

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2011-2020 The Bitcoin Core developers
-// Copyright (c) 2014-2024 The Reddcoin Core developers
+// Copyright (c) 2014-2023 The Reddcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -20,6 +20,10 @@ class QProgressBar;
 class QPushButton;
 QT_END_NAMESPACE
 
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
 QT_BEGIN_NAMESPACE
 class QMainWindow;
 QT_END_NAMESPACE
@@ -34,6 +38,8 @@ class HelpMessageDialog : public QDialog
     Q_OBJECT
 
 public:
+    //! node is only needed when checkUpdates is set, since the update check is
+    //! performed by the node rather than by the GUI.
     /**
      * @param[in] auto_check Start the update check on construction. Tests pass
      *                       false to build the dialog without performing the
@@ -51,22 +57,27 @@ private:
     /** Create the update check worker and start the thread it runs on */
     void startUpdateCheck();
 
+    /** Platform-appropriate wording for the hand-off button */
+    static QString handOffLabel();
+    static QString handOffTooltip();
+
     /** Add the download button and progress bar, once there is something to offer */
     void addDownloadControls(const QString& version, const QString& artifact);
 
     Ui::HelpMessageDialog *ui;
     QString text;
-
-    /** Thread the update check runs on, so its network requests cannot stall the GUI */
+    /** Thread the update check runs on, so its network request cannot stall the GUI */
     QThread m_update_check_thread;
 
-    /** Thread the download runs on, so a 29 MB transfer cannot stall the GUI */
+    /** Thread the download runs on, for the same reason and for much longer */
     QThread m_download_thread;
     /** Owned by m_download_thread, which deletes it when it finishes */
     UpdateDownloadWorker* m_download_worker{nullptr};
     QPushButton* m_download_button{nullptr};
     QProgressBar* m_download_progress{nullptr};
     QLabel* m_download_status{nullptr};
+    /** Where the verified artifact landed, once there is one */
+    QString m_downloaded_path;
 
 private Q_SLOTS:
     void on_okButton_accepted();
@@ -79,6 +90,8 @@ private Q_SLOTS:
     void onDownloadProgress(qint64 received, qint64 total);
     /** Report where the verified file is, or why there is not one */
     void onDownloadFinished(bool ok, const QString& path, qint64 size, const QString& error);
+    /** Hand the verified file to the platform. Never acts on it here */
+    void onHandOffClicked();
 };
 
 

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -7,9 +7,17 @@
 #define BITCOIN_QT_UTILITYDIALOG_H
 
 #include <QDialog>
+#include <QThread>
 #include <QWidget>
 
 class NetworkStyle;
+class UpdateDownloadWorker;
+
+QT_BEGIN_NAMESPACE
+class QLabel;
+class QProgressBar;
+class QPushButton;
+QT_END_NAMESPACE
 
 QT_BEGIN_NAMESPACE
 class QMainWindow;
@@ -32,11 +40,29 @@ public:
     void showOrPrint();
 
 private:
+    /** Add the download button and progress bar, once there is something to offer */
+    void addDownloadControls(const QString& version, const QString& artifact);
+
     Ui::HelpMessageDialog *ui;
     QString text;
 
+    /** Thread the download runs on, so a 29 MB transfer cannot stall the GUI */
+    QThread m_download_thread;
+    /** Owned by m_download_thread, which deletes it when it finishes */
+    UpdateDownloadWorker* m_download_worker{nullptr};
+    QPushButton* m_download_button{nullptr};
+    QProgressBar* m_download_progress{nullptr};
+    QLabel* m_download_status{nullptr};
+
 private Q_SLOTS:
     void on_okButton_accepted();
+
+    /** Start the download, or ask a running one to stop */
+    void onDownloadClicked();
+    /** Move the bar. Queued from the worker thread, already throttled there */
+    void onDownloadProgress(qint64 received, qint64 total);
+    /** Report where the verified file is, or why there is not one */
+    void onDownloadFinished(bool ok, const QString& path, qint64 size, const QString& error);
 };
 
 

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -8,6 +8,7 @@
 
 #include <QDialog>
 #include <QThread>
+#include <QVariantMap>
 #include <QWidget>
 
 class NetworkStyle;
@@ -33,18 +34,31 @@ class HelpMessageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit HelpMessageDialog(QWidget *parent, const NetworkStyle *networkStyle, bool about, bool checkUpdates);
+    /**
+     * @param[in] auto_check Start the update check on construction. Tests pass
+     *                       false to build the dialog without performing the
+     *                       network requests it would otherwise make, which is
+     *                       the same thing develop achieves by passing it no
+     *                       node.
+     */
+    explicit HelpMessageDialog(QWidget *parent, const NetworkStyle *networkStyle, bool about, bool checkUpdates, bool auto_check = true);
     ~HelpMessageDialog();
 
     void printToConsole();
     void showOrPrint();
 
 private:
+    /** Create the update check worker and start the thread it runs on */
+    void startUpdateCheck();
+
     /** Add the download button and progress bar, once there is something to offer */
     void addDownloadControls(const QString& version, const QString& artifact);
 
     Ui::HelpMessageDialog *ui;
     QString text;
+
+    /** Thread the update check runs on, so its network requests cannot stall the GUI */
+    QThread m_update_check_thread;
 
     /** Thread the download runs on, so a 29 MB transfer cannot stall the GUI */
     QThread m_download_thread;
@@ -56,6 +70,8 @@ private:
 
 private Q_SLOTS:
     void on_okButton_accepted();
+    /** Replace the "please wait" text once the check has an answer */
+    void showUpdateInfo(const QVariantMap& info);
 
     /** Start the download, or ask a running one to stop */
     void onDownloadClicked();

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -8,6 +8,7 @@
 
 #include <clientversion.h>
 #include <rpc/util.h>
+#include <node/release_verify.h>
 #include <node/update_check.h>
 #include <shutdown.h>
 #include <sync.h>
@@ -316,6 +317,81 @@ void checkforupdatesinfo(UniValue& result)
     node::CheckForUpdates(result);
 }
 
+static RPCHelpMan downloadupdate()
+{
+    return RPCHelpMan{"downloadupdate",
+        "\nDownload the current release and verify it against the signing key built into this "
+        "client.\n"
+        "\nThe file is only kept if its hash matches a manifest that key signed, so a successful "
+        "call means the artifact on disk is the one the release manager published. Nothing is "
+        "installed: this client never replaces its own files.\n"
+        "\nRe-running is cheap. An artifact already downloaded and still correct is not fetched "
+        "again.\n",
+        {
+            {"artifact", RPCArg::Type::STR, RPCArg::Default{"daemon"},
+             "Which build to fetch, \"daemon\" or \"gui\". They are the same file on Linux; on "
+             "Windows and macOS the gui build is the installer and the daemon build is the archive"},
+        },
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "version", "Version that was downloaded"},
+                {RPCResult::Type::STR, "artifact", "Filename that was downloaded"},
+                {RPCResult::Type::STR, "path", "Where the verified file is"},
+                {RPCResult::Type::NUM, "size", "Its size in bytes"},
+                {RPCResult::Type::BOOL, "verified", "Always true. A file that did not verify is deleted rather than reported"},
+            }},
+        RPCExamples{HelpExampleCli("downloadupdate", "") +
+                    HelpExampleCli("downloadupdate", "gui") +
+                    HelpExampleRpc("downloadupdate", "\"gui\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    // Defaults to the daemon build because this is the RPC: a reddcoind
+    // operator is who reaches it. The Qt console can ask for "gui", and the
+    // GUI itself will call the node directly rather than through here.
+    const std::string which{request.params[0].isNull() ? "daemon" : request.params[0].get_str()};
+    if (which != "daemon" && which != "gui") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "artifact must be \"daemon\" or \"gui\"");
+    }
+
+    // Ask what the current release is, rather than taking a version from the
+    // caller. A caller-supplied version would let this be pointed at anything
+    // on the server, and the answer to "which release" belongs in one place.
+    UniValue check(UniValue::VOBJ);
+    node::CheckForUpdates(check);
+
+    const std::string errors{check["errors"].isNull() ? "" : check["errors"].get_str()};
+    if (!errors.empty()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Could not determine the current release: " + errors);
+    }
+
+    const std::string version{check["remoteversion"].isNull() ? "" : check["remoteversion"].get_str()};
+    const std::string field{which == "gui" ? "guiartifact" : "daemonartifact"};
+    const std::string artifact{check[field].isNull() ? "" : check[field].get_str()};
+    if (version.empty() || artifact.empty()) {
+        throw JSONRPCError(RPC_MISC_ERROR,
+                           "No published build is known for this host, so there is nothing to download");
+    }
+
+    node::StagedRelease staged;
+    std::string error;
+    if (!node::StageVerifiedRelease(version, artifact, gArgs.GetDataDirNet() / "updates",
+                                    node::DownloadProgress{}, node::DownloadCancel{}, staged,
+                                    error)) {
+        throw JSONRPCError(RPC_MISC_ERROR, error.empty() ? "Download cancelled" : error);
+    }
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("version", version);
+    result.pushKV("artifact", staged.filename);
+    result.pushKV("path", staged.path.string());
+    result.pushKV("size", staged.size);
+    result.pushKV("verified", true);
+    return result;
+}
+    };
+}
+
 // clang-format off
 static const CRPCCommand vRPCCommands[] =
 { //  category               actor (function)
@@ -326,6 +402,7 @@ static const CRPCCommand vRPCCommands[] =
     { "control",             &stop,                   },
     { "control",             &uptime,                 },
     { "control",             &checkupdates,           },
+    { "control",             &downloadupdate,         },
 };
 // clang-format on
 


### PR DESCRIPTION
Phase 5c backport, the last slice of RED-98.

Once a download has been verified, the button becomes the platform's own next step rather than staying a download button with nothing left to download.

| Platform | Button | Action |
| --- | --- | --- |
| Windows | Run installer | opens the installer |
| macOS | Open disk image | opens the `.dmg` |
| Linux | Show in folder | opens the containing directory |

## Linux stops at revealing the file, deliberately

The install shape is not knowable from inside the client: a tarball, a distro package, a Snap, a Flatpak and a container are all plausible, and nothing here can tell which one this user is running. Opening the archive would hand it to an archive manager, which is a guess dressed up as help. That is **B5**, and it has been the plan since the tiers were chosen.

**Nothing is installed and nothing is executed on the user's behalf.** The client does not replace its own files; the last action is always the user's. That is what Tier 2 meant when Tier 3 was rejected.

## Details worth reviewing

The tooltip says the client will not close itself, because on Windows and macOS the next thing that happens is an installer wanting to replace a running application.

A hand-off that fails says so rather than leaving a button that silently does nothing. The file is verified and its path is already on screen.

The test asserts the wording matches the platform, and specifically that the **Linux label does not promise to install anything**. Telling a Linux user an installer will run when a file manager opens is the mistake available here.

## This was a copy across, which is the point

RED-121 was done first precisely so this would be. The two dialogs now differ only where they must: this line has no `interfaces::Node` to gate the check on, so it gates on `auto_check` instead. The download worker and the test header are **byte identical** to develop's.

## ⚠ Stacked

This branches from `qt/async-update-check-4.22.9` (#541), which branches from `qt/update-download-dialog-4.22.9` (#540), which branches from `rpc/download-update-4.22.9` (#538). Merge order: **#538, #540, #541, then this**. Each merge shrinks the next PR's diff to its own commit.

YouTrack: https://reddink.youtrack.cloud/issue/RED-120
