### PR TITLE
qt: refresh only the transaction rows a new block can change

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -14,6 +14,7 @@
 
 #include <QFont>
 #include <QDebug>
+#include <QHash>
 
 const QString AddressTableModel::Send = "S";
 const QString AddressTableModel::Receive = "R";
@@ -70,6 +71,12 @@ class AddressTablePriv
 {
 public:
     QList<AddressTableEntry> cachedAddressTable;
+    /** Label of every non-change address book entry, keyed by the address
+     *  as EncodeDestination spells it. Unlike cachedAddressTable this is
+     *  never narrowed by pk_hash_only, so labelForAddress() can answer from
+     *  it for any address without taking the wallet lock. Kept current by
+     *  the same notifications that maintain the table. */
+    QHash<QString, QString> labels;
     AddressTableModel *parent;
 
     explicit AddressTablePriv(AddressTableModel *_parent):
@@ -78,17 +85,19 @@ public:
     void refreshAddressTable(interfaces::Wallet& wallet, bool pk_hash_only = false)
     {
         cachedAddressTable.clear();
+        labels.clear();
         {
             for (const auto& address : wallet.getAddresses())
             {
+                const QString address_str = QString::fromStdString(EncodeDestination(address.dest));
+                const QString label = QString::fromStdString(address.name);
+                labels.insert(address_str, label);
                 if (pk_hash_only && !std::holds_alternative<PKHash>(address.dest)) {
                     continue;
                 }
                 AddressTableEntry::Type addressType = translateTransactionType(
                         QString::fromStdString(address.purpose), address.is_mine);
-                cachedAddressTable.append(AddressTableEntry(addressType,
-                                  QString::fromStdString(address.name),
-                                  QString::fromStdString(EncodeDestination(address.dest))));
+                cachedAddressTable.append(AddressTableEntry(addressType, label, address_str));
             }
         }
         // std::lower_bound() and std::upper_bound() require our cachedAddressTable list to be sorted in asc order
@@ -108,6 +117,12 @@ public:
         int upperIndex = (upper - cachedAddressTable.begin());
         bool inModel = (lower != upper);
         AddressTableEntry::Type newEntryType = translateTransactionType(purpose, isMine);
+
+        if (status == CT_DELETED) {
+            labels.remove(address);
+        } else {
+            labels.insert(address, label);
+        }
 
         switch(status)
         {
@@ -411,11 +426,29 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
 
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
-    std::string name;
-    if (getAddressData(address, &name, /* purpose= */ nullptr)) {
-        return QString::fromStdString(name);
+    // Answer from the label index rather than the wallet. The transaction
+    // and minting tables ask this for every row they evaluate, and the
+    // wallet path decodes the address and takes cs_wallet each time, which
+    // on a large wallet is a lock the GUI thread waits on behind the staker.
+    const auto it = priv->labels.constFind(address);
+    if (it != priv->labels.constEnd()) {
+        return it.value();
     }
-    return QString();
+
+    // Not under this spelling. Rows from the wallet models are spelled by
+    // EncodeDestination and so were found above if they are in the book;
+    // what remains is either an address that is not in the book or user
+    // input in another spelling (a bech32 address in upper case). Resolve
+    // the latter by re-spelling it, still without touching the wallet.
+    const std::string canonical = EncodeDestination(DecodeDestination(address.toStdString()));
+    if (canonical.empty()) {
+        return QString();
+    }
+    const QString canonical_str = QString::fromStdString(canonical);
+    if (canonical_str == address) {
+        return QString();
+    }
+    return priv->labels.value(canonical_str);
 }
 
 QString AddressTableModel::purposeForAddress(const QString &address) const

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -67,7 +67,8 @@ public:
      */
     QString addRow(const QString &type, const QString &label, const QString &address, const OutputType address_type);
 
-    /** Look up label for address in address book, if not found return empty string. */
+    /** Look up label for address in address book, if not found return empty string.
+     *  Served from the model's own index, so it does not take the wallet lock. */
     QString labelForAddress(const QString &address) const;
 
     /** Look up purpose for address in address book, if not found return empty string. */

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -49,18 +49,24 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     if (datetime < dateFrom || datetime > dateTo)
         return false;
 
-    QString address = index.data(TransactionTableModel::AddressRole).toString();
-    QString label = index.data(TransactionTableModel::LabelRole).toString();
-    QString txid = index.data(TransactionTableModel::TxHashRole).toString();
-    if (!address.contains(m_search_string, Qt::CaseInsensitive) &&
-        !  label.contains(m_search_string, Qt::CaseInsensitive) &&
-        !   txid.contains(m_search_string, Qt::CaseInsensitive)) {
-        return false;
-    }
-
     qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
     if (amount < minAmount)
         return false;
+
+    // The three strings below are the costly part of a row: each is built
+    // on request, and the label is looked up in the address book. An empty
+    // search string matches everything, so only pay for them when one is
+    // set.
+    if (!m_search_string.isEmpty()) {
+        QString address = index.data(TransactionTableModel::AddressRole).toString();
+        QString label = index.data(TransactionTableModel::LabelRole).toString();
+        QString txid = index.data(TransactionTableModel::TxHashRole).toString();
+        if (!address.contains(m_search_string, Qt::CaseInsensitive) &&
+            !  label.contains(m_search_string, Qt::CaseInsensitive) &&
+            !   txid.contains(m_search_string, Qt::CaseInsensitive)) {
+            return false;
+        }
+    }
 
     return true;
 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -10,6 +10,7 @@
 #include <key_io.h>
 #include <wallet/ismine.h>
 
+#include <cassert>
 #include <stdint.h>
 
 #include <QDateTime>
@@ -250,6 +251,24 @@ bool TransactionRecord::statusUpdateNeeded(const uint256& block_hash) const
 {
     assert(!block_hash.IsNull());
     return status.m_cur_block_hash != block_hash || status.needsUpdate;
+}
+
+bool TransactionStatus::needsBlockRefresh() const
+{
+    switch (status) {
+    case Unconfirmed:
+    case Confirming:
+    case Immature:
+    case OpenUntilDate:
+    case OpenUntilBlock:
+        return true;
+    case Confirmed:
+    case Conflicted:
+    case Abandoned:
+    case NotAccepted:
+        return false;
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
 }
 
 QString TransactionRecord::getTxHash() const

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -25,7 +25,8 @@ class TransactionStatus
 {
 public:
     TransactionStatus() : countsForBalance(false), sortKey(""),
-                          matures_in(0), status(Unconfirmed), depth(0), open_for(0)
+                          matures_in(0), status(Unconfirmed), depth(0), open_for(0),
+                          needsUpdate(false)
     { }
 
     enum Status {
@@ -65,6 +66,14 @@ public:
     uint256 m_cur_block_hash{};
 
     bool needsUpdate;
+
+    /** Whether a new block can change this status without the wallet
+     *  reporting a change to the transaction: the row is waiting on depth
+     *  (confirmations, maturity) or on finality. Every other status moves
+     *  only through a transaction notification, and a confirmed row only
+     *  gains confirmations, which is refreshed when the row is next shown.
+     */
+    bool needsBlockRefresh() const;
 };
 
 /** UI model for a transaction. A core transaction can be represented by multiple UI transactions if it has

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -17,7 +17,9 @@
 
 #include <core_io.h>
 #include <interfaces/handler.h>
+#include <logging.h>
 #include <uint256.h>
+#include <util/time.h>
 
 #include <algorithm>
 #include <functional>
@@ -291,8 +293,15 @@ void TransactionTableModel::updateConfirmations()
     // Invalidate status (number of confirmations) and (possibly) description
     //  for all rows. Qt is smart enough to only actually request the data for the
     //  visible rows.
+    //
+    // Every proxy attached to this model answers each emit synchronously, and
+    // a proxy with dynamic sorting re-runs its filter on every row in the
+    // range, so the time reported here grows with the row count.
+    const int64_t nStart = GetTimeMicros();
     Q_EMIT dataChanged(index(0, Status), index(priv->size()-1, Status));
     Q_EMIT dataChanged(index(0, ToAddress), index(priv->size()-1, ToAddress));
+    LogPrint(BCLog::BENCH, "TransactionTableModel::updateConfirmations [%s]: %d rows in %.2fms\n",
+             walletModel->getWalletName().toStdString(), priv->size(), 0.001 * (GetTimeMicros() - nStart));
 }
 
 int TransactionTableModel::rowCount(const QModelIndex &parent) const

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -201,11 +201,17 @@ public:
             parent->endRemoveRows();
             break;
         case CT_UPDATED:
-            // Miscellaneous updates -- nothing to do, status update will take care of this, and is only computed for
-            // visible transactions.
+            // Miscellaneous updates: flag the rows so index() refreshes their
+            // status, then re-evaluate them now. A conflict, an abandon or a
+            // reorg can move a row across a proxy filter, and the per-block
+            // sweep in updateConfirmations() only visits rows that are
+            // waiting on depth.
             for (int i = lowerIndex; i < upperIndex; i++) {
                 TransactionRecord *rec = &cachedWallet[i];
                 rec->status.needsUpdate = true;
+            }
+            if (inModel) {
+                parent->emitRowsChanged(lowerIndex, upperIndex - 1);
             }
             break;
         }
@@ -289,19 +295,53 @@ void TransactionTableModel::updateTransaction(const QString &hash, int status, b
 
 void TransactionTableModel::updateConfirmations()
 {
-    // Blocks came in since last poll.
-    // Invalidate status (number of confirmations) and (possibly) description
-    //  for all rows. Qt is smart enough to only actually request the data for the
-    //  visible rows.
+    // Blocks came in since last poll. Re-evaluate the rows whose displayed
+    // status can move with a new block: those waiting on confirmations,
+    // maturity or finality, and those the wallet has flagged since the last
+    // pass. A confirmed row only gains confirmations, which index() refreshes
+    // when the row is next painted or hovered, and a conflicted, abandoned or
+    // rejected row moves only through a transaction notification, which
+    // updateWallet() re-evaluates on arrival.
     //
-    // Every proxy attached to this model answers each emit synchronously, and
-    // a proxy with dynamic sorting re-runs its filter on every row in the
-    // range, so the time reported here grows with the row count.
+    // Emitting dataChanged over every row is not free. Each proxy attached to
+    // this model answers synchronously and re-runs its filter on every row in
+    // the range, on the GUI thread, so the two whole-table emits that used to
+    // be here cost about 5 s per block on a wallet with 176k transactions.
+    //
+    // Rows that have never been refreshed carry the default status, which is
+    // Unconfirmed, so the first pass after loading still visits every row
+    // once and settles them; after that the set is the handful that are
+    // still moving.
     const int64_t nStart = GetTimeMicros();
-    Q_EMIT dataChanged(index(0, Status), index(priv->size()-1, Status));
-    Q_EMIT dataChanged(index(0, ToAddress), index(priv->size()-1, ToAddress));
-    LogPrint(BCLog::BENCH, "TransactionTableModel::updateConfirmations [%s]: %d rows in %.2fms\n",
-             walletModel->getWalletName().toStdString(), priv->size(), 0.001 * (GetTimeMicros() - nStart));
+    const int size = priv->size();
+    int rows = 0;
+    int ranges = 0;
+    int first = -1;
+    for (int i = 0; i < size; ++i) {
+        const TransactionStatus& status = priv->cachedWallet.at(i).status;
+        if (status.needsUpdate || status.needsBlockRefresh()) {
+            if (first < 0) first = i;
+            ++rows;
+        } else if (first >= 0) {
+            emitRowsChanged(first, i - 1);
+            ++ranges;
+            first = -1;
+        }
+    }
+    if (first >= 0) {
+        emitRowsChanged(first, size - 1);
+        ++ranges;
+    }
+    LogPrint(BCLog::BENCH, "TransactionTableModel::updateConfirmations [%s]: %d of %d rows in %d ranges, %.2fms\n",
+             walletModel->getWalletName().toStdString(), rows, size, ranges, 0.001 * (GetTimeMicros() - nStart));
+}
+
+void TransactionTableModel::emitRowsChanged(int first, int last)
+{
+    // Span every column. The status icon, the bracketed amount and the row
+    // colour all follow the status, and a range wider than one cell is what
+    // makes a view repaint rather than update the single cell.
+    Q_EMIT dataChanged(index(first, Status), index(last, Amount));
 }
 
 int TransactionTableModel::rowCount(const QModelIndex &parent) const

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -95,6 +95,10 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
 
+    /** Re-evaluate rows first..last: refresh their status and tell every
+     *  attached view and proxy that the whole row changed. */
+    void emitRowsChanged(int first, int last);
+
     QString lookupAddress(const std::string &address, bool tooltip) const;
     QVariant addressColor(const TransactionRecord *wtx) const;
     QString formatTxStatus(const TransactionRecord *wtx) const;


### PR DESCRIPTION
On a wallet with a long staking history, reddcoin-qt froze for about ten seconds after every block. The transaction table was re-evaluating every row it holds, in every filter proxy attached to it, on the GUI thread, once per wallet per block.

Tracked as [RED-134](https://reddink.youtrack.cloud/issue/RED-134), part of the [RED-130](https://reddink.youtrack.cloud/issue/RED-130) epic on GUI stalls with large staking wallets. This is the release line first; the port to `develop` follows.

## The problem

`TransactionTableModel::updateConfirmations` runs on every tip change and emitted `dataChanged` over the whole table, twice. Each `TransactionFilterProxy` on the model (the history view and the overview list, both with dynamic sorting) answers a `dataChanged` by re-running `filterAcceptsRow` on every row in the range. Per row that meant a status refresh with three `cs_main` acquisitions, seven role lookups, a base58 decode of the address, and a hard `cs_wallet` lock for the label. Four full passes per wallet per block, on every loaded wallet, shown or not.

A staking wallet gains a transaction per stake, so it reaches sizes this code was never run at. Measured on a live mainnet client with the timer from the first commit, `--enable-debug` build:

| Wallet | Rows | `updateConfirmations` per block |
|---|---|---|
| Main_funds | 176,005 | 4,921 ms |
| default wallet | 59,093 | 1,601 ms |
| Bittrex_Funds_1 | 38,054 | 1,074 ms |
| all 16 loaded wallets | 273,152 | 7,611 ms |

A flat 27 to 28 us per row, and the GUI thread at 100% for 8 to 10 s after each block.

## The change

Only rows waiting on depth can change with a block without the wallet reporting it: unconfirmed, confirming, immature, and the two non-final states. `updateConfirmations` now scans the cached records in memory for those and emits per contiguous run. A confirmed row only gains confirmations, which `index()` already refreshes lazily when the row is next painted or hovered. A conflicted, abandoned or rejected row moves only through a transaction notification, so `updateWallet` now re-evaluates those rows itself when the notification arrives; previously it set a flag and left the whole-table sweep to notice.

A changed row emits its full column span rather than the status and address cells, so the amount brackets and the row colour repaint with the status icon. `needsUpdate` was never initialised and now is.

Two smaller changes cut the per-row cost of the passes that remain (the mapping build when a wallet loads, and filter changes in the history view):

- `labelForAddress` answers from a label index kept in `AddressTableModel`, maintained by the same address book notifications as the table, instead of decoding the address and taking `cs_wallet` on every call. The index is deliberately not narrowed by `pk_hash_only`: the sign-message dialog rebuilds the wallet's address table with pay-to-pubkey-hash entries only, and labels for other address types must survive that. A miss re-spells the address and looks again, so user input in another spelling still resolves.
- `filterAcceptsRow` builds the address, label and txid strings only when a search string is set.

The BENCH timer from the first commit stays, reporting live rows, total rows and range count per wallet per block under `-debug=bench`.

## Result

Same client, same wallets, staking on:

| | Before | After |
|---|---|---|
| Transaction-table refresh, all wallets, per block | 7,611 ms | about 3 ms |
| GUI thread pinned at 100% after a block | 8 to 10 s | none |
| GUI-thread CPU per block | about 8 s | 1.5 to 3 s |

The remaining 1.5 to 3 s is the stake-weight recomputation on the GUI thread, which is RED-131.

On a testnet wallet with 1,181,130 transactions the sweep is 49 to 50 live rows in 13 ms per block, where the old code would have spent about 33 s. The live set tracked the immature coinstakes exactly as stakes landed and matured.

## Verification

- `/proc` sampling of the GUI thread at 1 Hz across blocks, before and after, aligned with `UpdateTip`; figures above.
- `-debug=bench` lines per wallet per block, before and after.
- In the running client: labels shown in the history view and the overview list, search matching on address, label and txid, a new stake appearing as a row and losing its brackets at maturity, immature rows leaving the live set at 31 confirmations.
- `test_reddcoin-qt` aborts in `WalletTests` on this line (RED-122), so unit coverage lands with the `develop` port.

Behaviour to note: a label edit now repaints in the history view on the next repaint rather than on the next block.
