### PR TITLE
wallet: derive descriptor wallets at Reddcoin's coin type

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2043,12 +2043,9 @@ bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(const CExtKey& master_
     } // no default case, so the compiler can warn about missing cases
     assert(!desc_prefix.empty());
 
-    // Mainnet derives at 0', testnet and regtest derive at 1'
-    if (Params().IsTestChain()) {
-        desc_prefix += "/1'";
-    } else {
-        desc_prefix += "/0'";
-    }
+    // Derive at Reddcoin's registered SLIP-0044 coin type, the same one legacy
+    // HD wallets use: 4' on mainnet, 1' on the test chains.
+    desc_prefix += strprintf("/%d'", Params().ExtCoinType());
 
     std::string internal_path = internal ? "/1" : "/0";
     std::string desc_str = desc_prefix + "/0'" + internal_path + desc_suffix;

--- a/src/wallet/test/scriptpubkeyman_tests.cpp
+++ b/src/wallet/test/scriptpubkeyman_tests.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <chainparams.h>
+#include <chainparamsbase.h>
 #include <key.h>
 #include <script/standard.h>
 #include <test/util/setup_common.h>
@@ -36,6 +38,56 @@ BOOST_AUTO_TEST_CASE(CanProvide)
     BOOST_CHECK(!keyman.CanProvide(p2sh_script, data));
     keyman.AddCScript(multisig_script);
     BOOST_CHECK(keyman.CanProvide(p2sh_script, data));
+}
+
+// Reddcoin: descriptor wallets must derive under Reddcoin's registered
+// SLIP-0044 coin type, the same one legacy HD wallets use, on every chain.
+// They used to derive under Bitcoin's hardcoded 0' on mainnet, which put the
+// two wallet types in different places for one seed.
+BOOST_AUTO_TEST_CASE(DescriptorCoinType)
+{
+    constexpr uint32_t HARDENED = 0x80000000;
+    const std::vector<std::pair<OutputType, uint32_t>> purposes{
+        {OutputType::LEGACY, 44},
+        {OutputType::P2SH_SEGWIT, 49},
+        {OutputType::BECH32, 84},
+    };
+
+    for (const std::string& chain : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::REGTEST}) {
+        SelectParams(chain);
+        const uint32_t coin_type = Params().ExtCoinType();
+
+        for (const auto& [addr_type, purpose] : purposes) {
+            CWallet wallet(m_node.chain.get(), "", CreateMockWalletDatabase());
+            wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+            LOCK(wallet.cs_wallet);
+
+            CKey master_key;
+            master_key.MakeNewKey(true);
+            CExtKey master_ext;
+            master_ext.SetSeed(master_key.begin(), master_key.size());
+
+            auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(wallet));
+            BOOST_CHECK(desc_spk_man->SetupDescriptorGeneration(master_ext, addr_type, false));
+
+            // Check the path the wallet reports for an address it just handed
+            // out, which is what getaddressinfo shows the user.
+            CTxDestination dest;
+            std::string error;
+            BOOST_CHECK(desc_spk_man->GetNewDestination(addr_type, dest, error));
+
+            std::unique_ptr<CKeyMetadata> meta = desc_spk_man->GetMetadata(dest);
+            BOOST_REQUIRE(meta);
+            BOOST_REQUIRE(meta->has_key_origin);
+            BOOST_REQUIRE_EQUAL(meta->key_origin.path.size(), 5U);
+            BOOST_CHECK_EQUAL(meta->key_origin.path[0], purpose | HARDENED);
+            BOOST_CHECK_EQUAL(meta->key_origin.path[1], coin_type | HARDENED);
+            BOOST_CHECK_EQUAL(meta->key_origin.path[2], 0 | HARDENED);
+        }
+    }
+
+    // Restore the chain the unit tests run on.
+    SelectParams(CBaseChainParams::REGTEST);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Backport of #550 to the 4.22.9 release line. The patch is identical: this branch has the same hardcoded block and the same descriptor API.

Descriptor wallets appended a hardcoded `0'` (`1'` on the test chains) as the BIP44 coin type, inherited unchanged from Bitcoin Core, where `0'` is the correct value. Legacy HD wallets already use `Params().ExtCoinType()`, which is Reddcoin's registered SLIP-0044 value of 4 on mainnet, so a single seed produced keys in two different places depending on which wallet type created it:

| Wallet type | Derives at |
| --- | --- |
| Legacy HD | `m/44'/4'/0'/<change>/<index>` |
| Descriptor, before this change | `m/44'\|49'\|84'/0'/0'/<change>/<index>` |

No funds were ever at risk, since a wallet derives consistently with how it created its keys. The cost is interoperability: someone restoring a Reddcoin descriptor wallet seed into third-party or hardware wallet tooling points it at coin type 4, sees an empty wallet, and reasonably concludes the funds are gone.

## Change

`DescriptorScriptPubKeyMan::SetupDescriptorGeneration`:

```cpp
// Derive at Reddcoin's registered SLIP-0044 coin type, the same one legacy
// HD wallets use: 4' on mainnet, 1' on the test chains.
desc_prefix += strprintf("/%d'", Params().ExtCoinType());
```

`strprintf` is required rather than appending to the literal, because `ExtCoinType()` returns an `int`.

Mainnet descriptor wallets now derive at `m/44'/4'/0'`, `m/49'/4'/0'` and `m/84'/4'/0'`. The test chains are unchanged, since `ExtCoinType()` is already 1 there.

## Existing wallets are unaffected, and no migration is needed

RED-114 was filed on the assumption that changing the constant moves where existing descriptor wallets look for their keys, and so needs a version marker plus rescan handling. It does not.

A descriptor string is built once, in `SetupDescriptorGeneration`, and written to the wallet database by `WalletBatch::WriteDescriptor`. Loading a wallet reads the stored string back; nothing recomputes the path at load time. Wallets created before this change keep deriving exactly where their keys already are, and only newly created descriptor wallets use `4'`. That matters more on this branch than on develop, since this is the line users are actually running.

The only other setup call site is `CWallet::EncryptWallet`, which already rotates a descriptor wallet to fresh descriptors under a new seed when it is encrypted. Those descriptors now use `4'` as well. The pre-encryption managers are encrypted and retained as inactive spkms, so coins received before encryption stay spendable.

## Test

New `scriptpubkeyman_tests/DescriptorCoinType`, matching the develop PR. It sets up a descriptor spkm for each output type on mainnet, testnet and regtest, then asserts the key origin path the wallet reports for a freshly handed-out address, which is what `getaddressinfo` shows the user.

Only the mainnet leg has teeth. On the test chains `ExtCoinType()` is already 1, so the generated descriptor is byte-identical before and after this change. That also means no functional test could have caught this bug, because they all run on regtest.

## Testing done

- `src/test/test_reddcoin --run_test=scriptpubkeyman_tests`: passes, both cases.
- The wallet suites on this branch report 34 failures (`wallet_tests` 50-COIN and 60-block fixture expectations, `key_io_tests`, `psbt_wallet_tests`). These are the pre-existing failures tracked in RED-125 and are not caused by this change: running the same suite set with `scriptpubkeyman_tests` omitted gives exactly 34 as well. Independently, unit tests run on regtest, where `ExtCoinType()` is already 1 and the generated descriptor is byte-identical, so this change cannot affect them.

YouTrack: https://reddink.youtrack.cloud/issue/RED-114
