### PR TITLE
ci: keep the CentOS depends build on the job's own locale

### DIFF
--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -50,7 +50,16 @@ if [ -z "$NO_DEPENDS" ]; then
     # CentOS has problems building the depends if the config shell is not explicitly set
     # (i.e. for libevent a Makefile with an empty SHELL variable is generated, leading to
     #  an error as the first command is executed)
-    SHELL_OPTS="LC_ALL=en_US.UTF-8 CONFIG_SHELL=/bin/dash"
+    #
+    # Keep the locale the rest of the job runs under. Upstream forces en_US.UTF-8
+    # here, which its CentOS 8 image has; the stream9 image generates no en_US
+    # locale at all, so every shell call prints
+    #   sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+    # on stderr. Qt's configure reads its library flags by capturing stdout and
+    # stderr together, so that warning ends up inside the flags it got back from
+    # pkg-config, and the freetype test then fails to build with a shell syntax
+    # error. That takes the whole GUI depends build down.
+    SHELL_OPTS="LC_ALL=C.UTF-8 CONFIG_SHELL=/bin/dash"
   else
     SHELL_OPTS="CONFIG_SHELL="
   fi


### PR DESCRIPTION
The `32-bit + dash, gui [CentOS 9]` task fails while building depends, before any project code is compiled, and it does so on every pull request:

```
ERROR: Feature 'system-freetype' was enabled, but the pre-condition
       'features.freetype && libs.freetype' failed.
```

## Nothing is missing

depends builds and caches freetype itself, and pkg-config finds it. From the configure log of the failing run ([33704926388](https://github.com/reddcoin-project/reddcoin/actions/runs/33704926388/job/100491904450)):

```
+ PKG_CONFIG_LIBDIR=.../depends/i686-pc-linux-gnu/lib/pkgconfig pkg-config --modversion freetype2
> 19.0.13
+ ... --libs-only-L freetype2   ->  -L.../depends/i686-pc-linux-gnu/lib
+ ... --libs-only-l freetype2   ->  -lfreetype
+ ... --cflags freetype2        ->  -I.../depends/i686-pc-linux-gnu/include/freetype2
```

Every one of those calls is also preceded by this, on stderr:

```
sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```

## Cause

`ci/test/05_before_script.sh` forced `LC_ALL=en_US.UTF-8` for the depends build on any centos image. That comes from upstream, whose CentOS 8 image has the locale. **The stream9 image generates no `en_US` locale at all.**

Qt's configure reads a library's flags by capturing stdout and stderr together, so the warning became part of the flags it believed pkg-config had returned, and it linked the freetype test with the warning spliced into the command line:

```
g++ -m32 ... -o freetype main.o   /usr/bin/sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8) -L...
/bin/sh: -c: line 1: syntax error near unexpected token `('
```

Qt then fell through to its non-pkg-config source, which carries no include path:

```
main.cpp:2:10: fatal error: ft2build.h: No such file or directory
```

and reported the feature unavailable. The fontconfig error that follows is collateral: its own pre-condition names `features.system-freetype`.

## Fix

Use the locale the rest of the job already runs under. `ci/test/04_install.sh` passes `LC_ALL=C.UTF-8` into the container and the task's env file sets it; the depends build was the one step overriding it. That env file had already dropped `en_US.UTF-8` from `TEST_RUNNER_ENV` for this image, for the same reason, but the depends invocation kept it.

Installing `glibc-langpack-en` would also work. I did not take that route: it adds a package to keep a locale nothing needs, and leaves the depends build as the only step running under a different locale from everything around it.

## Worth knowing

- **This is not i686-specific**, despite where it shows up. Any job on a centos image that builds Qt would hit it; that task is simply the only one that does, and every other task uses an Ubuntu image, which never takes this branch.
- **`--disable-static` in `freetype.mk` is not involved.** Upstream builds freetype shared as well (`-DBUILD_SHARED_LIBS=TRUE`), and Qt builds against this same recipe on x86_64.
- **The depends cache was hiding it.** The i686 Qt build has been broken for as long as the stream9 image has lacked the locale; the cache key only turned over when `depends/packages/openssl.mk` changed in #503, which forced a real Qt build. The OpenSSL change did not cause this, it just stopped concealing it.

## Testing done

In the `quay.io/centos/centos:stream9` image itself:

- `locale -a` lists no `en_US` entry.
- Capturing a `pkg-config --cflags freetype2` call the way Qt's configure does, under `LC_ALL=en_US.UTF-8`, returns the setlocale warning ahead of the flags. Building a freetype test program with those captured flags fails (`ld: cannot find /bin/sh:`), the same class of failure as CI's shell syntax error.
- Under `LC_ALL=C.UTF-8` the flags come back clean and the same test program builds, which is what `libs.freetype` is testing.

The end-to-end proof is this PR's own `32-bit + dash, gui [CentOS 9]` run, since that is the only job that builds Qt.

YouTrack: https://reddink.youtrack.cloud/issue/RED-111
