### PR TITLE
qt: include <memory> where the test uses unique_ptr

### DIFF
--- a/src/qt/test/updatedialogtests.cpp
+++ b/src/qt/test/updatedialogtests.cpp
@@ -13,6 +13,8 @@
 #include <QPushButton>
 #include <QVariantMap>
 
+#include <memory>
+
 namespace {
 //! An update-check result, as showUpdateInfo receives it.
 QVariantMap Result(const QString& local, const QString& remote, const QString& artifact)


### PR DESCRIPTION
Same fix as the develop PR, applied here because the identical file landed on this line.

`qt/test/updatedialogtests.cpp` uses `std::unique_ptr` and never included `<memory>`. On develop it broke the `previous releases, qt5, DEBUG` job:

```
qt/test/updatedialogtests.cpp:96:10: error: 'unique_ptr' is not a member of 'std'
```

It compiles on my toolchain and on most of the CI matrix because something upstream happens to pull `<memory>` in.

**Nothing here would have caught it.** Only Codacy runs against this base, so this line has no build signal at all. Fixing it in both places rather than waiting for it to surface on whichever compiler notices first.

Verified locally: build clean including `reddcoin-qt`, and 14 + 9 + 9 + 27 unit tests plus the six dialog tests pass.
