### PR TITLE
wallet: stop asking the chain whether a confirmed transaction is final

### DIFF
--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -86,7 +86,11 @@ WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
     result.depth_in_main_chain = wtx.GetDepthInMainChain();
     result.time_received = wtx.nTimeReceived;
     result.lock_time = wtx.tx->nLockTime;
-    result.is_final = wallet.chain().checkFinalTx(*wtx.tx);
+    // Finality is settled for a confirmed transaction and for one the mempool
+    // accepted; only an unconfirmed transaction the mempool does not hold, a
+    // locktime transaction the wallet is keeping until it is final, needs the
+    // chain asked, and that is the one case the GUI shows as "open until".
+    result.is_final = result.depth_in_main_chain >= 1 || wtx.InMempool() || wallet.chain().checkFinalTx(*wtx.tx);
     result.is_trusted = wtx.IsTrusted();
     result.is_abandoned = wtx.isAbandoned();
     result.is_coinbase = wtx.IsCoinBase();

--- a/src/wallet/receive.cpp
+++ b/src/wallet/receive.cpp
@@ -280,8 +280,15 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
 bool CWallet::IsTrusted(const CWalletTx& wtx, std::set<uint256>& trusted_parents) const
 {
     AssertLockHeld(cs_wallet);
-    // Quick answer in most cases
-    if (!chain().checkFinalTx(*wtx.tx)) return false;
+    // Quick answer in most cases. No finality check is needed: a confirmed
+    // transaction passed it when it was mined and finality only grows with
+    // the chain, an unconfirmed one in the mempool passed it on acceptance,
+    // and an unconfirmed one outside the mempool is refused below anyway.
+    // The check used to run first, for every transaction, and each call
+    // took cs_main and recomputed the tip's median time past; on a wallet
+    // with hundreds of thousands of transactions that was most of the cost
+    // of every balance and coin scan, and every one of those acquisitions
+    // waited behind whatever else held cs_main, the staking thread included.
     int nDepth = wtx.GetDepthInMainChain();
     if (nDepth >= 1) return true;
     if (nDepth < 0) return false;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -687,7 +687,11 @@ static CAmount GetReceived(const CWallet& wallet, const UniValue& params, bool b
     CAmount amount = 0;
     for (const std::pair<const uint256, CWalletTx>& wtx_pair : wallet.mapWallet) {
         const CWalletTx& wtx = wtx_pair.second;
-        if (wtx.IsCoinBase() || !wallet.chain().checkFinalTx(*wtx.tx) || wtx.GetDepthInMainChain() < min_depth) {
+        // Depth first: a confirmed transaction is final, so only an
+        // unconfirmed one needs the chain asked, and that only when the
+        // caller wanted unconfirmed transactions at all.
+        const int depth = wtx.GetDepthInMainChain();
+        if (wtx.IsCoinBase() || depth < min_depth || (depth < 1 && !wallet.chain().checkFinalTx(*wtx.tx))) {
             continue;
         }
 
@@ -1148,12 +1152,17 @@ static UniValue ListReceived(const CWallet& wallet, const UniValue& params, bool
     for (const std::pair<const uint256, CWalletTx>& pairWtx : wallet.mapWallet) {
         const CWalletTx& wtx = pairWtx.second;
 
-        if (wtx.IsCoinBase() || !wallet.chain().checkFinalTx(*wtx.tx)) {
+        if (wtx.IsCoinBase()) {
             continue;
         }
 
+        // Depth first: a confirmed transaction is final, so only an
+        // unconfirmed one needs the chain asked, and that only when the
+        // caller wanted unconfirmed transactions at all.
         int nDepth = wtx.GetDepthInMainChain();
         if (nDepth < nMinDepth)
+            continue;
+        if (nDepth < 1 && !wallet.chain().checkFinalTx(*wtx.tx))
             continue;
 
         for (const CTxOut& txout : wtx.tx->vout)

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -83,10 +83,10 @@ void CWallet::AvailableCoins(std::vector<COutput>& vCoins, const CCoinControl* c
         const uint256& wtxid = entry.first;
         const CWalletTx& wtx = entry.second;
 
-        if (!chain().checkFinalTx(*wtx.tx)) {
-            continue;
-        }
-
+        // No finality check: a confirmed transaction is final at every later
+        // tip, an unconfirmed one is only considered below if it is in the
+        // mempool, which accepted it as final. The check took cs_main per
+        // transaction and this scan runs on every staking pass.
         if (wtx.IsImmatureCoinBase())
             continue;
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <interfaces/chain.h>
+#include <interfaces/wallet.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <policy/policy.h>
@@ -1271,6 +1272,100 @@ BOOST_FIXTURE_TEST_CASE(stake_weight_published_matches_computed, TestChain100Set
     BOOST_CHECK(weight.complete);
     BOOST_CHECK_EQUAL(weight.total, computed_total);
     BOOST_CHECK_EQUAL(weight.average, computed_average);
+}
+
+//! Trust and availability no longer ask the chain whether a transaction is
+//! final: a confirmed transaction is final at every later tip, and an
+//! unconfirmed one counts only once the mempool holds it, which accepted it
+//! as final. Pin every case the old check could have told apart, and the one
+//! place finality still carries information: the "open until" status of a
+//! locktime transaction the wallet holds but the mempool does not.
+BOOST_FIXTURE_TEST_CASE(trusted_and_available_without_finality_check, TestChain100Setup)
+{
+    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(m_node.chain.get(), "", CreateMockWalletDatabase());
+    wallet->LoadWallet();
+    auto spk_man = wallet->GetOrCreateLegacyScriptPubKeyMan();
+    const CBlockIndex* tip = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip());
+    {
+        LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
+        BOOST_CHECK(spk_man->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey()));
+        wallet->SetLastBlockProcessed(tip->nHeight, tip->GetBlockHash());
+    }
+    const CScript ours = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
+
+    // A confirmed transaction paying us three times, recorded in the tip block.
+    CMutableTransaction confirmed_tx;
+    confirmed_tx.vin.emplace_back(COutPoint(GetRandHash(), 0));
+    confirmed_tx.vout.emplace_back(1 * COIN, ours);
+    confirmed_tx.vout.emplace_back(2 * COIN, ours);
+    confirmed_tx.vout.emplace_back(3 * COIN, ours);
+    const CTransactionRef confirmed = MakeTransactionRef(confirmed_tx);
+    wallet->AddToWallet(confirmed, {CWalletTx::Status::CONFIRMED, tip->nHeight, tip->GetBlockHash(), /* index */ 1});
+
+    // An unconfirmed spend of our first output back to us. From us, so it can
+    // be trusted, but only once the mempool holds it.
+    CMutableTransaction unconfirmed_tx;
+    unconfirmed_tx.vin.emplace_back(COutPoint(confirmed->GetHash(), 0));
+    unconfirmed_tx.vout.emplace_back(1 * COIN - 1000, ours);
+    const CTransactionRef unconfirmed = MakeTransactionRef(unconfirmed_tx);
+    wallet->AddToWallet(unconfirmed, {CWalletTx::Status::UNCONFIRMED, /* height */ 0, /* hash */ {}, /* index */ 0});
+
+    // A spend of our second output locked a hundred blocks ahead. Not final,
+    // so the mempool will not hold it; the wallet keeps it until it is.
+    CMutableTransaction locked_tx;
+    locked_tx.vin.emplace_back(COutPoint(confirmed->GetHash(), 1));
+    locked_tx.vin.back().nSequence = 0; // locktime only binds when an input is not marked final
+    locked_tx.vout.emplace_back(2 * COIN - 1000, ours);
+    locked_tx.nLockTime = tip->nHeight + 100;
+    const CTransactionRef locked = MakeTransactionRef(locked_tx);
+    wallet->AddToWallet(locked, {CWalletTx::Status::UNCONFIRMED, /* height */ 0, /* hash */ {}, /* index */ 0});
+
+    const auto trusted = [&](const CTransactionRef& tx) {
+        LOCK(wallet->cs_wallet);
+        return wallet->GetWalletTx(tx->GetHash())->IsTrusted();
+    };
+    const auto available = [&]() {
+        LOCK(wallet->cs_wallet);
+        std::vector<COutput> coins;
+        wallet->AvailableCoins(coins);
+        std::set<COutPoint> outpoints;
+        for (const COutput& coin : coins) outpoints.insert(coin.GetInputCoin().outpoint);
+        return outpoints;
+    };
+    std::unique_ptr<interfaces::Wallet> view = interfaces::MakeWallet(wallet);
+    const auto is_final = [&](const CTransactionRef& tx) {
+        interfaces::WalletTxStatus status;
+        interfaces::WalletOrderForm order_form;
+        bool in_mempool = false;
+        int num_blocks = 0;
+        view->getWalletTxDetails(tx->GetHash(), status, order_form, in_mempool, num_blocks);
+        return status.is_final;
+    };
+
+    // Confirmed: trusted and final. Its third output, which nothing spends,
+    // is the only coin available; the first two are spent by the unconfirmed
+    // transactions even though neither of those is available itself.
+    BOOST_CHECK(trusted(confirmed));
+    BOOST_CHECK(is_final(confirmed));
+    BOOST_CHECK(available() == std::set<COutPoint>{COutPoint(confirmed->GetHash(), 2)});
+
+    // Unconfirmed and outside the mempool: not trusted and not available,
+    // final or not.
+    BOOST_CHECK(!trusted(unconfirmed));
+    BOOST_CHECK(is_final(unconfirmed));
+    BOOST_CHECK(!trusted(locked));
+    BOOST_CHECK(!is_final(locked));
+
+    // Once the mempool holds the unconfirmed spend it is trusted, since it
+    // and its parent are ours, and its output becomes available.
+    wallet->transactionAddedToMempool(unconfirmed, /* mempool_sequence */ 0);
+    BOOST_CHECK(trusted(unconfirmed));
+    BOOST_CHECK(is_final(unconfirmed));
+    BOOST_CHECK((available() == std::set<COutPoint>{COutPoint(confirmed->GetHash(), 2), COutPoint(unconfirmed->GetHash(), 0)}));
+
+    // The locked spend stays out until it is final, whatever else changes.
+    BOOST_CHECK(!trusted(locked));
+    BOOST_CHECK(!is_final(locked));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Port of #562 to `develop`. The wallet scan code is the same on both lines, so the source commit applies unchanged; the test only moved past the RED-131 seam test at the end of the file. Tracked as [RED-135](https://reddink.youtrack.cloud/issue/RED-135), part of the [RED-130](https://reddink.youtrack.cloud/issue/RED-130) epic.

## The problem

Every wallet balance and coin scan asked the chain, once per transaction, whether that transaction was final. `IsTrusted` called `chain().checkFinalTx` before it looked at anything else, and `AvailableCoins` called it on its own account and then again through `IsTrusted`. Each call took `cs_main` and recomputed the tip's median time past. `GetBalance` runs `IsTrusted` per transaction, so the GUI balance poll, `getbalances`, and every staking pass paid one to three `cs_main` acquisitions per wallet transaction, each waiting behind whatever else held `cs_main`, the staking thread included.

Measured on `--enable-debug` builds of the 4.22.9 line before the change: `getbalances` 0.17 s at 176k transactions and 0.95 s at 1.18M; `listunspent` 0.87 s at 176k.

## The change

Finality only grows with the chain. A transaction at depth one or more passed the check when it was mined and passes at every later tip; an unconfirmed transaction the mempool holds passed the same check on acceptance; an unconfirmed transaction outside the mempool is refused by both scans on that ground alone. So the check is gone from `IsTrusted` and `AvailableCoins`, with the depth and mempool tests that were already there carrying the result. The two received-by RPC tallies test depth first and ask the chain only below depth one.

The one place finality carries information is the GUI's "open until" status for a locktime transaction the wallet holds but the mempool does not. `MakeWalletTxStatus` asks the chain in that case only.

Later Bitcoin Core releases removed the same calls from the same two functions on the same reasoning.

## Result

On the 4.22.9 build of the same change, testnet, `staketest`, 1,182,779 transactions:

| | Before | After |
|---|---|---|
| `getbalances`, warm | 0.95 s | 0.60 s |
| `getstakinginfo`, on-demand path for a wallet that is not staking | 5.76 s | 4.98 s |

What remains of the balance scan is walking 1.18M map entries and their cached credits. `listunspent` (4.9 s on this wallet) and the on-demand weight are dominated by the per-output `IsSpent` lookup and script solve, which is O(outputs) work rather than a lock and does not sit on the per-block GUI path.

GUI thread over three minutes with staking on and three blocks found by this wallet: 4 s computing, 13 s blocked on a lock, 174 s idle. The computing is two or three balance scans per found block, since each transaction notification re-raises the poll's recheck flag (RED-137). The blocked time sits exactly on the staker's passes, which the GUI's remaining hard wallet locks wait out, and is now the largest stall left on a large wallet (RED-133, RED-132).

## Tests

`wallet_tests/trusted_and_available_without_finality_check` builds three transactions by hand on the fixture chain and pins every case the removed check could have told apart: a confirmed transaction is trusted and final with its unspent output available; an unconfirmed spend outside the mempool is neither trusted nor available whether or not it is final, and becomes both once the wallet is told the mempool holds it; a locktime spend a hundred blocks ahead, with a non-final sequence so the locktime binds, is never trusted or available and still reports not final.

Passes on develop's height-100 fixture as it does on 4.22.9's height-60 one; the test builds its own wallet and records its transactions in the tip block, so the fixture's own wallet and tail do not enter into it.
