### PR TITLE
miner: fix out-of-bounds erase in RegenerateCommitments

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -82,7 +82,9 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman)
 {
     CMutableTransaction tx{*block.vtx.at(0)};
-    tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
+    if (GetWitnessCommitmentIndex(block) != NO_WITNESS_COMMITMENT) {
+        tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
+    }
     block.vtx.at(0) = MakeTransactionRef(tx);
 
     CBlockIndex* prev_block = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block.hashPrevBlock));

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -134,7 +134,10 @@ void BumpFee(TransactionView& view, const uint256& txid, bool expectDisabled, st
 //     QT_QPA_PLATFORM=cocoa   src/qt/test/test_bitcoin-qt  # macOS
 void TestGUI(interfaces::Node& node)
 {
-    // Set up wallet and chain with 105 blocks (5 mature blocks for spending).
+    // Set up wallet and chain. TestChain100Setup mines nCoinbaseMaturity (60)
+    // blocks here, at which height no coinbase has matured yet, so five more
+    // are needed before anything is spendable. Heights 61-65 are still at or
+    // below nLastPowHeight = 89, so these are valid PoW blocks.
     TestChain100Setup test;
     for (int i = 0; i < 5; ++i) {
         test.CreateAndProcessBlock({}, GetScriptForRawPubKey(test.coinbaseKey.GetPubKey()));
@@ -147,7 +150,7 @@ void TestGUI(interfaces::Node& node)
         LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
         wallet->SetAddressBook(GetDestinationForKey(test.coinbaseKey.GetPubKey(), wallet->m_default_address_type), "", "receive");
         spk_man->AddKeyPubKey(test.coinbaseKey, test.coinbaseKey.GetPubKey());
-        wallet->SetLastBlockProcessed(105, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+        wallet->SetLastBlockProcessed(node.context()->chainman->ActiveChain().Height(), node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
     }
     {
         WalletRescanReserver reserver(*wallet);
@@ -182,11 +185,14 @@ void TestGUI(interfaces::Node& node)
     }
 
     // Send two transactions, and verify they are added to transaction list.
+    // The number of pre-existing wallet transactions follows the height of the
+    // chain the fixture built, so assert relative to the initial count rather
+    // than a hardcoded total.
     TransactionTableModel* transactionTableModel = walletModel.getTransactionTableModel();
-    QCOMPARE(transactionTableModel->rowCount({}), 105);
+    const int initial_tx_rows = transactionTableModel->rowCount({});
     uint256 txid1 = SendCoins(*wallet.get(), sendCoinsDialog, PKHash(), 5 * COIN, false /* rbf */);
     uint256 txid2 = SendCoins(*wallet.get(), sendCoinsDialog, PKHash(), 10 * COIN, true /* rbf */);
-    QCOMPARE(transactionTableModel->rowCount({}), 107);
+    QCOMPARE(transactionTableModel->rowCount({}), initial_tx_rows + 2);
     QVERIFY(FindTx(*transactionTableModel, txid1).isValid());
     QVERIFY(FindTx(*transactionTableModel, txid2).isValid());
 
@@ -232,7 +238,7 @@ void TestGUI(interfaces::Node& node)
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("payment_header")->text(), QString("Payment information"));
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("uri_tag")->text(), QString("URI:"));
             QString uri = receiveRequestDialog->QObject::findChild<QLabel*>("uri_content")->text();
-            QCOMPARE(uri.count("bitcoin:"), 2);
+            QCOMPARE(uri.count("reddcoin:"), 2);
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("address_tag")->text(), QString("Address:"));
             QVERIFY(address.isEmpty());
             address = receiveRequestDialog->QObject::findChild<QLabel*>("address_content")->text();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -213,19 +213,25 @@ TestChain100Setup::TestChain100Setup()
 {
     const Consensus::Params& params = Params().GetConsensus();
 
-    SetMockTime(1598887952);
+    // Start the clock just after genesis. UpdateTime floors a new block's time
+    // at the previous block's median time past plus one, so a mock time set
+    // earlier than genesis dates every block far beyond the mocked "now" and
+    // each one is rejected as time-too-new.
+    SetMockTime(Params().GenesisBlock().nTime + 1);
     constexpr std::array<unsigned char, 32> vchKey = {
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
     coinbaseKey.Set(vchKey.begin(), vchKey.end(), true);
 
-    // Generate a 100-block chain:
+    // Generate nCoinbaseMaturity PoW blocks, which is 60 on regtest and leaves
+    // the tip at height 60. Every one of them is below nLastPowHeight, so no
+    // staking is needed to build this chain.
     this->mineBlocks(params.GetCoinbaseMaturity());
 
     {
         LOCK(::cs_main);
         assert(
             m_node.chainman->ActiveChain().Tip()->GetBlockHash().ToString() ==
-            "571d80a9967ae599cec0448b0b0ba1cfb606f584d8069bd7166b86854ba7a191");
+            "7d94161290ee304fbaba0817cbd8ae31253d243abec3e4d2ea4d587230f05d23");
     }
 }
 


### PR DESCRIPTION
`test_reddcoin-qt` aborted partway through `WalletTests` with `double free or corruption (out)`, so the two suites after it never ran and `AddressBookTests` had no coverage at all on this line. Three defects were stacked behind that, each hiding the next.

## 1. Out-of-bounds erase in RegenerateCommitments

`src/miner.cpp` erased the witness commitment output unconditionally:

```cpp
tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
```

`GetWitnessCommitmentIndex` returns `NO_WITNESS_COMMITMENT`, which is `-1`, when the coinbase carries no commitment. `vout.begin() + (-1)` is an out-of-bounds iterator, so the erase wrote one `CTxOut` before the start of the heap buffer and the corruption surfaced when the `CMutableTransaction` was destroyed.

`GenerateCoinbaseCommitment` only adds that output when segwit is enabled, and segwit is `NEVER_ACTIVE` on regtest here, so the index was always `-1` and every block built through this path corrupted the heap.

This is not confined to tests. `RegenerateCommitments` has a second caller in the `generateblock` RPC, which carries no regtest gate, and mainnet segwit is `NEVER_ACTIVE` on this line too, so that RPC corrupts the heap of any node it is called on. Local authenticated RPC only, and of little use on a PoS chain, but it is a node defect rather than a test one.

Fixed by cherry-picking `e282065d0b` from develop, which restores the upstream guard and whose commit message describes this exact crash.

## 2. The chain fixture's clock started before genesis

With the corruption gone, the tip-hash assert in `TestChain100Setup` fired instead, and the chain turned out to be sitting at genesis with nothing connected.

The fixture set mock time to a hardcoded `1598887952`, which is 2020-08-31, while the regtest genesis block is dated `1642570147`, or 2022-01-19. `UpdateTime` floors a new block's timestamp at the previous block's median time past plus one, so every block was dated roughly 507 days beyond the mocked "now" and `AcceptBlock` rejected all 60 of them as `time-too-new`.

The start time now comes from the genesis block, as it does on develop, so the two cannot drift apart again. The tip hash the fixture produces is recorded, confirmed identical across separate runs and separate test suites.

## 3. wallettests.cpp was never adapted

It was still the upstream file. It assumed the fixture leaves the chain at height 100, so it hardcoded 105 as the height handed to `SetLastBlockProcessed` and 105 and 107 as the transaction row counts, and it asserted the payment URI carries a `bitcoin:` scheme where `GUIUtil::parseBitcoinURI` accepts only `reddcoin`.

`TestChain100Setup` mines `nCoinbaseMaturity` blocks on this line, which is 60, so the real height after the test's own five blocks is 65 and every one of those constants was wrong. The height and the row count now come from the chain rather than restating it.

The five extra blocks are kept deliberately. At height 60 with `nCoinbaseMaturity=60` no coinbase has matured yet, and heights 61 to 65 are below `nLastPowHeight=89`, so they are valid PoW blocks and are what makes anything spendable. This is why develop's version of the file could not simply be copied across: there the fixture already reaches height 100 and those same blocks are rejected as `pow-ended`.

## Verification

The full Qt suite now passes, and `AddressBookTests` runs for the first time on this line:

```
AppTests           3 passed, 0 failed
URITests           3 passed, 0 failed
UpdateDialogTests  6 passed, 0 failed
RPCNestedTests     3 passed, 0 failed
WalletTests        3 passed, 0 failed
AddressBookTests   3 passed, 0 failed
exit 0
```

Of the eight boost suites that use `TestChain100Setup`, four now pass that previously aborted in the fixture constructor: `blockfilter_index_tests`, `txvalidationcache_tests`, `coinstatsindex_tests` and `txindex_tests`.

## Known remaining, not addressed here

Four of those suites still fail, all for the same reason and none of it new: they expect a 100-block chain and this line's `TestChain100Setup` builds 60. `interfaces_tests` checks `Height() == 100`, `validation_chainstatemanager_tests` counts 100 coins, `wallet_tests` expects `m_coinbase_txns.size() == 103`. Reaching height 100 requires PoS blocks for heights 90 to 100, which means the staking apparatus develop's fixture carries, so it is left for a separate change rather than pulled into this one. `wallet_tests` also compares against an upstream error string still naming `bitcoind`.

`miner_tests` is unchanged at exactly 115 failures. It uses a different fixture and is neither caused nor fixed by anything here.

https://reddink.youtrack.cloud/issue/RED-122