### PR TITLE
qt: refresh only the transaction rows a new block can change

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -14,6 +14,7 @@
 
 #include <QFont>
 #include <QDebug>
+#include <QHash>
 
 const QString AddressTableModel::Send = "S";
 const QString AddressTableModel::Receive = "R";
@@ -70,6 +71,12 @@ class AddressTablePriv
 {
 public:
     QList<AddressTableEntry> cachedAddressTable;
+    /** Label of every non-change address book entry, keyed by the address
+     *  as EncodeDestination spells it. Unlike cachedAddressTable this is
+     *  never narrowed by pk_hash_only, so labelForAddress() can answer from
+     *  it for any address without taking the wallet lock. Kept current by
+     *  the same notifications that maintain the table. */
+    QHash<QString, QString> labels;
     AddressTableModel *parent;
 
     explicit AddressTablePriv(AddressTableModel *_parent):
@@ -78,17 +85,19 @@ public:
     void refreshAddressTable(interfaces::Wallet& wallet, bool pk_hash_only = false)
     {
         cachedAddressTable.clear();
+        labels.clear();
         {
             for (const auto& address : wallet.getAddresses())
             {
+                const QString address_str = QString::fromStdString(EncodeDestination(address.dest));
+                const QString label = QString::fromStdString(address.name);
+                labels.insert(address_str, label);
                 if (pk_hash_only && !std::holds_alternative<PKHash>(address.dest)) {
                     continue;
                 }
                 AddressTableEntry::Type addressType = translateTransactionType(
                         QString::fromStdString(address.purpose), address.is_mine);
-                cachedAddressTable.append(AddressTableEntry(addressType,
-                                  QString::fromStdString(address.name),
-                                  QString::fromStdString(EncodeDestination(address.dest))));
+                cachedAddressTable.append(AddressTableEntry(addressType, label, address_str));
             }
         }
         // std::lower_bound() and std::upper_bound() require our cachedAddressTable list to be sorted in asc order
@@ -108,6 +117,12 @@ public:
         int upperIndex = (upper - cachedAddressTable.begin());
         bool inModel = (lower != upper);
         AddressTableEntry::Type newEntryType = translateTransactionType(purpose, isMine);
+
+        if (status == CT_DELETED) {
+            labels.remove(address);
+        } else {
+            labels.insert(address, label);
+        }
 
         switch(status)
         {
@@ -411,11 +426,29 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
 
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
-    std::string name;
-    if (getAddressData(address, &name, /* purpose= */ nullptr)) {
-        return QString::fromStdString(name);
+    // Answer from the label index rather than the wallet. The transaction
+    // and minting tables ask this for every row they evaluate, and the
+    // wallet path decodes the address and takes cs_wallet each time, which
+    // on a large wallet is a lock the GUI thread waits on behind the staker.
+    const auto it = priv->labels.constFind(address);
+    if (it != priv->labels.constEnd()) {
+        return it.value();
     }
-    return QString();
+
+    // Not under this spelling. Rows from the wallet models are spelled by
+    // EncodeDestination and so were found above if they are in the book;
+    // what remains is either an address that is not in the book or user
+    // input in another spelling (a bech32 address in upper case). Resolve
+    // the latter by re-spelling it, still without touching the wallet.
+    const std::string canonical = EncodeDestination(DecodeDestination(address.toStdString()));
+    if (canonical.empty()) {
+        return QString();
+    }
+    const QString canonical_str = QString::fromStdString(canonical);
+    if (canonical_str == address) {
+        return QString();
+    }
+    return priv->labels.value(canonical_str);
 }
 
 QString AddressTableModel::purposeForAddress(const QString &address) const

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -67,7 +67,8 @@ public:
      */
     QString addRow(const QString &type, const QString &label, const QString &address, const OutputType address_type);
 
-    /** Look up label for address in address book, if not found return empty string. */
+    /** Look up label for address in address book, if not found return empty string.
+     *  Served from the model's own index, so it does not take the wallet lock. */
     QString labelForAddress(const QString &address) const;
 
     /** Look up purpose for address in address book, if not found return empty string. */

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -8,6 +8,7 @@
 
 #include <interfaces/chain.h>
 #include <interfaces/node.h>
+#include <qt/addresstablemodel.h>
 #include <qt/bitcoinamountfield.h>
 #include <qt/clientmodel.h>
 #include <qt/optionsmodel.h>
@@ -15,6 +16,8 @@
 #include <qt/qvalidatedlineedit.h>
 #include <qt/sendcoinsdialog.h>
 #include <qt/sendcoinsentry.h>
+#include <qt/transactionfilterproxy.h>
+#include <qt/transactionrecord.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
 #include <qt/walletmodel.h>
@@ -33,6 +36,7 @@
 #include <QAction>
 #include <QApplication>
 #include <QCheckBox>
+#include <QCoreApplication>
 #include <QPushButton>
 #include <QTimer>
 #include <QVBoxLayout>
@@ -294,20 +298,239 @@ void TestGUI(interfaces::Node& node)
     QCOMPARE(walletModel.wallet().getAddressReceiveRequests().size(), size_t{0});
 }
 
+//! Load the height-100 chain's coinbases into a fresh wallet, as TestGUI does.
+std::shared_ptr<CWallet> LoadCoinbaseWallet(interfaces::Node& node, TestChain100Setup& test)
+{
+    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
+    wallet->LoadWallet();
+    {
+        auto spk_man = wallet->GetOrCreateLegacyScriptPubKeyMan();
+        LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
+        wallet->SetAddressBook(GetDestinationForKey(test.coinbaseKey.GetPubKey(), wallet->m_default_address_type), "", "receive");
+        spk_man->AddKeyPubKey(test.coinbaseKey, test.coinbaseKey.GetPubKey());
+        wallet->SetLastBlockProcessed(node.context()->chainman->ActiveChain().Height(), node.context()->chainman->ActiveChain().Tip()->GetBlockHash());
+    }
+    WalletRescanReserver reserver(*wallet);
+    reserver.reserve();
+    CWallet::ScanResult result = wallet->ScanForWalletTransactions(Params().GetConsensus().hashGenesisBlock, 0 /* block height */, {} /* max height */, reserver, true /* fUpdate */);
+    if (result.status != CWallet::ScanResult::SUCCESS) return nullptr;
+    return wallet;
+}
+
+//! The per-block refresh visits exactly the rows whose status can still move
+//! with a block, a transaction notification re-evaluates the rows it names,
+//! and the history filter still finds rows by txid and label.
+void TestTransactionTableRefresh(interfaces::Node& node)
+{
+    TestChain100Setup test;
+    node.setContext(&test.m_node);
+    std::shared_ptr<CWallet> wallet = LoadCoinbaseWallet(node, test);
+    QVERIFY(wallet);
+
+    // A view attaches a dynamic filter proxy, as the history page does, so
+    // every row is evaluated and settled the way it is in the client.
+    std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
+    TransactionView transactionView(platformStyle.get());
+    OptionsModel optionsModel;
+    ClientModel clientModel(node, &optionsModel);
+    AddWallet(wallet);
+    WalletModel walletModel(interfaces::MakeWallet(wallet), clientModel, platformStyle.get());
+    RemoveWallet(wallet, std::nullopt);
+    transactionView.setModel(&walletModel);
+
+    TransactionTableModel* model = walletModel.getTransactionTableModel();
+    const int rows = model->rowCount({});
+    QVERIFY(rows > 0);
+
+    // Record every row range the model reports as changed.
+    std::vector<std::pair<int, int>> ranges;
+    QMetaObject::Connection recorder = QObject::connect(model, &QAbstractItemModel::dataChanged,
+        [&ranges](const QModelIndex& top_left, const QModelIndex& bottom_right) {
+            ranges.emplace_back(top_left.row(), bottom_right.row());
+        });
+    auto covered = [&ranges](int row) {
+        for (const auto& range : ranges) {
+            if (row >= range.first && row <= range.second) return true;
+        }
+        return false;
+    };
+    auto role = [model](int row, int which) {
+        return model->data(model->index(row, 0, {}), which);
+    };
+    auto live = [&role](int row) {
+        TransactionStatus status;
+        status.status = static_cast<TransactionStatus::Status>(role(row, TransactionTableModel::StatusRole).toInt());
+        return status.needsBlockRefresh();
+    };
+
+    // The first sweep after loading may visit every row, since a row that
+    // has never been refreshed carries the default status. The second sees
+    // settled statuses and is the one the client runs on every block.
+    model->updateConfirmations();
+    ranges.clear();
+    model->updateConfirmations();
+
+    // At height 100 with a maturity of 60 the early coinbases are confirmed
+    // and the later ones immature, so both kinds are present.
+    int live_rows = 0;
+    int settled_rows = 0;
+    for (int row = 0; row < rows; ++row) {
+        if (live(row)) {
+            ++live_rows;
+            QVERIFY2(covered(row), "a row still waiting on depth was not refreshed");
+        } else {
+            ++settled_rows;
+            QVERIFY2(!covered(row), "a settled row was refreshed");
+        }
+    }
+    QVERIFY(live_rows > 0);
+    QVERIFY(settled_rows > 0);
+
+    // A transaction notification re-evaluates the rows it names, whether or
+    // not the per-block sweep would have visited them.
+    int settled_row = -1;
+    for (int row = 0; row < rows && settled_row < 0; ++row) {
+        if (!live(row)) settled_row = row;
+    }
+    QVERIFY(settled_row >= 0);
+    const QString settled_hash = role(settled_row, TransactionTableModel::TxHashRole).toString();
+    uint256 settled_txid;
+    settled_txid.SetHex(settled_hash.toStdString());
+    ranges.clear();
+    wallet->NotifyTransactionChanged(settled_txid, CT_UPDATED);
+    QCoreApplication::processEvents(); // the notification reaches the model through the event loop
+    QVERIFY2(covered(settled_row), "a CT_UPDATED notification did not re-evaluate its row");
+    QObject::disconnect(recorder);
+
+    // The filter reads the address, label and txid strings only when a
+    // search is set; both paths must still answer correctly.
+    TransactionFilterProxy proxy;
+    proxy.setSourceModel(model);
+    QCOMPARE(proxy.rowCount({}), rows);
+    proxy.setSearchString(settled_hash.left(16));
+    QCOMPARE(proxy.rowCount({}), 1);
+    proxy.setSearchString("no such transaction");
+    QCOMPARE(proxy.rowCount({}), 0);
+
+    // Labelling the coinbase address must make every row paying to it match
+    // a search for that label. Stake rows carry no address and do not count.
+    const QString coinbase_address = QString::fromStdString(EncodeDestination(GetDestinationForKey(test.coinbaseKey.GetPubKey(), wallet->m_default_address_type)));
+    int coinbase_rows = 0;
+    for (int row = 0; row < rows; ++row) {
+        if (role(row, TransactionTableModel::AddressRole).toString() == coinbase_address) ++coinbase_rows;
+    }
+    QVERIFY(coinbase_rows > 0);
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->SetAddressBook(GetDestinationForKey(test.coinbaseKey.GetPubKey(), wallet->m_default_address_type), "mined here", "receive");
+    }
+    QCoreApplication::processEvents(); // the address book change reaches the label index through the event loop
+    proxy.setSearchString("mined here");
+    QCOMPARE(proxy.rowCount({}), coinbase_rows);
+    proxy.setSearchString("");
+    QCOMPARE(proxy.rowCount({}), rows);
+}
+
+//! Labels are served from the address table model's own index: complete for
+//! every address type, current with the address book, and tolerant of
+//! another spelling of the same address.
+void TestLabelIndex(interfaces::Node& node)
+{
+    TestChain100Setup test;
+    node.setContext(&test.m_node);
+    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(node.context()->chain.get(), "", CreateMockWalletDatabase());
+    wallet->SetupLegacyScriptPubKeyMan();
+    wallet->LoadWallet();
+
+    // Two spellings of one key: a pay-to-pubkey-hash address and a bech32 one.
+    CKey key;
+    key.MakeNewKey(true);
+    const CTxDestination pkhash_dest = GetDestinationForKey(key.GetPubKey(), OutputType::LEGACY);
+    const CTxDestination bech32_dest = GetDestinationForKey(key.GetPubKey(), OutputType::BECH32);
+    const QString pkhash_address = QString::fromStdString(EncodeDestination(pkhash_dest));
+    const QString bech32_address = QString::fromStdString(EncodeDestination(bech32_dest));
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->SetAddressBook(pkhash_dest, "legacy label", "send");
+        wallet->SetAddressBook(bech32_dest, "witness label", "send");
+    }
+
+    std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
+    OptionsModel optionsModel;
+    ClientModel clientModel(node, &optionsModel);
+    AddWallet(wallet);
+    WalletModel walletModel(interfaces::MakeWallet(wallet), clientModel, platformStyle.get());
+    RemoveWallet(wallet, std::nullopt);
+
+    AddressTableModel* addresses = walletModel.getAddressTableModel();
+    QCOMPARE(addresses->labelForAddress(pkhash_address), QString("legacy label"));
+    QCOMPARE(addresses->labelForAddress(bech32_address), QString("witness label"));
+    // bech32 is case-insensitive, so the upper-case spelling names the same entry.
+    QCOMPARE(addresses->labelForAddress(bech32_address.toUpper()), QString("witness label"));
+
+    // An address that is not in the book, and a string that is not an address.
+    CKey other;
+    other.MakeNewKey(true);
+    QCOMPARE(addresses->labelForAddress(QString::fromStdString(EncodeDestination(GetDestinationForKey(other.GetPubKey(), OutputType::LEGACY)))), QString());
+    QCOMPARE(addresses->labelForAddress(QString("not an address")), QString());
+
+    // The index follows the address book through its notifications.
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->SetAddressBook(pkhash_dest, "renamed", "send");
+        wallet->DelAddressBook(bech32_dest);
+    }
+    QCoreApplication::processEvents();
+    QCOMPARE(addresses->labelForAddress(pkhash_address), QString("renamed"));
+    QCOMPARE(addresses->labelForAddress(bech32_address), QString());
+
+    // The sign-message dialog rebuilds the wallet's address table with
+    // pay-to-pubkey-hash entries only. The table shrinks; the labels of every
+    // other address type must survive, since the history view still asks for them.
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->SetAddressBook(bech32_dest, "witness label", "send");
+    }
+    QCoreApplication::processEvents();
+    walletModel.refresh(/* pk_hash_only */ true);
+    addresses = walletModel.getAddressTableModel();
+    QCOMPARE(addresses->rowCount({}), 1);
+    QCOMPARE(addresses->labelForAddress(pkhash_address), QString("renamed"));
+    QCOMPARE(addresses->labelForAddress(bech32_address), QString("witness label"));
+}
+
+//! Qt on macOS crashes inside the framework on the "minimal" platform when it
+//! looks up unimplemented cocoa functions (https://bugreports.qt.io/browse/QTBUG-49686).
+bool SkipOnMacMinimalPlatform(const char* test_name)
+{
+#ifdef Q_OS_MAC
+    if (QApplication::platformName() == "minimal") {
+        QWARN(QString("Skipping %1 on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
+                      "with 'QT_QPA_PLATFORM=cocoa test_reddcoin-qt' on mac, or else use a linux or windows build.")
+                  .arg(test_name).toUtf8().constData());
+        return true;
+    }
+#endif
+    (void)test_name;
+    return false;
+}
+
 } // namespace
 
 void WalletTests::walletTests()
 {
-#ifdef Q_OS_MAC
-    if (QApplication::platformName() == "minimal") {
-        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
-        // framework when it tries to look up unimplemented cocoa functions,
-        // and fails to handle returned nulls
-        // (https://bugreports.qt.io/browse/QTBUG-49686).
-        QWARN("Skipping WalletTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
-              "with 'QT_QPA_PLATFORM=cocoa test_reddcoin-qt' on mac, or else use a linux or windows build.");
-        return;
-    }
-#endif
+    if (SkipOnMacMinimalPlatform("WalletTests")) return;
     TestGUI(m_node);
+}
+
+void WalletTests::transactionTableTests()
+{
+    if (SkipOnMacMinimalPlatform("transactionTableTests")) return;
+    TestTransactionTableRefresh(m_node);
+}
+
+void WalletTests::labelIndexTests()
+{
+    if (SkipOnMacMinimalPlatform("labelIndexTests")) return;
+    TestLabelIndex(m_node);
 }

--- a/src/qt/test/wallettests.h
+++ b/src/qt/test/wallettests.h
@@ -22,6 +22,8 @@ class WalletTests : public QObject
 
 private Q_SLOTS:
     void walletTests();
+    void transactionTableTests();
+    void labelIndexTests();
 };
 
 #endif // BITCOIN_QT_TEST_WALLETTESTS_H

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -49,18 +49,24 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     if (datetime < dateFrom || datetime > dateTo)
         return false;
 
-    QString address = index.data(TransactionTableModel::AddressRole).toString();
-    QString label = index.data(TransactionTableModel::LabelRole).toString();
-    QString txid = index.data(TransactionTableModel::TxHashRole).toString();
-    if (!address.contains(m_search_string, Qt::CaseInsensitive) &&
-        !  label.contains(m_search_string, Qt::CaseInsensitive) &&
-        !   txid.contains(m_search_string, Qt::CaseInsensitive)) {
-        return false;
-    }
-
     qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
     if (amount < minAmount)
         return false;
+
+    // The three strings below are the costly part of a row: each is built
+    // on request, and the label is looked up in the address book. An empty
+    // search string matches everything, so only pay for them when one is
+    // set.
+    if (!m_search_string.isEmpty()) {
+        QString address = index.data(TransactionTableModel::AddressRole).toString();
+        QString label = index.data(TransactionTableModel::LabelRole).toString();
+        QString txid = index.data(TransactionTableModel::TxHashRole).toString();
+        if (!address.contains(m_search_string, Qt::CaseInsensitive) &&
+            !  label.contains(m_search_string, Qt::CaseInsensitive) &&
+            !   txid.contains(m_search_string, Qt::CaseInsensitive)) {
+            return false;
+        }
+    }
 
     return true;
 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -10,6 +10,7 @@
 #include <key_io.h>
 #include <wallet/ismine.h>
 
+#include <cassert>
 #include <stdint.h>
 
 #include <QDateTime>
@@ -250,6 +251,24 @@ bool TransactionRecord::statusUpdateNeeded(const uint256& block_hash) const
 {
     assert(!block_hash.IsNull());
     return status.m_cur_block_hash != block_hash || status.needsUpdate;
+}
+
+bool TransactionStatus::needsBlockRefresh() const
+{
+    switch (status) {
+    case Unconfirmed:
+    case Confirming:
+    case Immature:
+    case OpenUntilDate:
+    case OpenUntilBlock:
+        return true;
+    case Confirmed:
+    case Conflicted:
+    case Abandoned:
+    case NotAccepted:
+        return false;
+    } // no default case, so the compiler can warn about missing cases
+    assert(false);
 }
 
 QString TransactionRecord::getTxHash() const

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -25,7 +25,8 @@ class TransactionStatus
 {
 public:
     TransactionStatus() : countsForBalance(false), sortKey(""),
-                          matures_in(0), status(Unconfirmed), depth(0), open_for(0)
+                          matures_in(0), status(Unconfirmed), depth(0), open_for(0),
+                          needsUpdate(false)
     { }
 
     enum Status {
@@ -65,6 +66,14 @@ public:
     uint256 m_cur_block_hash{};
 
     bool needsUpdate;
+
+    /** Whether a new block can change this status without the wallet
+     *  reporting a change to the transaction: the row is waiting on depth
+     *  (confirmations, maturity) or on finality. Every other status moves
+     *  only through a transaction notification, and a confirmed row only
+     *  gains confirmations, which is refreshed when the row is next shown.
+     */
+    bool needsBlockRefresh() const;
 };
 
 /** UI model for a transaction. A core transaction can be represented by multiple UI transactions if it has

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -203,11 +203,17 @@ public:
             parent->endRemoveRows();
             break;
         case CT_UPDATED:
-            // Miscellaneous updates -- nothing to do, status update will take care of this, and is only computed for
-            // visible transactions.
+            // Miscellaneous updates: flag the rows so index() refreshes their
+            // status, then re-evaluate them now. A conflict, an abandon or a
+            // reorg can move a row across a proxy filter, and the per-block
+            // sweep in updateConfirmations() only visits rows that are
+            // waiting on depth.
             for (int i = lowerIndex; i < upperIndex; i++) {
                 TransactionRecord *rec = &cachedWallet[i];
                 rec->status.needsUpdate = true;
+            }
+            if (inModel) {
+                parent->emitRowsChanged(lowerIndex, upperIndex - 1);
             }
             break;
         }
@@ -291,19 +297,53 @@ void TransactionTableModel::updateTransaction(const QString &hash, int status, b
 
 void TransactionTableModel::updateConfirmations()
 {
-    // Blocks came in since last poll.
-    // Invalidate status (number of confirmations) and (possibly) description
-    //  for all rows. Qt is smart enough to only actually request the data for the
-    //  visible rows.
+    // Blocks came in since last poll. Re-evaluate the rows whose displayed
+    // status can move with a new block: those waiting on confirmations,
+    // maturity or finality, and those the wallet has flagged since the last
+    // pass. A confirmed row only gains confirmations, which index() refreshes
+    // when the row is next painted or hovered, and a conflicted, abandoned or
+    // rejected row moves only through a transaction notification, which
+    // updateWallet() re-evaluates on arrival.
     //
-    // Every proxy attached to this model answers each emit synchronously, and
-    // a proxy with dynamic sorting re-runs its filter on every row in the
-    // range, so the time reported here grows with the row count.
+    // Emitting dataChanged over every row is not free. Each proxy attached to
+    // this model answers synchronously and re-runs its filter on every row in
+    // the range, on the GUI thread, so the two whole-table emits that used to
+    // be here cost about 5 s per block on a wallet with 176k transactions.
+    //
+    // Rows that have never been refreshed carry the default status, which is
+    // Unconfirmed, so the first pass after loading still visits every row
+    // once and settles them; after that the set is the handful that are
+    // still moving.
     const int64_t nStart = GetTimeMicros();
-    Q_EMIT dataChanged(index(0, Status), index(priv->size()-1, Status));
-    Q_EMIT dataChanged(index(0, ToAddress), index(priv->size()-1, ToAddress));
-    LogPrint(BCLog::BENCH, "TransactionTableModel::updateConfirmations [%s]: %d rows in %.2fms\n",
-             walletModel->getWalletName().toStdString(), priv->size(), 0.001 * (GetTimeMicros() - nStart));
+    const int size = priv->size();
+    int rows = 0;
+    int ranges = 0;
+    int first = -1;
+    for (int i = 0; i < size; ++i) {
+        const TransactionStatus& status = priv->cachedWallet.at(i).status;
+        if (status.needsUpdate || status.needsBlockRefresh()) {
+            if (first < 0) first = i;
+            ++rows;
+        } else if (first >= 0) {
+            emitRowsChanged(first, i - 1);
+            ++ranges;
+            first = -1;
+        }
+    }
+    if (first >= 0) {
+        emitRowsChanged(first, size - 1);
+        ++ranges;
+    }
+    LogPrint(BCLog::BENCH, "TransactionTableModel::updateConfirmations [%s]: %d of %d rows in %d ranges, %.2fms\n",
+             walletModel->getWalletName().toStdString(), rows, size, ranges, 0.001 * (GetTimeMicros() - nStart));
+}
+
+void TransactionTableModel::emitRowsChanged(int first, int last)
+{
+    // Span every column. The status icon, the bracketed amount and the row
+    // colour all follow the status, and a range wider than one cell is what
+    // makes a view repaint rather than update the single cell.
+    Q_EMIT dataChanged(index(first, Status), index(last, Amount));
 }
 
 int TransactionTableModel::rowCount(const QModelIndex &parent) const

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -17,7 +17,9 @@
 
 #include <core_io.h>
 #include <interfaces/handler.h>
+#include <logging.h>
 #include <uint256.h>
+#include <util/time.h>
 
 #include <algorithm>
 #include <functional>
@@ -293,8 +295,15 @@ void TransactionTableModel::updateConfirmations()
     // Invalidate status (number of confirmations) and (possibly) description
     //  for all rows. Qt is smart enough to only actually request the data for the
     //  visible rows.
+    //
+    // Every proxy attached to this model answers each emit synchronously, and
+    // a proxy with dynamic sorting re-runs its filter on every row in the
+    // range, so the time reported here grows with the row count.
+    const int64_t nStart = GetTimeMicros();
     Q_EMIT dataChanged(index(0, Status), index(priv->size()-1, Status));
     Q_EMIT dataChanged(index(0, ToAddress), index(priv->size()-1, ToAddress));
+    LogPrint(BCLog::BENCH, "TransactionTableModel::updateConfirmations [%s]: %d rows in %.2fms\n",
+             walletModel->getWalletName().toStdString(), priv->size(), 0.001 * (GetTimeMicros() - nStart));
 }
 
 int TransactionTableModel::rowCount(const QModelIndex &parent) const

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -95,6 +95,10 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
 
+    /** Re-evaluate rows first..last: refresh their status and tell every
+     *  attached view and proxy that the whole row changed. */
+    void emitRowsChanged(int first, int last);
+
     QString lookupAddress(const std::string &address, bool tooltip) const;
     QVariant addressColor(const TransactionRecord *wtx) const;
     QString formatTxStatus(const TransactionRecord *wtx) const;


### PR DESCRIPTION
Port of #558 to `develop`, with the unit coverage that line cannot run. The four source commits apply unchanged; `transactiontablemodel.cpp` differs here only in the palette colours, outside the changed regions.

On a wallet with a long staking history, reddcoin-qt froze for about ten seconds after every block. The transaction table was re-evaluating every row it holds, in every filter proxy attached to it, on the GUI thread, once per wallet per block. Tracked as [RED-134](https://reddink.youtrack.cloud/issue/RED-134), part of the [RED-130](https://reddink.youtrack.cloud/issue/RED-130) epic on GUI stalls with large staking wallets.

## The problem

`TransactionTableModel::updateConfirmations` runs on every tip change and emitted `dataChanged` over the whole table, twice. Each `TransactionFilterProxy` on the model (the history view and the overview list, both with dynamic sorting) answers a `dataChanged` by re-running `filterAcceptsRow` on every row in the range. Per row that meant a status refresh with three `cs_main` acquisitions, seven role lookups, a base58 decode of the address, and a hard `cs_wallet` lock for the label. Four full passes per wallet per block, on every loaded wallet, shown or not.

Measured on a live mainnet client with the timer from the first commit, `--enable-debug` build:

| Wallet | Rows | `updateConfirmations` per block |
|---|---|---|
| Main_funds | 176,005 | 4,921 ms |
| default wallet | 59,093 | 1,601 ms |
| Bittrex_Funds_1 | 38,054 | 1,074 ms |
| all 16 loaded wallets | 273,152 | 7,611 ms |

A flat 27 to 28 us per row, and the GUI thread at 100% for 8 to 10 s after each block.

## The change

Only rows waiting on depth can change with a block without the wallet reporting it: unconfirmed, confirming, immature, and the two non-final states. `updateConfirmations` now scans the cached records in memory for those and emits per contiguous run. A confirmed row only gains confirmations, which `index()` already refreshes lazily when the row is next painted or hovered. A conflicted, abandoned or rejected row moves only through a transaction notification, so `updateWallet` now re-evaluates those rows itself when the notification arrives; previously it set a flag and left the whole-table sweep to notice.

A changed row emits its full column span rather than the status and address cells, so the amount brackets and the row colour repaint with the status icon. `needsUpdate` was never initialised and now is.

Two smaller changes cut the per-row cost of the passes that remain (the mapping build when a wallet loads, and filter changes in the history view):

- `labelForAddress` answers from a label index kept in `AddressTableModel`, maintained by the same address book notifications as the table, instead of decoding the address and taking `cs_wallet` on every call. The index is deliberately not narrowed by `pk_hash_only`: the sign-message dialog rebuilds the wallet's address table with pay-to-pubkey-hash entries only, and labels for other address types must survive that. A miss re-spells the address and looks again, so user input in another spelling still resolves.
- `filterAcceptsRow` builds the address, label and txid strings only when a search string is set.

The BENCH timer from the first commit stays, reporting live rows, total rows and range count per wallet per block under `-debug=bench`.

## Result

Same client, same wallets, staking on:

| | Before | After |
|---|---|---|
| Transaction-table refresh, all wallets, per block | 7,611 ms | about 3 ms |
| GUI thread pinned at 100% after a block | 8 to 10 s | none |
| GUI-thread CPU per block | about 8 s | 1.5 to 3 s |

The remaining 1.5 to 3 s is the stake-weight recomputation on the GUI thread, which is RED-131.

On a testnet wallet with 1,181,130 transactions the sweep is 49 to 50 live rows in 13 ms per block, where the old code would have spent about 33 s. The live set tracked the immature coinstakes exactly as stakes landed and matured.

## Tests

Two new slots in `WalletTests` (`src/qt/test/wallettests.cpp`), on the chain `TestChain100Setup` builds, which at height 100 with a maturity of 60 holds both confirmed and immature rows:

- `transactionTableTests`: with a history view attached so rows settle as in the client, a sweep refreshes every row still waiting on depth and none that is settled; a CT_UPDATED notification re-evaluates the row it names regardless; the history filter finds rows by txid and by label when a search is set and accepts every row when none is.
- `labelIndexTests`: labels found for a pay-to-pubkey-hash and a bech32 address, found under the upper-case bech32 spelling, empty for an address not in the book and for a string that is not an address, following a rename and a delete, and still present for the bech32 entry after the address table has been rebuilt pay-to-pubkey-hash only.

`test_reddcoin-qt` passes with both.

Verified in a running client on the 4.22.9 build of the same commits: labels shown in the history view and the overview list, search matching on address, label and txid, a new stake appearing as a row and losing its brackets at maturity, immature rows leaving the live set at 31 confirmations.

Behaviour to note: a label edit now repaints in the history view on the next repaint rather than on the next block.
