### PR TITLE
test: count an RPC the node answered with an error as covered

### DIFF
--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -10,6 +10,8 @@ testing.
 
 import os
 
+from .authproxy import JSONRPCException
+
 
 REFERENCE_FILENAME = 'rpc_interface.txt'
 
@@ -43,8 +45,22 @@ class AuthServiceProxyWrapper():
         Delegates to AuthServiceProxy, then writes the particular RPC method
         called to a file.
 
+        A call the node answered with an error is recorded too. It reached the
+        RPC and the RPC decided the answer, which is what the coverage gate is
+        asking about, and for an RPC whose success path a test cannot reach it
+        is the only coverage there will ever be: downloadupdate can only succeed
+        by fetching a signed release over the network, so rpc_checkupdates.py
+        can only test how it rejects a bad argument. Recording nothing there
+        reported an RPC that is exercised by a passing test as untested.
+
+        A transport failure is not recorded. Nothing reached the RPC, so there
+        is nothing to claim coverage of.
         """
-        return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
+        try:
+            return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
+        except JSONRPCException:
+            self._log_call()
+            raise
         self._log_call()
         return return_val
 


### PR DESCRIPTION
The `previous releases, qt5, DEBUG` task fails on every pull request, and on develop, at the functional suite's `--coverage` gate:

```
Uncovered RPC commands:
  - downloadupdate
```

Baseline: develop run [34099031737](https://github.com/reddcoin-project/reddcoin/actions/runs/34099031737) fails identically, so this is not caused by anything in flight.

## The RPC was never uncovered

`test/functional/rpc_checkupdates.py` calls it, and passes in the same run that reports it as uncovered:

```
rpc_checkupdates.py     | ✓ Passed  | 1 s
```

```python
assert_raises_rpc_error(-8, 'artifact must be "daemon" or "gui"',
                        node.downloadupdate, "nonsense")
```

The coverage wrapper only recorded a call after it returned:

```python
return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
self._log_call()      # never reached when the call raises
return return_val
```

`assert_raises_rpc_error` needs the call to raise. So the RPC was invoked, the node answered, the assertion passed, and nothing was written to the coverage file.

This is general rather than one RPC's problem, and is inherited from Bitcoin Core: **any RPC whose only functional coverage is an error-path test was reported as untested.** `downloadupdate` is simply the first one here with no other kind of coverage available.

## Why this RPC has no success-path test

`downloadupdate` (`src/rpc/server.cpp:290`) only returns successfully after fetching a release over the network and verifying it against the signing key built into the client. A functional test cannot do that, and should not: tests must not make real network requests, which is a lesson this tree already paid for once, when a unit test was found doing real DNS and TLS during the RED-98 work.

How it rejects a bad argument is therefore the only behaviour a test can assert, and `rpc_checkupdates.py` also asserts that it rejects *before* reaching the network, by timing the call.

## Fix

Record a call the node answered with an error. It reached the RPC and the RPC decided the answer, which is exactly what the gate is asking about:

```python
try:
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
except JSONRPCException:
    self._log_call()
    raise
self._log_call()
return return_val
```

A transport failure is still not recorded. Nothing reached the RPC, so there is nothing to claim coverage of.

## Why not EXPECTED_UNCOVERED_RPCS

`test_runner.py` already has an exemption list, and adding one line to it would have turned the job green. Its contract is explicit:

```python
# RPCs the --coverage gate must not count against us, because no test in this
# tree can exercise them. This is not a list of RPCs we have not got round to;
# each entry is paired with the reason it is unreachable...
```

A test does exercise `downloadupdate`. Listing it there would record a claim that is false, and would hide the RPC from the gate for good, including if a success path ever became testable. The gate was under-counting; that is what is fixed.

## Testing done

Ran `rpc_checkupdates.py` with `--coveragedir` before and after, and diffed what the run recorded:

- before: `checkupdates, getbestblockhash, getblockcount, getmempoolinfo, getrawmempool, help, stop, syncwithvalidationinterfacequeue`
- after: the same, plus `downloadupdate`

`rpc_checkupdates.py` and `rpc_help.py` both pass with the change. The gate itself can only be confirmed by a coverage-enabled suite run, which is this task; `downloadupdate` was the only entry in its uncovered list.

YouTrack: https://reddink.youtrack.cloud/issue/RED-126
