### PR TITLE
validation: verify proof of work in CheckBlockHeader

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -82,7 +82,9 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman)
 {
     CMutableTransaction tx{*block.vtx.at(0)};
-    tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
+    if (GetWitnessCommitmentIndex(block) != NO_WITNESS_COMMITMENT) {
+        tx.vout.erase(tx.vout.begin() + GetWitnessCommitmentIndex(block));
+    }
     block.vtx.at(0) = MakeTransactionRef(tx);
 
     CBlockIndex* prev_block = WITH_LOCK(::cs_main, return chainman.m_blockman.LookupBlockIndex(block.hashPrevBlock));

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -134,7 +134,10 @@ void BumpFee(TransactionView& view, const uint256& txid, bool expectDisabled, st
 //     QT_QPA_PLATFORM=cocoa   src/qt/test/test_bitcoin-qt  # macOS
 void TestGUI(interfaces::Node& node)
 {
-    // Set up wallet and chain with 105 blocks (5 mature blocks for spending).
+    // Set up wallet and chain. TestChain100Setup mines nCoinbaseMaturity (60)
+    // blocks here, at which height no coinbase has matured yet, so five more
+    // are needed before anything is spendable. Heights 61-65 are still at or
+    // below nLastPowHeight = 89, so these are valid PoW blocks.
     TestChain100Setup test;
     for (int i = 0; i < 5; ++i) {
         test.CreateAndProcessBlock({}, GetScriptForRawPubKey(test.coinbaseKey.GetPubKey()));
@@ -147,7 +150,7 @@ void TestGUI(interfaces::Node& node)
         LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
         wallet->SetAddressBook(GetDestinationForKey(test.coinbaseKey.GetPubKey(), wallet->m_default_address_type), "", "receive");
         spk_man->AddKeyPubKey(test.coinbaseKey, test.coinbaseKey.GetPubKey());
-        wallet->SetLastBlockProcessed(105, node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+        wallet->SetLastBlockProcessed(node.context()->chainman->ActiveChain().Height(), node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
     }
     {
         WalletRescanReserver reserver(*wallet);
@@ -182,11 +185,14 @@ void TestGUI(interfaces::Node& node)
     }
 
     // Send two transactions, and verify they are added to transaction list.
+    // The number of pre-existing wallet transactions follows the height of the
+    // chain the fixture built, so assert relative to the initial count rather
+    // than a hardcoded total.
     TransactionTableModel* transactionTableModel = walletModel.getTransactionTableModel();
-    QCOMPARE(transactionTableModel->rowCount({}), 105);
+    const int initial_tx_rows = transactionTableModel->rowCount({});
     uint256 txid1 = SendCoins(*wallet.get(), sendCoinsDialog, PKHash(), 5 * COIN, false /* rbf */);
     uint256 txid2 = SendCoins(*wallet.get(), sendCoinsDialog, PKHash(), 10 * COIN, true /* rbf */);
-    QCOMPARE(transactionTableModel->rowCount({}), 107);
+    QCOMPARE(transactionTableModel->rowCount({}), initial_tx_rows + 2);
     QVERIFY(FindTx(*transactionTableModel, txid1).isValid());
     QVERIFY(FindTx(*transactionTableModel, txid2).isValid());
 
@@ -232,7 +238,7 @@ void TestGUI(interfaces::Node& node)
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("payment_header")->text(), QString("Payment information"));
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("uri_tag")->text(), QString("URI:"));
             QString uri = receiveRequestDialog->QObject::findChild<QLabel*>("uri_content")->text();
-            QCOMPARE(uri.count("bitcoin:"), 2);
+            QCOMPARE(uri.count("reddcoin:"), 2);
             QCOMPARE(receiveRequestDialog->QObject::findChild<QLabel*>("address_tag")->text(), QString("Address:"));
             QVERIFY(address.isEmpty());
             address = receiveRequestDialog->QObject::findChild<QLabel*>("address_content")->text();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -126,7 +126,7 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
 
     CChainParams chainparams(Params());
 
-    while (max_tries > 0 && block.nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(UintToArith256(block.GetHash()), block.nBits, chainparams.GetConsensus()) && !ShutdownRequested()) {
+    while (max_tries > 0 && block.nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(UintToArith256(block.GetPoWHash()), block.nBits, chainparams.GetConsensus()) && !ShutdownRequested()) {
         ++block.nNonce;
         --max_tries;
     }

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -2,10 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <arith_uint256.h>
 #include <chain.h>
 #include <chainparams.h>
+#include <consensus/validation.h>
 #include <pow.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <validation.h>
+
 #include <test/util/setup_common.h>
+
+#include <string>
 
 #include <boost/test/unit_test.hpp>
 
@@ -180,6 +188,97 @@ BOOST_AUTO_TEST_CASE(ChainParams_TESTNET_sanity)
 BOOST_AUTO_TEST_CASE(ChainParams_SIGNET_sanity)
 {
     sanity_check_chainparams(*m_node.args, CBaseChainParams::SIGNET);
+}
+
+//! A target far harder than any regtest header will meet by accident.
+static const uint32_t UNREACHABLE_TARGET{0x1d00ffff};
+
+//! Build a block carrying only a header.
+//!
+//! CheckBlockHeader runs before every check that inspects transactions, so a
+//! block with no transactions is enough to reach it. Anything that gets past
+//! the header check fails later for an unrelated reason, which is why the
+//! cases below test the reject reason rather than the return value.
+static CBlock HeaderOnlyBlock(int32_t version, uint32_t time, uint32_t bits)
+{
+    CBlock block;
+    block.nVersion = version;
+    block.hashPrevBlock.SetNull();
+    block.hashMerkleRoot.SetNull();
+    block.nTime = time;
+    block.nBits = bits;
+    block.nNonce = 0;
+    return block;
+}
+
+//! Proof of work must actually be verified.
+//!
+//! This is the regression test for the stub CheckBlockHeader that shipped on
+//! this line: 80b9c562c6 deleted the check during the PoSV migration, so a
+//! block's claimed nBits went untested against any work for the whole of the
+//! historical proof-of-work range.
+BOOST_AUTO_TEST_CASE(pow_is_rejected_when_the_header_misses_its_target)
+{
+    const Consensus::Params& params = Params().GetConsensus();
+    CBlock block = HeaderOnlyBlock(POW_BLOCK_VERSION, CHECK_POW_FROM_NTIME + 1, UNREACHABLE_TARGET);
+
+    // The premise: this header does not meet the target it claims. Asserted
+    // rather than assumed, so the case cannot quietly stop testing anything
+    // if the hash or the target ever changes.
+    BOOST_CHECK(!CheckProofOfWork(block.GetPoWHash(), block.nBits, params));
+
+    BlockValidationState state;
+    BOOST_CHECK(!CheckBlock(block, state, params));
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), std::string{"high-hash"});
+}
+
+//! The control: a header that meets its target passes the proof-of-work check.
+//! Without this, the case above would still pass if the check rejected
+//! everything put in front of it.
+BOOST_AUTO_TEST_CASE(pow_is_accepted_when_the_header_meets_its_target)
+{
+    const Consensus::Params& params = Params().GetConsensus();
+    const uint32_t easiest{UintToArith256(params.powLimit).GetCompact()};
+    CBlock block = HeaderOnlyBlock(POW_BLOCK_VERSION, CHECK_POW_FROM_NTIME + 1, easiest);
+    while (!CheckProofOfWork(block.GetPoWHash(), block.nBits, params)) ++block.nNonce;
+
+    BlockValidationState state;
+    CheckBlock(block, state, params);
+    BOOST_CHECK_NE(state.GetRejectReason(), std::string{"high-hash"});
+}
+
+//! Proof-of-stake headers carry no proof of work and are exempt.
+//!
+//! Note which predicate decides this. CheckBlockHeader takes a CBlockHeader,
+//! so IsProofOfWork resolves to the header's version test and not to the
+//! coinstake test CBlock shadows it with. Every block the miner produces
+//! carries a versionbits nVersion, so the check does not apply to them: its
+//! reach is the historical proof-of-work era, where blocks carry version 1
+//! or 2. This case exists to pin that down, because it is not obvious from
+//! reading CheckBlockHeader alone.
+BOOST_AUTO_TEST_CASE(pow_is_not_checked_for_proof_of_stake_headers)
+{
+    const Consensus::Params& params = Params().GetConsensus();
+    CBlock block = HeaderOnlyBlock(POW_BLOCK_VERSION + 1, CHECK_POW_FROM_NTIME + 1, UNREACHABLE_TARGET);
+    BOOST_CHECK(block.CBlockHeader::IsProofOfStake());
+    BOOST_CHECK(!CheckProofOfWork(block.GetPoWHash(), block.nBits, params));
+
+    BlockValidationState state;
+    CheckBlock(block, state, params);
+    BOOST_CHECK_NE(state.GetRejectReason(), std::string{"high-hash"});
+}
+
+//! Headers at or before CHECK_POW_FROM_NTIME are exempt, matching the
+//! historical chain, which is why the constant exists.
+BOOST_AUTO_TEST_CASE(pow_is_not_checked_before_check_pow_from_ntime)
+{
+    const Consensus::Params& params = Params().GetConsensus();
+    CBlock block = HeaderOnlyBlock(POW_BLOCK_VERSION, CHECK_POW_FROM_NTIME, UNREACHABLE_TARGET);
+    BOOST_CHECK(!CheckProofOfWork(block.GetPoWHash(), block.nBits, params));
+
+    BlockValidationState state;
+    CheckBlock(block, state, params);
+    BOOST_CHECK_NE(state.GetRejectReason(), std::string{"high-hash"});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -213,19 +213,25 @@ TestChain100Setup::TestChain100Setup()
 {
     const Consensus::Params& params = Params().GetConsensus();
 
-    SetMockTime(1598887952);
+    // Start the clock just after genesis. UpdateTime floors a new block's time
+    // at the previous block's median time past plus one, so a mock time set
+    // earlier than genesis dates every block far beyond the mocked "now" and
+    // each one is rejected as time-too-new.
+    SetMockTime(Params().GenesisBlock().nTime + 1);
     constexpr std::array<unsigned char, 32> vchKey = {
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}};
     coinbaseKey.Set(vchKey.begin(), vchKey.end(), true);
 
-    // Generate a 100-block chain:
+    // Generate nCoinbaseMaturity PoW blocks, which is 60 on regtest and leaves
+    // the tip at height 60. Every one of them is below nLastPowHeight, so no
+    // staking is needed to build this chain.
     this->mineBlocks(params.GetCoinbaseMaturity());
 
     {
         LOCK(::cs_main);
         assert(
             m_node.chainman->ActiveChain().Tip()->GetBlockHash().ToString() ==
-            "571d80a9967ae599cec0448b0b0ba1cfb606f584d8069bd7166b86854ba7a191");
+            "7d94161290ee304fbaba0817cbd8ae31253d243abec3e4d2ea4d587230f05d23");
     }
 }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -231,7 +231,7 @@ TestChain100Setup::TestChain100Setup()
         LOCK(::cs_main);
         assert(
             m_node.chainman->ActiveChain().Tip()->GetBlockHash().ToString() ==
-            "7d94161290ee304fbaba0817cbd8ae31253d243abec3e4d2ea4d587230f05d23");
+            "4b6e425dc3cde14b1dc017534f95ae33f9640cbb2a7500f9d0db4b7d5d5bdd7b");
     }
 }
 
@@ -258,7 +258,7 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
     }
     RegenerateCommitments(block, *Assert(m_node.chainman));
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetPoWHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
     Assert(m_node.chainman)->ProcessNewBlock(chainparams, shared_pblock, true, nullptr);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3144,6 +3144,20 @@ void CChainState::ReceivedBlockTransactions(const CBlock& block, CBlockIndex* pi
 
 static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
+    // Check proof of work matches claimed amount.
+    //
+    // Reddcoin's proof of work is scrypt, so this hashes GetPoWHash() and not
+    // GetHash(). Proof of stake blocks carry no proof of work and are checked
+    // by CheckProofOfStake instead. Blocks at or before CHECK_POW_FROM_NTIME
+    // are exempt, matching the historical chain.
+    if (block.GetBlockTime() > CHECK_POW_FROM_NTIME) {
+        if (fCheckPOW && block.IsProofOfWork()) {
+            if (!CheckProofOfWork(block.GetPoWHash(), block.nBits, consensusParams)) {
+                return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "high-hash", "proof of work failed");
+            }
+        }
+    }
+
     return true;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -101,6 +101,9 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to >= 550 MiB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
+/** Start checking POW after block 44877 http://live.reddcoin.com/block/4253e7618d40aded00d11b664e874245ae74d55b976f4ac087d1a9db2f5f3cda */
+static const int64_t CHECK_POW_FROM_NTIME = 1394048078;
+
 /** Current sync state passed to tip changed callbacks. */
 enum class SynchronizationState {
     INIT_REINDEX,


### PR DESCRIPTION
`CheckBlockHeader` on this line is a stub:

```cpp
static bool CheckBlockHeader(const CBlockHeader& block, BlockValidationState& state,
                             const Consensus::Params& consensusParams, bool fCheckPOW = true)
{
    return true;
}
```

`CheckProofOfWork` is therefore called nowhere in validation, and `CBlockHeader::GetPoWHash`, the scrypt hash, is defined but never called from anywhere. A block's claimed `nBits` is never tested against any actual work.

`80b9c562c6`, the PoSV migration, removed the check rather than adapting it. The upstream line it deleted was wrong for Reddcoin, because it hashed `GetHash()` where our proof of work is scrypt, but deleting it left nothing in its place. develop has since restored it correctly, and this is that fix ported across.

> Stacked on #547, which it needs for the chain fixture. Review that one first.

## What this actually reaches, which is narrower than it sounds

`CheckBlockHeader` takes a `CBlockHeader`, so `block.IsProofOfWork()` binds to the header predicate, which is `nVersion <= POW_BLOCK_VERSION`, and not to the coinstake predicate `CBlock` shadows it with. Every block the miner produces carries a versionbits `nVersion` of `0x20000000`, so the check does not apply to them.

What it covers is the historical proof-of-work era: heights at or below `nLastPowHeight`, which is 260799 on mainnet, where blocks carry version 1 or 2 and are dated after `CHECK_POW_FROM_NTIME`. That is the range that was unprotected, and it is the same reach the check has on develop, so this does not make the two lines diverge.

Exposure before this change was limited rather than open, and worth stating plainly so the change is not over-rated. Proof-of-stake blocks were never affected, since `CheckProofOfStake` tests the kernel against a target derived from the same `nBits` that chainwork is computed from. The whole proof-of-work era sits below the last mainnet checkpoint, at height 5728519, and `ContextualCheckBlockHeader` rejects forks below it. This restores defence in depth that had been lost, and removes a dependency on the checkpoint list that was never meant to be load bearing.

## Commits

1. **`validation: verify proof of work in CheckBlockHeader`** restores the check, hashing `GetPoWHash()`, skipping proof-of-stake headers, and exempting blocks at or before `CHECK_POW_FROM_NTIME`. Adds that constant, matching develop.

2. **`mining: grind the scrypt hash rather than SHA256d`** fixes both nonce-grinding loops, in `rpc/mining.cpp` and the test fixture, which tested `CheckProofOfWork` against `block.GetHash()`. They were satisfying a target the consensus code does not check. Harmless only while `CheckBlockHeader` was a stub; now that it verifies work, grinding the wrong hash could produce blocks the node itself rejects.

   Grinding a different hash selects a different nonce, so the fixture's chain has different block hashes and the tip hash recorded in #547 is updated here. Confirmed identical across separate runs and separate suites. The chain still reaches height 60, so nothing is rejected by the restored check.

3. **`test: cover the proof of work check in CheckBlockHeader`** adds the regression test the original check never had, which is how it came to be deleted without anything failing.

## The test

`CheckBlockHeader` is static, but `CheckBlock` is not and calls it before any check that inspects transactions, so a block carrying only a header reaches it. Four cases, covering the check and each condition that switches it off:

- a proof-of-work header missing its target is rejected as `high-hash`
- one meeting its target is not, so the first case is not merely watching the check reject everything put in front of it
- a proof-of-stake header is exempt, decided by the header's version rather than the coinstake test, which pins down why the check does not apply to blocks produced today
- a header at `CHECK_POW_FROM_NTIME` is exempt, matching the historical chain

Each case asserts its own premise, that the header really does miss or meet `CheckProofOfWork`, so none can quietly stop testing anything if the hash or the target changes. They use `BasicTestingSetup` and build no chain, so they are independent of the chain fixture.

## Verification

Four new cases pass. Full Qt suite green, exit 0. `blockfilter_index_tests`, `txvalidationcache_tests`, `coinstatsindex_tests` and `txindex_tests` all still pass.

## Pre-existing failures, not from this change

Three suites fail on this line for reasons this PR does not touch, all of them unadapted upstream tests that develop has already adapted, and all belonging with RED-125:

- `pow_tests` has 5 failing cases that assert Bitcoin's `CalculateNextWorkRequired` values. Reddcoin uses Kimoto Gravity Well and that function is a stub returning 0. develop expects `0U` and adds `get_next_work_kgw`. The changes here are pure additions to that file, 99 insertions and no deletions.
- `validation_tests/block_subsidy_test` asserts Bitcoin's 50 COIN initial subsidy against Reddcoin's schedule. develop adapted it to the real halvings at 140,000 and 190,000.
- `validation_block_tests` fails with `BLOCK_RESULT_UNSET` and an empty reject reason, so it is not the check added here, which can only fail with `high-hash`. It uses `MinerTestingSetup` rather than the chain fixture, and develop carries a 59-line adaptation of the file that this line lacks.

https://reddink.youtrack.cloud/issue/RED-124