### PR TITLE
test: classify downloadupdate for the rpc fuzz target

### DIFF
--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -68,6 +68,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "addpeeraddress", // avoid DNS lookups
     "analyzepsbt",    // avoid signed integer overflow in CFeeRate::GetFee(unsigned long) (https://github.com/bitcoin/bitcoin/issues/20607)
     "checkupdates",   // avoid outbound network access (queries the release feed over TLS)
+    "downloadupdate", // avoid outbound network access and writing to disk (fetches a release into the datadir)
     "dumptxoutset",   // avoid writing to disk
     "dumpwallet", // avoid writing to disk
     "echoipc",              // avoid assertion failure (Assertion `"EnsureAnyNodeContext(request.context).init" && check' failed.)


### PR DESCRIPTION
The `fuzzer, address, undefined, integer, no depends` task fails on every pull request, and on develop:

```
Error: RPC command "downloadupdate" not found in RPC_COMMANDS_SAFE_FOR_FUZZING
or RPC_COMMANDS_NOT_SAFE_FOR_FUZZING. Please update test/fuzz/rpc.cpp.

1 of 179 target(s) failed
```

Example: [job 101918918304](https://github.com/reddcoin-project/reddcoin/actions/runs/34180654255/job/101918918304).

## What actually happens

`src/test/fuzz/rpc.cpp` requires every RPC the node registers to be classified in one of two lists, and calls `std::terminate()` when one is not:

```cpp
for (const std::string& rpc_command : supported_rpc_commands) {
    ...
    if (!(safe_for_fuzzing || not_safe_for_fuzzing)) {
        std::cerr << "Error: RPC command \"" << rpc_command << "\" not found in ...";
        std::terminate();
    }
}
```

So this is not a fuzzing failure. The target aborts during initialisation and **nothing is fuzzed at all**, which is worse than it looks from the job name.

`downloadupdate` arrived with the assisted-upgrade work (`src/rpc/server.cpp:290`) and was never classified. It is the sibling of the RPC coverage gap in #555: an RPC landed without updating a test-side registry that has no compile-time link to the RPC table, so nothing failed until CI ran.

## Fix

`downloadupdate` performs outbound network access and writes the fetched artifact into the datadir, both of which the not-safe list exists to exclude. Its sibling is already there for the network half of the same reason, so the new line sits next to it and keeps the list alphabetical:

```cpp
 "checkupdates",   // avoid outbound network access (queries the release feed over TLS)
+"downloadupdate", // avoid outbound network access and writing to disk (fetches a release into the datadir)
 "dumptxoutset",   // avoid writing to disk
```

## The check terminates on the first miss, so I looked for the next one

Fixing the reported name can simply expose another, so I reproduced the check rather than assuming `downloadupdate` was alone. It is a set-membership test over registered command names, so it does not need a fuzz build: list the RPCs a wallet-free node registers, and diff against both lists parsed out of `rpc.cpp`.

Two names are missing, not one:

- `downloadupdate`, fixed here.
- `getzmqnotifications`, which **cannot** trip the check today. The fuzz container installs no ZMQ library (`PACKAGES` in `ci/test/00_setup_env_native_fuzz.sh`), so that RPC is not registered in the fuzz binary, and upstream omits it from these lists for the same reason.

I have deliberately left the second one unclassified. Adding an entry for an RPC that build cannot register would be a guess about how it should be fuzzed rather than a fact. It becomes a failure the day ZMQ is added to that container, and the symptom will look identical to this one, so it is recorded on the issue.

## Testing done

- Membership diff, before: `downloadupdate` and `getzmqnotifications` missing. After: `getzmqnotifications` only.
- Also checked that no command appears in *both* lists, which is the other condition that terminates the target: none does.
- `g++ -fsyntax-only` on the changed file is clean.

The end-to-end proof is this PR's own fuzz job, since running the target itself needs the clang plus sanitizer build.

## Unrelated, but noticed

Those lists carry several commands this tree no longer has: `addconnection`, `addpeeraddress`, `dumptxoutset`, `echoipc`, `estimaterawfee` among others. Stale entries are harmless, because only registered commands are checked, but they make the lists a poor guide to what exists. Not touched here.

YouTrack: https://reddink.youtrack.cloud/issue/RED-127
