### PR TITLE
test: adapt upstream expectations to Reddcoin's rules

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -137,11 +137,18 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
 bool CheckProofOfWork(arith_uint256 hash, unsigned int nBits, const Consensus::Params& params)
 {
+    bool fNegative;
+    bool fOverflow;
     arith_uint256 bnTarget;
-    bnTarget.SetCompact(nBits);
 
-    // Check range
-    if (bnTarget <= 0 || bnTarget > UintToArith256(params.powLimit))
+    bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
+
+    // Check range. arith_uint256 is unsigned, so bnTarget <= 0 only ever caught
+    // zero: a compact encoding carrying the sign bit was silently accepted as
+    // its own magnitude, and one whose exponent overflows was accepted as
+    // whatever SetCompact left behind. Both have to come from SetCompact's own
+    // flags, which is what upstream does and what develop already carries.
+    if (fNegative || bnTarget == 0 || fOverflow || bnTarget > UintToArith256(params.powLimit))
         return error("CheckProofOfWork() : nBits below minimum work");
 
     // Check proof of work matches claimed amount

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -46,13 +46,17 @@ BOOST_AUTO_TEST_CASE(findBlock)
 
     bool cur_active{false}, next_active{false};
     uint256 next_hash;
-    BOOST_CHECK_EQUAL(active.Height(), 100);
-    BOOST_CHECK(chain->findBlock(active[99]->GetBlockHash(), FoundBlock().inActiveChain(cur_active).nextBlock(FoundBlock().inActiveChain(next_active).hash(next_hash))));
+    // TestChain100Setup mines nCoinbaseMaturity blocks on this line, which is
+    // 60 on regtest, so the tip is not at the height the fixture's name
+    // suggests. Take it from the chain so these checks follow the fixture
+    // rather than a number kept in step with it by hand.
+    const int tip_height = active.Height();
+    BOOST_CHECK(chain->findBlock(active[tip_height - 1]->GetBlockHash(), FoundBlock().inActiveChain(cur_active).nextBlock(FoundBlock().inActiveChain(next_active).hash(next_hash))));
     BOOST_CHECK(cur_active);
     BOOST_CHECK(next_active);
-    BOOST_CHECK_EQUAL(next_hash, active[100]->GetBlockHash());
+    BOOST_CHECK_EQUAL(next_hash, active[tip_height]->GetBlockHash());
     cur_active = next_active = false;
-    BOOST_CHECK(chain->findBlock(active[100]->GetBlockHash(), FoundBlock().inActiveChain(cur_active).nextBlock(FoundBlock().inActiveChain(next_active))));
+    BOOST_CHECK(chain->findBlock(active[tip_height]->GetBlockHash(), FoundBlock().inActiveChain(cur_active).nextBlock(FoundBlock().inActiveChain(next_active))));
     BOOST_CHECK(cur_active);
     BOOST_CHECK(!next_active);
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -13,58 +13,69 @@
 
 #include <test/util/setup_common.h>
 
-#include <string>
-
 #include <boost/test/unit_test.hpp>
+
+#include <string>
 
 BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)
 
-/* Test calculation of next difficulty target with no constraints applying */
-BOOST_AUTO_TEST_CASE(get_next_work)
+/* Test CalculateNextWorkRequired stub returns 0 */
+// NOTE: Reddcoin uses Kimoto Gravity Well, not Bitcoin's CalculateNextWorkRequired
+// CalculateNextWorkRequired() is a stub that returns 0 in Reddcoin
+BOOST_AUTO_TEST_CASE(calculate_next_work_stub)
 {
     const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
-    int64_t nLastRetargetTime = 1261130161; // Block #30240
     CBlockIndex pindexLast;
-    pindexLast.nHeight = 32255;
-    pindexLast.nTime = 1262152739;  // Block #32255
-    pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00d86aU);
+    pindexLast.nHeight = 1000;
+    pindexLast.nTime = 1391411877;
+    pindexLast.nBits = 0x1c05f176;
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, 0, chainParams->GetConsensus()), 0U);
 }
 
-/* Test the constraint on the upper bound for next work */
+/* Test GetNextWorkRequired with actual Reddcoin mainnet blocks */
+// Kimoto Gravity Well difficulty adjustment
+BOOST_AUTO_TEST_CASE(get_next_work_kgw)
+{
+    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+
+    // Build a simple chain to test KGW
+    // Using actual mainnet block data: height 1000, time 1391411877, bits 0x1c05f176
+    CBlockIndex pindexLast;
+    pindexLast.nHeight = 1000;
+    pindexLast.nTime = 1391411877;
+    pindexLast.nBits = 0x1c05f176;
+    pindexLast.pprev = nullptr;
+
+    // Test that GetNextWorkRequired returns a valid difficulty
+    CBlockHeader blockHeader;
+    blockHeader.nTime = pindexLast.nTime + 60; // 1 minute later
+    unsigned int nBits = GetNextWorkRequired(&pindexLast, &blockHeader, chainParams->GetConsensus());
+
+    // Verify it's within powLimit
+    arith_uint256 bnTarget;
+    bnTarget.SetCompact(nBits);
+    BOOST_CHECK(bnTarget <= UintToArith256(chainParams->GetConsensus().powLimit));
+    BOOST_CHECK(bnTarget > 0);
+}
+
+/* Test GetNextWorkRequired returns powLimit for very early blocks */
 BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 {
     const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
-    int64_t nLastRetargetTime = 1231006505; // Block #0
-    CBlockIndex pindexLast;
-    pindexLast.nHeight = 2015;
-    pindexLast.nTime = 1233061996;  // Block #2015
-    pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00ffffU);
-}
 
-/* Test the constraint on the lower bound for actual time taken */
-BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
-{
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
-    int64_t nLastRetargetTime = 1279008237; // Block #66528
+    // Very early block should return powLimit
     CBlockIndex pindexLast;
-    pindexLast.nHeight = 68543;
-    pindexLast.nTime = 1279297671;  // Block #68543
-    pindexLast.nBits = 0x1c05a3f4;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1c0168fdU);
-}
+    pindexLast.nHeight = 5;
+    pindexLast.nTime = 1390280460; // shortly after genesis
+    pindexLast.nBits = 0x1e0ffff0;
+    pindexLast.pprev = nullptr;
 
-/* Test the constraint on the upper bound for actual time taken */
-BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
-{
-    const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
-    int64_t nLastRetargetTime = 1263163443; // NOTE: Not an actual block time
-    CBlockIndex pindexLast;
-    pindexLast.nHeight = 46367;
-    pindexLast.nTime = 1269211443;  // Block #46367
-    pindexLast.nBits = 0x1c387f6f;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00e1fdU);
+    CBlockHeader blockHeader;
+    blockHeader.nTime = pindexLast.nTime + 60;
+    unsigned int nBits = GetNextWorkRequired(&pindexLast, &blockHeader, chainParams->GetConsensus());
+
+    // Should return powLimit for blocks with height < PastBlocksMin
+    BOOST_CHECK_EQUAL(nBits, UintToArith256(chainParams->GetConsensus().powLimit).GetCompact());
 }
 
 BOOST_AUTO_TEST_CASE(CheckProofOfWork_test_negative_target)

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -14,51 +14,126 @@
 
 BOOST_FIXTURE_TEST_SUITE(validation_tests, TestingSetup)
 
-static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
-{
-    int maxHalvings = 64;
-    CAmount nInitialSubsidy = 50 * COIN;
-
-    CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 0
-    BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
-    for (int nHalvings = 0; nHalvings < maxHalvings; nHalvings++) {
-        int nHeight = nHalvings * consensusParams.nSubsidyHalvingInterval;
-        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK(nSubsidy <= nInitialSubsidy);
-        BOOST_CHECK_EQUAL(nSubsidy, nPreviousSubsidy / 2);
-        nPreviousSubsidy = nSubsidy;
-    }
-    BOOST_CHECK_EQUAL(GetBlockSubsidy(maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
-}
-
-static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
-{
-    Consensus::Params consensusParams;
-    consensusParams.nSubsidyHalvingInterval = nSubsidyHalvingInterval;
-    TestBlockSubsidyHalvings(consensusParams);
-}
-
+// Test Reddcoin's unique block reward schedule
 BOOST_AUTO_TEST_CASE(block_subsidy_test)
 {
     const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
-    TestBlockSubsidyHalvings(chainParams->GetConsensus()); // As in main
-    TestBlockSubsidyHalvings(150); // As in regtest
-    TestBlockSubsidyHalvings(1000); // Just another interval
+    const Consensus::Params& consensusParams = chainParams->GetConsensus();
+
+    // Genesis block (height 0): 10,000 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(0, consensusParams), 10000 * COIN);
+
+    // Premine blocks (heights 1-10): 545,000,000 RDD each
+    for (int height = 1; height <= 10; height++) {
+        BOOST_CHECK_EQUAL(GetBlockSubsidy(height, consensusParams), 545000000 * COIN);
+    }
+
+    // Bonus period 1 (heights 11-9,999): 300,000 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(11, consensusParams), 300000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(5000, consensusParams), 300000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(9999, consensusParams), 300000 * COIN);
+
+    // Bonus period 2 (heights 10,000-19,999): 200,000 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(10000, consensusParams), 200000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(15000, consensusParams), 200000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(19999, consensusParams), 200000 * COIN);
+
+    // Bonus period 3 (heights 20,000-29,999): 150,000 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(20000, consensusParams), 150000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(25000, consensusParams), 150000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(29999, consensusParams), 150000 * COIN);
+
+    // Standard reward period (heights 30,000-139,999): 100,000 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(30000, consensusParams), 100000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(100000, consensusParams), 100000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(139999, consensusParams), 100000 * COIN);
+
+    // Halving period starts at 140,000
+    // First halving at 140,000: 100,000 >> 1 = 50,000 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(140000, consensusParams), 50000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(189999, consensusParams), 50000 * COIN);
+
+    // Second halving at 190,000: 50,000 >> 1 = 25,000 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(190000, consensusParams), 25000 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(239999, consensusParams), 25000 * COIN);
+
+    // Third halving at 240,000: 25,000 >> 1 = 12,500 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(240000, consensusParams), 12500 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(289999, consensusParams), 12500 * COIN);
+
+    // Fourth halving at 290,000: 12,500 >> 1 = 6,250 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(290000, consensusParams), 6250 * COIN);
+
+    // Test many halvings into the future
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(340000, consensusParams), 3125 * COIN);
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(390000, consensusParams), 1562 * COIN + 50000000); // 1562.5 RDD
+    BOOST_CHECK_EQUAL(GetBlockSubsidy(440000, consensusParams), 781 * COIN + 25000000); // 781.25 RDD
 }
 
+// Test Reddcoin's total PoW supply calculation
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
     const auto chainParams = CreateChainParams(*m_node.args, CBaseChainParams::MAIN);
+    const Consensus::Params& consensusParams = chainParams->GetConsensus();
+
     CAmount nSum = 0;
-    for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
-        CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());
-        BOOST_CHECK(nSubsidy <= 50 * COIN);
-        nSum += nSubsidy * 1000;
-        BOOST_CHECK(MoneyRange(nSum));
+
+    // Genesis block (height 0)
+    nSum += GetBlockSubsidy(0, consensusParams);
+    BOOST_CHECK_EQUAL(nSum, 10000 * COIN);
+
+    // Premine (heights 1-10): 10 blocks × 545,000,000 RDD
+    for (int h = 1; h <= 10; h++) {
+        nSum += GetBlockSubsidy(h, consensusParams);
     }
-    BOOST_CHECK_EQUAL(nSum, CAmount{2099999997690000});
+    BOOST_CHECK_EQUAL(nSum, 10000 * COIN + 5450000000LL * COIN);
+
+    // Bonus period 1 (heights 11-9,999): 9,989 blocks × 300,000 RDD
+    for (int h = 11; h < 10000; h++) {
+        nSum += GetBlockSubsidy(h, consensusParams);
+    }
+    CAmount expectedAfterBonus1 = 10000LL * COIN + 5450000000LL * COIN + 9989LL * 300000LL * COIN;
+    BOOST_CHECK_EQUAL(nSum, expectedAfterBonus1);
+
+    // Bonus period 2 (heights 10,000-19,999): 10,000 blocks × 200,000 RDD
+    for (int h = 10000; h < 20000; h++) {
+        nSum += GetBlockSubsidy(h, consensusParams);
+    }
+    CAmount expectedAfterBonus2 = expectedAfterBonus1 + 10000LL * 200000LL * COIN;
+    BOOST_CHECK_EQUAL(nSum, expectedAfterBonus2);
+
+    // Bonus period 3 (heights 20,000-29,999): 10,000 blocks × 150,000 RDD
+    for (int h = 20000; h < 30000; h++) {
+        nSum += GetBlockSubsidy(h, consensusParams);
+    }
+    CAmount expectedAfterBonus3 = expectedAfterBonus2 + 10000LL * 150000LL * COIN;
+    BOOST_CHECK_EQUAL(nSum, expectedAfterBonus3);
+
+    // Standard period (heights 30,000-139,999): 110,000 blocks × 100,000 RDD
+    for (int h = 30000; h < 140000; h++) {
+        nSum += GetBlockSubsidy(h, consensusParams);
+    }
+    CAmount expectedAfterStandard = expectedAfterBonus3 + 110000LL * 100000LL * COIN;
+    BOOST_CHECK_EQUAL(nSum, expectedAfterStandard);
+
+    // First halving period (heights 140,000-189,999): 50,000 blocks × 50,000 RDD
+    for (int h = 140000; h < 190000; h++) {
+        nSum += GetBlockSubsidy(h, consensusParams);
+    }
+    CAmount expectedAfterHalving1 = expectedAfterStandard + 50000LL * 50000LL * COIN;
+    BOOST_CHECK_EQUAL(nSum, expectedAfterHalving1);
+
+    // Verify all money is in valid range
+    BOOST_CHECK(MoneyRange(nSum));
+
+    // Test that subsidy becomes small after many halvings
+    // Note: Right shift operations in C++ are limited to the bit width (63 for int64_t)
+    // so extremely high blocks will cycle rather than reach 0
+    CAmount farFuture = GetBlockSubsidy(1000000, consensusParams);
+    BOOST_CHECK(farFuture < 100 * COIN); // Less than 100 RDD after ~17 halvings
 }
 
+// Test Proof-of-Stake reward calculation
 BOOST_AUTO_TEST_CASE(signet_parse_tests)
 {
     ArgsManager signet_argsman;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -228,7 +228,7 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
                       "timestamp %d. There was an error reading a block from time %d, which is after or within %d "
                       "seconds of key creation, and could contain transactions pertaining to the key. As a result, "
                       "transactions and coins using this key may not appear in the wallet. This error could be caused "
-                      "by pruning or data corruption (see bitcoind log for details) and could be dealt with by "
+                      "by pruning or data corruption (see reddcoind log for details) and could be dealt with by "
                       "downloading and rescanning the relevant blocks (see -reindex and -rescan "
                       "options).\"}},{\"success\":true}]",
                               0, oldTip->GetBlockTimeMax(), TIMESTAMP_WINDOW));


### PR DESCRIPTION
Several test files on this line still assert Bitcoin's numbers against Reddcoin's consensus rules, so they fail on arithmetic that was never going to hold. develop has already adapted them; this ports those adaptations across.

> Stacked on #548, which is stacked on #547. Review those first.

Scope is deliberately limited to ports. Where develop's version is built on its staking fixture, or hardcodes values for the chain that fixture produces, it is not taken: `TestChain100Setup` on this line mines `nCoinbaseMaturity` blocks, which is 60 on regtest, and reaching 100 needs proof-of-stake blocks for heights 90 to 100. That decision is recorded in RED-125.

## Ported

**`pow_tests`** expected Bitcoin's retarget results from `CalculateNextWorkRequired`. Reddcoin uses Kimoto Gravity Well and that function is a stub returning 0, so the four cases built on it could not pass. Replaced with develop's `calculate_next_work_stub` and `get_next_work_kgw`, which test the retarget actually in use.

**`validation_tests`** expected Bitcoin's 50 COIN initial subsidy and halving schedule. Reddcoin pays 10,000 RDD at genesis, 545,000,000 for the premine blocks, then a bonus schedule before the halvings at 140,000 and 190,000. Replaced `block_subsidy_test` and `subsidy_limit_test` with develop's, which encode the real schedule.

**`interfaces_tests`** asserted the tip was at height 100 and then indexed the chain at 99 and 100. On a 60-block chain the assertion was wrong and the indexing walked off the end, which is what turned that failure into a segfault. Takes the height from the chain now, as develop does.

**`wallet_tests`** compared against an error string still naming `bitcoind` where the code emits `reddcoind`.

## Result

`pow_tests` passes in full, 17 cases, including the four added in #548 and `CheckProofOfWork_test_negative_target`, which that PR's `pow.cpp` fix is what repairs.

`validation_tests` goes from 3168 failures to 6. `interfaces_tests` from 2 to 1.

`blockfilter_index_tests`, `txvalidationcache_tests`, `coinstatsindex_tests` and `txindex_tests` still pass.

## Left failing, deliberately

**`validation_tests/test_assumeutxo`**, 3 checks. The entries in this line's chainparams are for heights 110 and 200, which the fixture cannot reach, and `src/chainparams.cpp` already carries a `TODO: Recompute these hashes after RegenerateCommitments fix`. develop's version of this test hardcodes hashes for its own chain, so porting it would swap one set of wrong constants for another.

**`validation_tests/signet_parse_tests`**, 3 checks. develop deleted this test; it is kept here. It forces `-signetchallenge` to `51` and still does not get `OP_TRUE` back from `CreateChainParams`, which suggests the argument is not being honoured. That is a real question, and deleting a red test without understanding it would hide the answer rather than produce one.

**`interfaces_tests/hasBlocks`**, segfault. It clears `BLOCK_HAVE_DATA` on `active[95]`, which is null on a 60-block chain. develop's copy is byte-identical and passes only because its chain reaches 100, so there is nothing to port: adapting it means choosing new sample heights, which is a rewrite rather than a port.

**`wallet_tests`** balance and coinbase-count expectations, and **`validation_chainstatemanager_tests`**. develop's versions of both call `stakeBlocks` throughout. The latter also needs the chain at height 110 for its assumeutxo entry, and proof of work is capped at `nLastPowHeight`, which is 89, so that case cannot pass without proof-of-stake blocks at all.

**`miner_tests`** is unchanged at 115 failures on a different fixture, and is not part of this.

https://reddink.youtrack.cloud/issue/RED-125