### PR TITLE
staker: publish the stake weight from the search pass

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -26,7 +26,6 @@
 class BanMan;
 class CCoinControl;
 class CFeeRate;
-class CInputCoin;
 class CNodeStats;
 class Coin;
 class RPCTimerInterface;
@@ -151,9 +150,6 @@ public:
 
     //! Get PoSVKernelPS.
     virtual uint64_t getPoSVKernelPS() = 0;
-
-    //! Get the total and average weights from the wallet for staking.
-    virtual bool getStakeWeight(std::set<CInputCoin>& setCoins, uint64_t& nAverageWeight, uint64_t & nTotalWeight) = 0;
 
     //! Set staking active.
     virtual void setNodeStakingActive(bool active) = 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -193,9 +193,6 @@ public:
     //! Get node synchronization information.
     virtual void getSyncInfo(int& numBlocks, bool& isSyncing) = 0;
 
-    //! Try to get node synchronization information.
-    virtual bool tryGetSyncInfo(int& numBlocks, bool& isSyncing) = 0;
-
     //! Get wallet client.
     virtual WalletClient& walletClient() = 0;
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -25,7 +25,6 @@
 
 class CCoinControl;
 class CFeeRate;
-class CInputCoin;
 class CKey;
 class CWallet;
 enum class FeeReason;
@@ -90,8 +89,11 @@ public:
     //! Get public key.
     virtual bool getPubKey(const CScript& script, const CKeyID& address, CPubKey& pub_key) = 0;
 
-    //! Get set of input coins to calculate average and total weight.
-    virtual bool GetStakeWeightSet(std::set<CInputCoin>& setCoins) = 0;
+    //! Stake weight the staking thread last published for this wallet, in
+    //! coin-days: average per coin and total. Returns false, with zeros,
+    //! until a search pass has completed or once the thread has stopped.
+    //! Takes no lock.
+    virtual bool getStakeWeight(uint64_t& average_weight, uint64_t& total_weight) = 0;
 
     //! Get wallet staking enabled.
     virtual bool getEnableStaking() = 0;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -186,7 +186,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         int64_t nSearchTime = txCoinStake.nTime; // search to current time
         if (nSearchTime > nLastCoinStakeSearchTime)
         {
-            if (CreateCoinStake(pwallet, &m_chainstate, pblock->nBits, nSearchTime-nLastCoinStakeSearchTime, txCoinStake, chainparams.GetConsensus()))
+            StakeWeightSummary weight;
+            if (CreateCoinStake(pwallet, &m_chainstate, pblock->nBits, nSearchTime-nLastCoinStakeSearchTime, txCoinStake, chainparams.GetConsensus(), &weight))
             {
                 if (txCoinStake.nTime >= std::max(pindexPrev->GetMedianTimePast()+1, pindexPrev->GetBlockTime() - MAX_FUTURE_STAKE_TIME))
                 {   // make sure coinstake would meet timestamp protocol
@@ -198,6 +199,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
                 }
             }
             pwallet->SetLastCoinStakeSearchInterval(nSearchTime - nLastCoinStakeSearchTime);
+            // Publish what the pass measured, beside the interval it already
+            // reports, so the GUI and getstakinginfo need not rescan the wallet.
+            if (weight.complete) pwallet->PublishStakeWeight(weight.average, weight.total);
             nLastCoinStakeSearchTime = nSearchTime;
         }
         if (*pfPoSCancel)

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -315,21 +315,6 @@ public:
         int64_t secs = GetTime() - blockTime;
         isSyncing = secs >= 90*60 ? true : false;
     }
-    bool tryGetSyncInfo(int& numBlocks, bool& isSyncing) override
-    {
-        TRY_LOCK(::cs_main, lockMain);
-        if (lockMain) {
-            // Get node synchronization information with minimal locks
-            numBlocks = chainman().ActiveChain().Height();
-            int64_t blockTime = chainman().ActiveChain().Tip() ? chainman().ActiveChain().Tip()->GetBlockTime() :
-                                                      Params().GenesisBlock().GetBlockTime();
-            int64_t secs = GetTime() - blockTime;
-            isSyncing = secs >= 90*60 ? true : false;
-            return true;
-        }
-
-        return false;
-    }
     WalletClient& walletClient() override
     {
         return *Assert(m_context->wallet_client);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -256,10 +256,6 @@ public:
 	    }
         return GetPoSVKernelPS(tip);
     }
-    bool getStakeWeight(std::set<CInputCoin>& setCoins, uint64_t& nAverageWeight, uint64_t& nTotalWeight) override
-    {
-      return GetStakeWeight(setCoins, nAverageWeight, nTotalWeight);
-    }
     void setNodeStakingActive(bool active) override
     {
         if (m_context->stakeman) {

--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -14,61 +14,6 @@
 #include <pos/kernel.h>
 #include <wallet/coincontrol.h>
 
-bool GetStakeWeight(std::set<CInputCoin>& setCoins, uint64_t& nAverageWeight, uint64_t & nTotalWeight)
-{
-    CChainParams chainparams(Params());
-
-    const Consensus::Params consensusParams = chainparams.GetConsensus();
-
-    std::vector<CTransactionRef> vwtxPrev;
-
-    nAverageWeight = nTotalWeight = 0;
-    uint64_t nWeightCount = 0;
-
-    for (const CInputCoin& pcoin : setCoins)
-    {
-        CDiskTxPos postx;
-        if (!g_txindex) {
-            return error("GetStakeWeight() : tx index not available");
-        }
-        if (!g_txindex->FindTxPosition(pcoin.outpoint.hash, postx))
-            continue;
-
-        // Read block header
-        CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
-        CBlockHeader header;
-        CTransactionRef txRef;
-        try {
-            file >> header;
-            fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
-            file >> txRef;
-        } catch (std::exception &e) {
-            return error("%s() : deserialize or I/O error in GetStakeWeight()", __PRETTY_FUNCTION__);
-        }
-
-        CMutableTransaction tx(*txRef);
-
-        // Deal with transaction timestamp
-        unsigned int nTimeTx = tx.nTime ? tx.nTime : header.GetBlockTime();
-
-        int64_t nTimeWeight = GetCoinAgeWeight((int64_t)nTimeTx, (int64_t)GetTime(), consensusParams);
-        arith_uint512 bnCoinDayWeight = arith_uint512(pcoin.txout.nValue) * nTimeWeight / COIN / (24 * 60 * 60);
-
-        // Weight is greater than zero
-        if (nTimeWeight > 0)
-        {
-            nTotalWeight += bnCoinDayWeight.GetLow64();
-            nWeightCount++;
-        }
-
-    }
-
-    if (nWeightCount > 0)
-    nAverageWeight = nTotalWeight / nWeightCount;
-
-    return true;
-}
-
 bool GetStakeWeight(const CWallet* pwallet, uint64_t& nAverageWeight, uint64_t & nTotalWeight, const Consensus::Params& consensusParams)
 {
       // Choose coins to use
@@ -140,7 +85,7 @@ bool GetStakeWeight(const CWallet* pwallet, uint64_t& nAverageWeight, uint64_t &
 
 // Reddcoin: create coin stake transaction
 typedef std::vector<unsigned char> valtype;
-bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams)
+bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams, StakeWeightSummary* weight)
 {
     // The following split & combine thresholds are important to security
     // Should not be adjusted if you don't understand the consequences
@@ -163,13 +108,28 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
     scriptEmpty.clear();
     txNew.vout.push_back(CTxOut(0, scriptEmpty));
 
+    // Every pass examines every stakeable coin, so it can report the stake
+    // weight GetStakeWeight would compute, at no extra cost: the same value
+    // and timestamp feed both. The GUI status and getstakinginfo read the
+    // published result instead of rescanning the wallet themselves.
+    StakeWeightSummary weight_summary;
+    uint64_t nWeightCount = 0;
+    const auto publish_weight = [&]() {
+        if (!weight) return;
+        if (nWeightCount > 0) weight_summary.average = weight_summary.total / nWeightCount;
+        weight_summary.complete = true;
+        *weight = weight_summary;
+    };
+
     // Choose coins to use
     CAmount nBalance = pwallet->GetBalance().m_mine_trusted;
     CAmount nReserveBalance = 0;
     if (gArgs.IsArgSet("-reservebalance") && !ParseMoney(gArgs.GetArg("-reservebalance", ""), nReserveBalance))
         return error("CreateCoinStake : invalid reserve balance amount");
-    if (nBalance <= nReserveBalance)
+    if (nBalance <= nReserveBalance) {
+        publish_weight(); // nothing stakeable: zero weight, and known to be zero
         return false;
+    }
     std::set<CInputCoin> setCoins;
     std::vector<CTransactionRef> vwtxPrev;
     CAmount nValueIn = 0;
@@ -177,12 +137,17 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
     CCoinControl temp;
     CoinSelectionParams coin_selection_params;
     pwallet->AvailableCoins(vAvailableCoins, &temp);
-    if (!pwallet->SelectCoins(vAvailableCoins, nBalance - nReserveBalance, setCoins, nValueIn, temp, coin_selection_params))
+    if (!pwallet->SelectCoins(vAvailableCoins, nBalance - nReserveBalance, setCoins, nValueIn, temp, coin_selection_params)) {
+        publish_weight();
         return false;
-    if (setCoins.empty())
+    }
+    if (setCoins.empty()) {
+        publish_weight();
         return false;
+    }
     CAmount nCredit = 0;
     CScript scriptPubKeyKernel;
+    bool fKernelFound = false;
     for (const auto& pcoin : setCoins)
     {
         CDiskTxPos postx;
@@ -201,11 +166,23 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
             return error("%s() : deserialize or I/O error in CreateCoinStake()", __PRETTY_FUNCTION__);
         }
 
+        // Weight, before the age gate below: GetStakeWeight counts every coin
+        // with positive weight, and a coin can carry a little while still
+        // inside the search margin.
+        {
+            const unsigned int nTimeTx = tx->nTime ? tx->nTime : header.GetBlockTime();
+            const int64_t nTimeWeight = GetCoinAgeWeight((int64_t)nTimeTx, (int64_t)txNew.nTime, consensusParams);
+            if (nTimeWeight > 0) {
+                const arith_uint512 bnCoinDayWeight = arith_uint512(pcoin.txout.nValue) * nTimeWeight / COIN / (24 * 60 * 60);
+                weight_summary.total += bnCoinDayWeight.GetLow64();
+                nWeightCount++;
+            }
+        }
+
         static int nMaxStakeSearchInterval = 60;
         if (header.GetBlockTime() + consensusParams.nStakeMinAge > txNew.nTime - nMaxStakeSearchInterval)
             continue; // only count coins meeting min age requirement
 
-        bool fKernelFound = false;
         for (unsigned int n=0; n<std::min(nSearchInterval,(int64_t)nMaxStakeSearchInterval) && !fKernelFound; n++)
         {
             // Search backward in time from the given txNew timestamp
@@ -254,6 +231,10 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
         if (fKernelFound)
             break; // if kernel is found stop searching
     }
+    // A pass that stopped at a kernel saw only part of the set; leave the
+    // previously published weight standing rather than report a partial sum.
+    if (!fKernelFound)
+        publish_weight();
     if (nCredit == 0 || nCredit > nBalance - nReserveBalance)
         return false;
     for (const auto& pcoin : setCoins)

--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -179,6 +179,14 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
             }
         }
 
+        // The search ends at the first kernel, but the weight must cover the
+        // whole set: a wallet that finds a kernel on every pass, as a large
+        // one does on a quiet network, would otherwise never publish. The
+        // remaining coins are read once more here, which the combine loop
+        // below does anyway on a pass that found a kernel.
+        if (fKernelFound)
+            continue;
+
         static int nMaxStakeSearchInterval = 60;
         if (header.GetBlockTime() + consensusParams.nStakeMinAge > txNew.nTime - nMaxStakeSearchInterval)
             continue; // only count coins meeting min age requirement
@@ -228,13 +236,8 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
                 break;
             }
         }
-        if (fKernelFound)
-            break; // if kernel is found stop searching
     }
-    // A pass that stopped at a kernel saw only part of the set; leave the
-    // previously published weight standing rather than report a partial sum.
-    if (!fKernelFound)
-        publish_weight();
+    publish_weight();
     if (nCredit == 0 || nCredit > nBalance - nReserveBalance)
         return false;
     for (const auto& pcoin : setCoins)

--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -22,10 +22,10 @@ static const bool DEFAULT_PRINTCOINSTAKE = false;
 bool GetStakeWeight(const CWallet* pwallet, uint64_t& nAverageWeight, uint64_t& nTotalWeight, const Consensus::Params& consensusParams);
 
 /** Stake weight of the coins one CreateCoinStake pass examined, summed the
- *  way GetStakeWeight sums it. Complete only when the pass ran over every
- *  coin; a pass that stopped at a kernel leaves it incomplete and the
- *  previously published value should stand. A pass that found nothing to
- *  stake is complete with zero weight. */
+ *  way GetStakeWeight sums it. Complete when the pass ran over every coin,
+ *  whether or not it found a kernel; incomplete only when the pass failed
+ *  before it could, in which case the previously published value should
+ *  stand. A pass that found nothing to stake is complete with zero weight. */
 struct StakeWeightSummary {
     uint64_t average{0};
     uint64_t total{0};

--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -15,9 +15,24 @@ class CChainState;
 // logging defaults
 static const bool DEFAULT_PRINTCOINSTAKE = false;
 
+/** Stake weight of the wallet's stakeable coins, computed on demand: scans
+ *  the wallet under cs_wallet and reads each coin from disk, so on a large
+ *  wallet this takes seconds. While a staking thread runs, prefer the weight
+ *  it publishes through CWallet::GetPublishedStakeWeight. */
 bool GetStakeWeight(const CWallet* pwallet, uint64_t& nAverageWeight, uint64_t& nTotalWeight, const Consensus::Params& consensusParams);
-bool GetStakeWeight(std::set<CInputCoin>& setCoins, uint64_t& nAverageWeight, uint64_t& nTotalWeight);
-bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams);
+
+/** Stake weight of the coins one CreateCoinStake pass examined, summed the
+ *  way GetStakeWeight sums it. Complete only when the pass ran over every
+ *  coin; a pass that stopped at a kernel leaves it incomplete and the
+ *  previously published value should stand. A pass that found nothing to
+ *  stake is complete with zero weight. */
+struct StakeWeightSummary {
+    uint64_t average{0};
+    uint64_t total{0};
+    bool complete{false};
+};
+
+bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams, StakeWeightSummary* weight = nullptr);
 
 #endif // BITCOIN_POS_STAKE_H
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1666,12 +1666,15 @@ void BitcoinGUI::updateWalletStakingStatus()
     uint64_t nAverageWeight = 0, nTotalWeight = 0;
     int64_t nLastCoinStakeSearchInterval;
     bool staking = false;
+    // False until the staking thread has completed a pass and published what
+    // it measured. Until then a zero weight says nothing about the coins.
+    bool weight_known = false;
 
     QString msg;
     QString icon = "";
     if (walletModel) {
         qDebug() << QString("BitcoinGUI::%1: wallet %2 updated").arg(__func__).arg(walletModel->getDisplayName());
-        walletModel->GetStakeWeight(nAverageWeight, nTotalWeight);
+        weight_known = walletModel->GetStakeWeight(nAverageWeight, nTotalWeight);
         nLastCoinStakeSearchInterval = walletModel->wallet().getLastCoinStakeSearchInterval();
         staking = nLastCoinStakeSearchInterval && nAverageWeight;
     }
@@ -1695,7 +1698,7 @@ void BitcoinGUI::updateWalletStakingStatus()
         } else if (m_node.isInitialBlockDownload()) {
             msg = tr("Not staking because wallet is syncing");
             icon = ":/icons/warning";
-        } else if (!nAverageWeight) {
+        } else if (weight_known && !nAverageWeight) {
             msg = tr("Not staking because you don't have mature coins");
             icon = ":/icons/warning";
         } else if (!staking) {

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -125,6 +125,14 @@ int ClientModel::getNumBlocks() const
     return m_cached_num_blocks;
 }
 
+int64_t ClientModel::getBlockTipTime() const
+{
+    if (m_cached_tip_time == -1) {
+        m_cached_tip_time = m_node.getLastBlockTime();
+    }
+    return m_cached_tip_time;
+}
+
 uint256 ClientModel::getBestBlockHash()
 {
     uint256 tip{WITH_LOCK(m_cached_tip_mutex, return m_cached_tip_blocks)};
@@ -318,6 +326,7 @@ static void BlockTipChanged(ClientModel* clientmodel, SynchronizationState sync_
         clientmodel->cachedBestHeaderTime = tip.block_time;
     } else {
         clientmodel->m_cached_num_blocks = tip.block_height;
+        clientmodel->m_cached_tip_time = tip.block_time;
         WITH_LOCK(clientmodel->m_cached_tip_mutex, clientmodel->m_cached_tip_blocks = tip.block_hash;);
     }
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -63,6 +63,9 @@ public:
     int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
     int getNumBlocks() const;
     uint256 getBestBlockHash();
+    //! Time of the block at the tip, from the cache the tip notifications
+    //! keep. Takes cs_main only once, before the first notification.
+    int64_t getBlockTipTime() const;
     int getHeaderTipHeight() const;
     int64_t getHeaderTipTime() const;
     bool getStakingEnabled() const;
@@ -86,6 +89,7 @@ public:
     mutable std::atomic<int> cachedBestHeaderHeight;
     mutable std::atomic<int64_t> cachedBestHeaderTime;
     mutable std::atomic<int> m_cached_num_blocks{-1};
+    mutable std::atomic<int64_t> m_cached_tip_time{-1};
 
     Mutex m_cached_tip_mutex;
     uint256 m_cached_tip_blocks GUARDED_BY(m_cached_tip_mutex){};

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -163,6 +163,8 @@ bool WalletModel::validateAddress(const QString &address)
 
 bool WalletModel::GetStakeWeight(uint64_t& nAverageWeight, uint64_t& nTotalWeight)
 {
+    nAverageWeight = nTotalWeight = 0;
+
     int numBlocks = -1;
     bool isSyncing = false;
 
@@ -172,16 +174,11 @@ bool WalletModel::GetStakeWeight(uint64_t& nAverageWeight, uint64_t& nTotalWeigh
     if (isSyncing)
         return false;
 
-    std::set<CInputCoin> setCoins;
-    if (!m_wallet->GetStakeWeightSet(setCoins))
-        return false;
-    if (setCoins.empty())
-        return false;
-
-    if (!m_node.getStakeWeight(setCoins, nAverageWeight, nTotalWeight))
-        return false;
-
-    return true;
+    // The staking thread publishes the weight of the coins it examined on
+    // its last complete pass. Reading it costs nothing. Computing it here
+    // used to mean a wallet lock, two full scans of the wallet and a disk
+    // read per UTXO, on the GUI thread, several times per block.
+    return m_wallet->getStakeWeight(nAverageWeight, nTotalWeight);
 }
 
 WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -27,6 +27,7 @@
 #include <node/ui_interface.h>
 #include <psbt.h>
 #include <util/system.h> // for GetBoolArg
+#include <util/time.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h> // for CRecipient
@@ -165,14 +166,16 @@ bool WalletModel::GetStakeWeight(uint64_t& nAverageWeight, uint64_t& nTotalWeigh
 {
     nAverageWeight = nTotalWeight = 0;
 
-    int numBlocks = -1;
-    bool isSyncing = false;
-
-    if (!m_node.tryGetSyncInfo(numBlocks, isSyncing))
-        return false;
-
-    if (isSyncing)
-        return false;
+    // A weight measured against a chain this far behind says nothing about
+    // staking, so report none. The tip time comes from the client model's
+    // cache and costs no lock. This used to try cs_main and give up if it
+    // was busy, and the staking thread holds cs_main for a good part of
+    // every pass, so the status bar showed "waiting" whenever a block
+    // happened to land during one.
+    static constexpr int64_t STALE_TIP_SECONDS = 90 * 60;
+    if (!m_client_model) return false;
+    const int64_t tip_time = m_client_model->getBlockTipTime();
+    if (tip_time > 0 && GetTime() - tip_time >= STALE_TIP_SECONDS) return false;
 
     // The staking thread publishes the weight of the coins it examined on
     // its last complete pass. Reading it costs nothing. Computing it here

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -704,7 +704,14 @@ static RPCHelpMan getstakinginfo()
     uint64_t nAverageWeight = 0, nTotalWeight = 0;
     int64_t nLastCoinStakeSearchInterval = pwallet->GetLastCoinStakeSearchInterval();
 
-    GetStakeWeight(pwallet.get(), nAverageWeight, nTotalWeight, chainparams.GetConsensus());
+    // While the staking thread runs it publishes the weight of the coins it
+    // examined on its last complete pass; read that rather than rescanning
+    // the wallet under cs_wallet, which on a large wallet takes seconds per
+    // call and stalls everything else that needs the wallet. A wallet that
+    // is not staking has nothing published, so compute it for that case.
+    if (!pwallet->GetPublishedStakeWeight(nAverageWeight, nTotalWeight)) {
+        GetStakeWeight(pwallet.get(), nAverageWeight, nTotalWeight, chainparams.GetConsensus());
+    }
 
     NodeContext& node = EnsureAnyNodeContext(request.context);
     const CTxMemPool& mempool = EnsureMemPool(node);

--- a/src/staker.cpp
+++ b/src/staker.cpp
@@ -353,6 +353,7 @@ void CStakeman::ThreadStaker(std::shared_ptr<CWallet> pwallet, ChainstateManager
         }
     }
     pwallet->SetLastCoinStakeSearchInterval(0);
+    pwallet->ResetPublishedStakeWeight();
     LogPrintf("CStakeman::%s Staking thread [%s] stopped\n", __func__, thread_id);
     pwallet->NotifyWalletStakingStatusChanged();
 }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -144,14 +144,9 @@ public:
         }
         return false;
     }
-    bool GetStakeWeightSet(std::set<CInputCoin>& setCoins) override
+    bool getStakeWeight(uint64_t& average_weight, uint64_t& total_weight) override
     {
-        if (!m_wallet->GetStakeWeightSet(setCoins))
-          return false;
-        if (setCoins.empty())
-          return false;
-
-        return true;
+        return m_wallet->GetPublishedStakeWeight(average_weight, total_weight);
     }
     void setEnableStaking(bool enableStaking) override
     {

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -862,4 +862,41 @@ BOOST_AUTO_TEST_CASE(unload_marks_wallet_before_notifying)
     BOOST_CHECK(marked_when_notified);
 }
 
+//! The stake weight the staking thread publishes is unknown until a pass has
+//! completed and again once the thread stops, and readers must be able to
+//! tell that state from a wallet with nothing stakeable, which is a known
+//! zero. The GUI keys its "waiting" and "no mature coins" messages on that
+//! distinction, and getstakinginfo keys its fallback to the on-demand
+//! computation on it.
+BOOST_AUTO_TEST_CASE(published_stake_weight)
+{
+    uint64_t average = 1;
+    uint64_t total = 1;
+
+    // Nothing published yet: unknown, and the outputs are cleared.
+    BOOST_CHECK(!m_wallet.GetPublishedStakeWeight(average, total));
+    BOOST_CHECK_EQUAL(average, 0U);
+    BOOST_CHECK_EQUAL(total, 0U);
+
+    // A completed pass publishes what it measured.
+    m_wallet.PublishStakeWeight(5362915, 3115853698);
+    BOOST_CHECK(m_wallet.GetPublishedStakeWeight(average, total));
+    BOOST_CHECK_EQUAL(average, 5362915U);
+    BOOST_CHECK_EQUAL(total, 3115853698U);
+
+    // A pass that found nothing stakeable publishes a zero that is known.
+    m_wallet.PublishStakeWeight(0, 0);
+    BOOST_CHECK(m_wallet.GetPublishedStakeWeight(average, total));
+    BOOST_CHECK_EQUAL(average, 0U);
+    BOOST_CHECK_EQUAL(total, 0U);
+
+    // The thread stopping forgets the value: unknown again, not a known zero.
+    m_wallet.PublishStakeWeight(7, 9);
+    m_wallet.ResetPublishedStakeWeight();
+    average = total = 1;
+    BOOST_CHECK(!m_wallet.GetPublishedStakeWeight(average, total));
+    BOOST_CHECK_EQUAL(average, 0U);
+    BOOST_CHECK_EQUAL(total, 0U);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3414,31 +3414,6 @@ bool CWallet::IsLegacy() const
     return spk_man != nullptr;
 }
 
-bool CWallet::GetStakeWeightSet(std::set<CInputCoin>& setCoins)
-{
-    // Choose coins to use
-    LOCK(cs_wallet);
-    CAmount nBalance = GetBalance().m_mine_trusted;
-    CAmount nReserveBalance = 0;
-    if (gArgs.IsArgSet("-reservebalance") && !ParseMoney(gArgs.GetArg("-reservebalance", ""), nReserveBalance))
-        return error("GetStakeWeightSet : invalid reserve balance amount");
-    if (nBalance <= nReserveBalance)
-        return false;
-
-    CAmount nValueIn = 0;
-
-    std::vector<COutput> vAvailableCoins;
-    CCoinControl temp;
-    CoinSelectionParams coin_selection_params;
-    AvailableCoins(vAvailableCoins, &temp);
-    if (!SelectCoins(vAvailableCoins, nBalance - nReserveBalance, setCoins, nValueIn, temp, coin_selection_params))
-        return false;
-    if (setCoins.empty())
-        return false;
-
-    return true;
-}
-
 DescriptorScriptPubKeyMan* CWallet::GetDescriptorScriptPubKeyMan(const WalletDescriptor& desc) const
 {
     for (auto& spk_man_pair : m_spk_managers) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -271,6 +271,16 @@ private:
      * Used to keep track of last coinstake interval */
     int64_t nLastCoinStakeSearchInterval = 0;
     /**
+     * Stake weight of the coins the staking thread examined on its last
+     * complete search pass, in coin-days: the average per coin and the sum.
+     * The staking thread writes them, the GUI thread and RPC workers read
+     * them, so they are atomics. m_stake_weight_known is false until a pass
+     * has completed and again once the thread has stopped, so that readers
+     * can tell "nothing stakeable" from "not measured yet". */
+    std::atomic<uint64_t> m_stake_average_weight{0};
+    std::atomic<uint64_t> m_stake_total_weight{0};
+    std::atomic<bool> m_stake_weight_known{false};
+    /**
      * Was this wallet imported
      */
     bool fImporting = false;
@@ -414,8 +424,6 @@ public:
     bool Lock();
 
     bool IsStakingOnly() const;
-
-    bool GetStakeWeightSet(std::set<CInputCoin>& setCoins);
 
     /** Interface to assert chain access */
     bool HaveChain() const { return m_chain ? true : false; }
@@ -830,6 +838,34 @@ public:
     int64_t GetLastCoinStakeSearchInterval() const { return nLastCoinStakeSearchInterval; }
     /** Set this wallet last coinstake search interval. */
     void SetLastCoinStakeSearchInterval(int64_t searchInterval) { nLastCoinStakeSearchInterval = searchInterval; }
+
+    /** Read the stake weight the staking thread last published. Returns
+     *  false, with both values zero, until a search pass has completed or
+     *  after the thread has stopped. Takes no lock. */
+    bool GetPublishedStakeWeight(uint64_t& average, uint64_t& total) const
+    {
+        if (!m_stake_weight_known.load(std::memory_order_acquire)) {
+            average = total = 0;
+            return false;
+        }
+        average = m_stake_average_weight.load(std::memory_order_relaxed);
+        total = m_stake_total_weight.load(std::memory_order_relaxed);
+        return true;
+    }
+    /** Publish the stake weight of a completed search pass. */
+    void PublishStakeWeight(uint64_t average, uint64_t total)
+    {
+        m_stake_average_weight.store(average, std::memory_order_relaxed);
+        m_stake_total_weight.store(total, std::memory_order_relaxed);
+        m_stake_weight_known.store(true, std::memory_order_release);
+    }
+    /** Forget the published stake weight: the staking thread has stopped. */
+    void ResetPublishedStakeWeight()
+    {
+        m_stake_weight_known.store(false, std::memory_order_release);
+        m_stake_average_weight.store(0, std::memory_order_relaxed);
+        m_stake_total_weight.store(0, std::memory_order_relaxed);
+    }
 
     /** Return whether transaction can be abandoned */
     bool TransactionCanBeAbandoned(const uint256& hashTx) const;


### PR DESCRIPTION
With the transaction-table refresh fixed in #558, the stake-weight recomputation was all that remained of the per-block GUI stall, and it grows with the wallet's transaction count. Tracked as [RED-131](https://reddink.youtrack.cloud/issue/RED-131), part of the [RED-130](https://reddink.youtrack.cloud/issue/RED-130) epic.

## The problem

`WalletModel::GetStakeWeight` recomputed the wallet's stake weight from scratch on every call: a hard `cs_wallet` lock, a full balance scan, a full available-coins scan, a complete coin selection for the whole balance, and then a txindex lookup and block-file read per UTXO. The status bar called it on every block and on every staking notification; the node window's staking tab called it on every block-tip signal, headers included, whether or not the window was open. A block this wallet found cost four calls on the GUI thread. `getstakinginfo` ran the same scan under `cs_wallet` on every poll.

Measured on `--enable-debug` builds:

| Wallet | Transactions | One call | GUI thread per found block |
|---|---|---|---|
| Main_funds, mainnet | 176k | 0.8 s | 1.5 to 3 s |
| staketest, testnet | 1.18M | 5.8 s | 19 to 26 s at 100% |

## The change

The staking thread already examines every stakeable coin on every pass and holds, per coin, the value and the timestamp the weight formula needs. `CreateCoinStake` now sums the weight as it goes, before its age gate so the sum matches the on-demand formula, and returns it in a `StakeWeightSummary`. `CreateNewBlock` publishes it on the wallet beside the search interval it already records, as two atomics and a known flag. `WalletModel::GetStakeWeight`, the node window and `getstakinginfo` read the published values, which takes no lock. The staking thread resets them on exit.

Two states are distinguished so the callers can act on them. A pass that finds nothing stakeable publishes a known zero, and the status bar reports "no mature coins". Before any pass has completed, and after the thread stops, the value is unknown, and the status bar reports "waiting for staking to start"; `getstakinginfo` computes on demand in that case, so it stays meaningful for a wallet that is not staking.

The search still stops at the first kernel, but the sum continues over the rest of the set, and every pass that runs to the end publishes. A wallet large enough to find a kernel on every pass, which the testnet wallet is, would otherwise never publish; the first cut of this change had that bug and testnet found it.

The GUI's stale-tip check used to try `cs_main` and give up if busy. The staking thread holds `cs_main` for a good part of every pass, so a status refresh landing during one reported no weight and showed "waiting" until the next block. It now reads the tip time from the client model's cache, which the tip notifications already keep.

The coin-set overload of the weight function, `Node::getStakeWeight`, `CWallet::GetStakeWeightSet` and `Node::tryGetSyncInfo` had no other callers and are removed.

## Result

Testnet, staketest, 1,182,446 transactions, 461 UTXOs, staking, five minutes with five blocks all found by this wallet:

| | Before | After |
|---|---|---|
| `getstakinginfo` while staking | 6.46 s under `cs_wallet` | 0.00 s |
| GUI thread after a block this wallet found | 19 to 26 s at 100% | 1 s |
| GUI thread over 300 s | | 294 s idle, 5 s computing, 0 s blocked on a lock |

The remaining second per block on this wallet is the balance poll's scan of 1.18M transactions (RED-135) and the minting-table update (RED-136).

## Tests

`wallet_tests/published_stake_weight` pins the contract the callers depend on: unknown before any pass, known after one including a known zero, unknown again after the thread stops, with the outputs cleared in the unknown case.

The published-equals-computed check needs a harness that can stake, which this line's cannot; it lands with the `develop` port.

Verified in the running testnet client: `getstakinginfo` answers instantly with the published weights, and the status bar and the node window's staking tab show the same weights as the RPC.
