### PR TITLE
test: stop a unit test performing real network requests

### DIFF
--- a/src/qt/test/updatedialogtests.cpp
+++ b/src/qt/test/updatedialogtests.cpp
@@ -13,6 +13,8 @@
 #include <QPushButton>
 #include <QVariantMap>
 
+#include <memory>
+
 namespace {
 //! An update-check result, as showUpdateInfo receives it.
 QVariantMap Result(const QString& local, const QString& remote, const QString& artifact)

--- a/src/test/release_verify_tests.cpp
+++ b/src/test/release_verify_tests.cpp
@@ -222,25 +222,12 @@ BOOST_AUTO_TEST_CASE(the_real_published_release_verifies)
 //! decisions around it, what is kept, what is thrown away, are the part that
 //! can be got wrong quietly and are testable here.
 
-BOOST_AUTO_TEST_CASE(a_manifest_the_key_did_not_sign_stages_nothing)
-{
-    // The ordering that matters: verification precedes everything. A staging
-    // directory should not so much as be created for a manifest that fails.
-    const fs::path root{gArgs.GetDataDirNet() / "staging-unsigned"};
-    StagedRelease staged;
-    std::string error;
-
-    // No network is reached: the version is one no server will answer for, so
-    // this fails at the fetch. The point is that it fails without leaving a
-    // directory behind.
-    BOOST_CHECK(!node::StageVerifiedRelease("0.0.0-nonexistent", "whatever.tar.gz", root,
-                                            node::DownloadProgress{},
-                                            [] { return true; }, staged, error));
-    BOOST_CHECK(!fs::exists(root));
-}
-
 BOOST_AUTO_TEST_CASE(staging_refuses_an_empty_version_or_name)
 {
+    // These are the arguments StageVerifiedRelease rejects before it fetches
+    // anything, which is what makes them safe to assert here. Anything that
+    // reaches the fetch performs real DNS and TLS, so it does not belong in a
+    // unit test however certain the failure is.
     const fs::path root{gArgs.GetDataDirNet() / "staging-empty"};
     StagedRelease staged;
     std::string error;


### PR DESCRIPTION
**Fixes the MSan job**, which failed on develop after the phase 5 merge. The failure looked like it was inside OpenSSL; it was mine.

```
MemorySanitizer: use-of-uninitialized-value
  in drbg_ctr_generate  (openssl 3.5.7)
  ...
  #11 SSL_CTX_new
  #14 HttpsConnection::HttpsConnection
  #16 node::FetchToString
  #17 node::StageVerifiedRelease
  #18 release_verify_tests::a_manifest_the_key_did_not_sign_stages_nothing
```

## What was actually wrong

That test called `StageVerifiedRelease` with a version no server publishes, and carried a comment I wrote saying:

> No network is reached: the version is one no server will answer for, so this fails at the fetch.

**The comment was wrong.** Failing *at* the fetch means performing the fetch. It resolved a name, built a TLS context and opened a connection, on every run of the unit tests.

MSan is what surfaced it, and only incidentally: OpenSSL comes from `depends` uninstrumented, so its DRBG reads trip a use-of-uninitialized-value the moment an SSL context is constructed. **The sanitiser finding is an artifact of the uninstrumented dependency. The test making the call at all is the real defect**, and it was there on every machine, silently doing DNS and TLS in a unit test.

## Fix

Remove it. What it asserted, that a failure leaves no staging directory behind, is already covered by the empty-argument test, which is rejected before anything is fetched and is therefore safe to assert. That test now says so explicitly, so the next person does not reintroduce a network call on the grounds that the failure is certain.

## Verified by removing the network, not by reasoning about it

```
release_verify_tests     PASS  (inside a network namespace, no connectivity)
release_manifest_tests   PASS
release_artifacts_tests  PASS
update_check_tests       PASS
UpdateDialogTests        PASS
```

`release_verify_tests` now runs in **0.16 seconds**, which a DNS lookup and TLS handshake could not fit inside.

I would rather this check were permanent than rely on me remembering. Running the suite under `unshare -r -n` is a cheap way to keep it honest, and worth considering for CI.