### PR TITLE
qt: include <memory> where the test uses unique_ptr

### DIFF
--- a/src/qt/test/updatedialogtests.cpp
+++ b/src/qt/test/updatedialogtests.cpp
@@ -13,6 +13,8 @@
 #include <QPushButton>
 #include <QVariantMap>
 
+#include <memory>
+
 namespace {
 //! An update-check result, as showUpdateInfo receives it.
 QVariantMap Result(const QString& local, const QString& remote, const QString& artifact)


### PR DESCRIPTION
**Fixes the build on develop.** `qt/test/updatedialogtests.cpp` uses `std::unique_ptr` and never included `<memory>`.

```
qt/test/updatedialogtests.cpp:96:10: error: 'unique_ptr' is not a member of 'std'
```

Every other error in that job cascades from this one; it is the only file that failed.

## Why it got through

It compiled on my machine, and in the `qt5` job's sibling configurations, because something upstream happens to pull `<memory>` in. It did not on the `previous releases, qt5, DEBUG` toolchain. A missing include that a transitive one hides compiles for whoever wrote it and for nobody else, which is why the fix is the include rather than relying on the chain that happened to work.

I checked the other files added across phases 3 to 5 for the same class of mistake. `updatedownloadworker.cpp`, `updatecheckworker.cpp` and `release_verify.cpp` all include what they use.

## Not the only red job on that run

Two others failed and neither is this:

- `32-bit + dash, gui [CentOS 9]` is RED-111, which fails before any project code compiles
- `MSan, depends` is still being looked at and is not this file

The same fix is going to `v4.22.9-regtest`, where the identical file landed and where only Codacy runs, so nothing there would have caught it.
