### PR TITLE
staker: search for a kernel without holding the wallet lock

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -140,7 +140,7 @@ void BlockAssembler::resetBlock()
     nFees = 0;
 }
 
-std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool* pfPoSCancel)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool* pfPoSCancel, const StakeCandidates* candidates, const StakeKernel* kernel)
 {
     int64_t nTimeStart = GetTimeMicros();
 
@@ -183,26 +183,41 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         *pfPoSCancel = true;
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
         CMutableTransaction txCoinStake;
-        int64_t nSearchTime = txCoinStake.nTime; // search to current time
-        if (nSearchTime > nLastCoinStakeSearchTime)
-        {
-            StakeWeightSummary weight;
-            if (CreateCoinStake(pwallet, &m_chainstate, pblock->nBits, nSearchTime-nLastCoinStakeSearchTime, txCoinStake, chainparams.GetConsensus(), &weight))
-            {
-                if (txCoinStake.nTime >= std::max(pindexPrev->GetMedianTimePast()+1, pindexPrev->GetBlockTime() - MAX_FUTURE_STAKE_TIME))
-                {   // make sure coinstake would meet timestamp protocol
-                    // as it would be the same as the block timestamp
-                    coinbaseTx.vout[0].SetEmpty();
-                    coinbaseTx.nTime = txCoinStake.nTime;
-                    pblock->vtx.push_back(MakeTransactionRef(CTransaction(txCoinStake)));
-                    *pfPoSCancel = false;
-                }
+        const auto accept_coinstake = [&]() {
+            if (txCoinStake.nTime >= std::max(pindexPrev->GetMedianTimePast()+1, pindexPrev->GetBlockTime() - MAX_FUTURE_STAKE_TIME))
+            {   // make sure coinstake would meet timestamp protocol
+                // as it would be the same as the block timestamp
+                coinbaseTx.vout[0].SetEmpty();
+                coinbaseTx.nTime = txCoinStake.nTime;
+                pblock->vtx.push_back(MakeTransactionRef(CTransaction(txCoinStake)));
+                *pfPoSCancel = false;
             }
-            pwallet->SetLastCoinStakeSearchInterval(nSearchTime - nLastCoinStakeSearchTime);
-            // Publish what the pass measured, beside the interval it already
-            // reports, so the GUI and getstakinginfo need not rescan the wallet.
-            if (weight.complete) pwallet->PublishStakeWeight(weight.average, weight.total);
-            nLastCoinStakeSearchTime = nSearchTime;
+        };
+        if (kernel)
+        {
+            // The staking thread searched its candidates without the locks
+            // and found this kernel. Build around it here, under them, where
+            // BuildCoinStake re-checks it against the tip this template is
+            // built on. The thread recorded the search interval and the
+            // stake weight when it searched.
+            assert(candidates != nullptr);
+            if (BuildCoinStake(pwallet, &m_chainstate, pblock->nBits, *candidates, *kernel, txCoinStake, chainparams.GetConsensus()))
+                accept_coinstake();
+        }
+        else
+        {
+            int64_t nSearchTime = txCoinStake.nTime; // search to current time
+            if (nSearchTime > nLastCoinStakeSearchTime)
+            {
+                StakeWeightSummary weight;
+                if (CreateCoinStake(pwallet, &m_chainstate, pblock->nBits, nSearchTime-nLastCoinStakeSearchTime, txCoinStake, chainparams.GetConsensus(), &weight))
+                    accept_coinstake();
+                pwallet->SetLastCoinStakeSearchInterval(nSearchTime - nLastCoinStakeSearchTime);
+                // Publish what the pass measured, beside the interval it already
+                // reports, so the GUI and getstakinginfo need not rescan the wallet.
+                if (weight.complete) pwallet->PublishStakeWeight(weight.average, weight.total);
+                nLastCoinStakeSearchTime = nSearchTime;
+            }
         }
         if (*pfPoSCancel)
             return nullptr; // reddcoin: there is no point to continue if we failed to create coinstake

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -576,21 +576,27 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
     ReserveDestination reservedest(pwallet, output_type);
     CTxDestination dest;
 
-    // Compute timeout for pos as sqrt(numUTXO)
-    unsigned int pos_timio;
     {
         LOCK(pwallet->cs_wallet);
 
         std::string strError;
         if (!reservedest.GetReservedDestination(dest, true, strError))
             throw std::runtime_error("Error: Keypool ran out, please call keypoolrefill first");
-
-        std::vector<COutput> vCoins;
-        CCoinControl coincontrol;
-        pwallet->AvailableCoins(vCoins, &coincontrol);
-        pos_timio = gArgs.GetArg("-staketimio", DEFAULT_STAKETIMIO) + 30 * sqrt(vCoins.size());
-        LogPrintf("Staker thread [%d]: Set proof-of-stake timeout: %ums for %u UTXOs\n", thread_id, pos_timio, vCoins.size());
     }
+
+    // The coins to search. Collecting them walks the whole wallet under
+    // cs_wallet, seconds on a large one, so it happens once per block the
+    // wallet processes rather than once per pass; the search itself runs
+    // over this set without the lock. The first collection also sizes the
+    // sleep between passes as sqrt(numUTXO).
+    StakeCandidates candidates;
+    CollectStakeCandidates(pwallet, candidates);
+    const unsigned int pos_timio = gArgs.GetArg("-staketimio", DEFAULT_STAKETIMIO) + 30 * sqrt(candidates.coins.size());
+    LogPrintf("Staker thread [%d]: Set proof-of-stake timeout: %ums for %u UTXOs\n", thread_id, pos_timio, candidates.coins.size());
+
+    // How far the previous search reached, per thread. This used to be a
+    // static shared by every caller of CreateNewBlock.
+    int64_t nLastCoinStakeSearchTime = GetAdjustedTime();
 
     std::string strMintMessage = _("Info: Staking suspended due to locked wallet.").translated;
     std::string strMintSyncMessage = _("Info: Staking suspended while synchronizing wallet.").translated;
@@ -671,22 +677,73 @@ void PoSMiner(CWallet* pwallet, ChainstateManager* chainman, CConnman* connman, 
             }
 
             //
-            // Create new block
+            // Search for a kernel, then build the block around it
             //
+            // Collect the candidates again once the wallet's view of the
+            // chain has moved: a block may have matured or spent some of
+            // them. This is the only step that holds cs_wallet for long.
+            {
+                const uint256 hashLastBlock = WITH_LOCK(pwallet->cs_wallet, return pwallet->GetLastBlockHash());
+                if (!candidates.collected || candidates.hashLastBlock != hashLastBlock) {
+                    CollectStakeCandidates(pwallet, candidates);
+                }
+            }
+            if (!candidates.collected) {
+                // The reserve balance setting could not be parsed; the
+                // collection has logged it, and there is nothing to search.
+                if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
+                    return;
+                continue;
+            }
+
             bool fPoSCancel = false;
             CScript scriptPubKey = GetScriptForDestination(dest);
             CBlock *pblock;
             std::unique_ptr<CBlockTemplate> pblocktemplate;
 
+            // The search holds neither cs_wallet nor cs_main for the pass;
+            // a pass that finds nothing never takes either. The weight it
+            // measures and the interval it covered are published here, as
+            // CreateNewBlock does for the on-demand path.
+            const int64_t nSearchTime = GetAdjustedTime();
+            if (nSearchTime <= nLastCoinStakeSearchTime) {
+                if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
+                    return;
+                continue;
+            }
+            unsigned int nBits;
+            {
+                LOCK(cs_main);
+                CBlockHeader next;
+                next.nTime = nSearchTime;
+                nBits = GetNextWorkRequired(chainman->ActiveChain().Tip(), &next, Params().GetConsensus());
+            }
+            StakeKernel kernel;
+            StakeWeightSummary weight;
+            const bool found = SearchStakeKernel(pwallet, &chainman->ActiveChainstate(), candidates, nBits, nSearchTime - nLastCoinStakeSearchTime, nSearchTime, Params().GetConsensus(), kernel, &weight);
+            pwallet->SetLastCoinStakeSearchInterval(nSearchTime - nLastCoinStakeSearchTime);
+            if (weight.complete) pwallet->PublishStakeWeight(weight.average, weight.total);
+            nLastCoinStakeSearchTime = nSearchTime;
+            if (!found) {
+                if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
+                    return;
+                continue;
+            }
+
             {
                 LOCK(pwallet->cs_wallet);
-                pblocktemplate = BlockAssembler(chainman->ActiveChainstate(), *mempool, Params()).CreateNewBlock(scriptPubKey, pwallet, &fPoSCancel);
+                pblocktemplate = BlockAssembler(chainman->ActiveChainstate(), *mempool, Params()).CreateNewBlock(scriptPubKey, pwallet, &fPoSCancel, &candidates, &kernel);
             }
 
             if (!pblocktemplate.get())
             {
                 if (fPoSCancel == true)
                 {
+                    // The kernel did not survive the re-check under the
+                    // locks, most often because the wallet spent the coin
+                    // since the candidates were collected. Collect again
+                    // before the next pass rather than wait for a block.
+                    candidates.collected = false;
                     if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
                         return;
                     continue;

--- a/src/miner.h
+++ b/src/miner.h
@@ -37,6 +37,8 @@ class CChainParams;
 class CScheduler;
 class CScript;
 class CWallet;
+struct StakeCandidates;
+struct StakeKernel;
 
 namespace Consensus { struct Params; };
 
@@ -178,8 +180,14 @@ public:
     explicit BlockAssembler(CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params);
     explicit BlockAssembler(CChainState& chainstate, const CTxMemPool& mempool, const CChainParams& params, const Options& options);
 
-    /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet=nullptr, bool* pfPoSCancel=nullptr);
+    /** Construct a new block template with coinbase to scriptPubKeyIn.
+     *
+     *  With a wallet, the template carries a coinstake and the coinbase is
+     *  emptied. Given a kernel the staking thread already found among the
+     *  candidates, the coinstake is built around it (re-checked against the
+     *  tip this template uses); without one, the kernel search runs here,
+     *  under the locks, which is what the generate RPCs rely on. */
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet=nullptr, bool* pfPoSCancel=nullptr, const StakeCandidates* candidates=nullptr, const StakeKernel* kernel=nullptr);
 
     inline static std::optional<int64_t> m_last_block_num_txs{};
     inline static std::optional<int64_t> m_last_block_weight{};

--- a/src/pos/stake.cpp
+++ b/src/pos/stake.cpp
@@ -83,31 +83,72 @@ bool GetStakeWeight(const CWallet* pwallet, uint64_t& nAverageWeight, uint64_t &
   return true;
 }
 
-// Reddcoin: create coin stake transaction
+namespace {
+
 typedef std::vector<unsigned char> valtype;
-bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams, StakeWeightSummary* weight)
+
+// The following split & combine thresholds are important to security
+// Should not be adjusted if you don't understand the consequences
+static const unsigned int nStakeSplitAge = (60 * 60 * 24 * 45);
+static const int64_t nCombineThreshold = 2000000 * COIN;
+
+enum class CoinSource { OK, MISSING, FAILED };
+
+//! Read the block header and transaction that created a coin, through the
+//! transaction index. MISSING when the index has no entry for it, FAILED on
+//! a read error; callers skip the first and abandon the pass on the second,
+//! as the search always has.
+CoinSource ReadCoinSource(const COutPoint& outpoint, CBlockHeader& header, CTransactionRef& tx)
 {
-    // The following split & combine thresholds are important to security
-    // Should not be adjusted if you don't understand the consequences
-    static unsigned int nStakeSplitAge = (60 * 60 * 24 * 45);
-    int64_t nCombineThreshold = 2000000 * COIN;
-
-    arith_uint256 bnTargetPerCoinDay;
-    bnTargetPerCoinDay.SetCompact(nBits);
-
     // Transaction index is required to get to block header
-    if (!g_txindex)
-        return error("CreateCoinStake : transaction index unavailable");
+    if (!g_txindex) {
+        error("CreateCoinStake : transaction index unavailable");
+        return CoinSource::FAILED;
+    }
+    CDiskTxPos postx;
+    if (!g_txindex->FindTxPosition(outpoint.hash, postx))
+        return CoinSource::MISSING;
+    CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
+    try {
+        file >> header;
+        fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
+        file >> tx;
+    } catch (const std::exception& e) {
+        error("%s() : deserialize or I/O error reading %s", __func__, outpoint.ToString());
+        return CoinSource::FAILED;
+    }
+    return CoinSource::OK;
+}
 
-    LOCK2(cs_main, pwallet->cs_wallet);
-    txNew.vin.clear();
-    txNew.vout.clear();
+} // namespace
 
-    // Mark coin stake transaction
-    CScript scriptEmpty;
-    scriptEmpty.clear();
-    txNew.vout.push_back(CTxOut(0, scriptEmpty));
+bool CollectStakeCandidates(const CWallet* pwallet, StakeCandidates& candidates)
+{
+    candidates = StakeCandidates{};
 
+    LOCK(pwallet->cs_wallet);
+    candidates.hashLastBlock = pwallet->GetLastBlockHash();
+    candidates.nBalance = pwallet->GetBalance().m_mine_trusted;
+    if (gArgs.IsArgSet("-reservebalance") && !ParseMoney(gArgs.GetArg("-reservebalance", ""), candidates.nReserveBalance))
+        return error("CreateCoinStake : invalid reserve balance amount");
+    candidates.collected = true;
+    if (candidates.nBalance <= candidates.nReserveBalance)
+        return false;
+
+    std::vector<COutput> vAvailableCoins;
+    CCoinControl temp;
+    CoinSelectionParams coin_selection_params;
+    CAmount nValueIn = 0;
+    pwallet->AvailableCoins(vAvailableCoins, &temp);
+    if (!pwallet->SelectCoins(vAvailableCoins, candidates.nBalance - candidates.nReserveBalance, candidates.coins, nValueIn, temp, coin_selection_params)) {
+        candidates.coins.clear();
+        return false;
+    }
+    return !candidates.coins.empty();
+}
+
+bool SearchStakeKernel(const CWallet* pwallet, CChainState* chainstate, const StakeCandidates& candidates, unsigned int nBits, int64_t nSearchInterval, uint32_t nTimeTx, const Consensus::Params& consensusParams, StakeKernel& kernel, StakeWeightSummary* weight)
+{
     // Every pass examines every stakeable coin, so it can report the stake
     // weight GetStakeWeight would compute, at no extra cost: the same value
     // and timestamp feed both. The GUI status and getstakinginfo read the
@@ -121,57 +162,23 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
         *weight = weight_summary;
     };
 
-    // Choose coins to use
-    CAmount nBalance = pwallet->GetBalance().m_mine_trusted;
-    CAmount nReserveBalance = 0;
-    if (gArgs.IsArgSet("-reservebalance") && !ParseMoney(gArgs.GetArg("-reservebalance", ""), nReserveBalance))
-        return error("CreateCoinStake : invalid reserve balance amount");
-    if (nBalance <= nReserveBalance) {
-        publish_weight(); // nothing stakeable: zero weight, and known to be zero
-        return false;
-    }
-    std::set<CInputCoin> setCoins;
-    std::vector<CTransactionRef> vwtxPrev;
-    CAmount nValueIn = 0;
-    std::vector<COutput> vAvailableCoins;
-    CCoinControl temp;
-    CoinSelectionParams coin_selection_params;
-    pwallet->AvailableCoins(vAvailableCoins, &temp);
-    if (!pwallet->SelectCoins(vAvailableCoins, nBalance - nReserveBalance, setCoins, nValueIn, temp, coin_selection_params)) {
-        publish_weight();
-        return false;
-    }
-    if (setCoins.empty()) {
-        publish_weight();
-        return false;
-    }
-    CAmount nCredit = 0;
-    CScript scriptPubKeyKernel;
     bool fKernelFound = false;
-    for (const auto& pcoin : setCoins)
+    for (const CInputCoin& pcoin : candidates.coins)
     {
-        CDiskTxPos postx;
-        if (!g_txindex->FindTxPosition(pcoin.outpoint.hash, postx))
-            continue;
-
-        // Read block header
-        CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
         CBlockHeader header;
         CTransactionRef tx;
-        try {
-            file >> header;
-            fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
-            file >> tx;
-        } catch (std::exception &e) {
-            return error("%s() : deserialize or I/O error in CreateCoinStake()", __PRETTY_FUNCTION__);
+        switch (ReadCoinSource(pcoin.outpoint, header, tx)) {
+        case CoinSource::MISSING: continue;
+        case CoinSource::FAILED: return false;
+        case CoinSource::OK: break;
         }
 
         // Weight, before the age gate below: GetStakeWeight counts every coin
         // with positive weight, and a coin can carry a little while still
         // inside the search margin.
         {
-            const unsigned int nTimeTx = tx->nTime ? tx->nTime : header.GetBlockTime();
-            const int64_t nTimeWeight = GetCoinAgeWeight((int64_t)nTimeTx, (int64_t)txNew.nTime, consensusParams);
+            const unsigned int nTimeTxPrev = tx->nTime ? tx->nTime : header.GetBlockTime();
+            const int64_t nTimeWeight = GetCoinAgeWeight((int64_t)nTimeTxPrev, (int64_t)nTimeTx, consensusParams);
             if (nTimeWeight > 0) {
                 const arith_uint512 bnCoinDayWeight = arith_uint512(pcoin.txout.nValue) * nTimeWeight / COIN / (24 * 60 * 60);
                 weight_summary.total += bnCoinDayWeight.GetLow64();
@@ -183,12 +190,12 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
         // whole set: a wallet that finds a kernel on every pass, as a large
         // one does on a quiet network, would otherwise never publish. The
         // remaining coins are read once more here, which the combine loop
-        // below does anyway on a pass that found a kernel.
+        // in BuildCoinStake does anyway on a pass that found a kernel.
         if (fKernelFound)
             continue;
 
-        static int nMaxStakeSearchInterval = 60;
-        if (header.GetBlockTime() + consensusParams.nStakeMinAge > txNew.nTime - nMaxStakeSearchInterval)
+        static const int nMaxStakeSearchInterval = 60;
+        if (header.GetBlockTime() + consensusParams.nStakeMinAge > nTimeTx - nMaxStakeSearchInterval)
             continue; // only count coins meeting min age requirement
 
         for (unsigned int n=0; n<std::min(nSearchInterval,(int64_t)nMaxStakeSearchInterval) && !fKernelFound; n++)
@@ -196,8 +203,15 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
             // Search backward in time from the given txNew timestamp
             // Search nSearchInterval seconds back up to nMaxStakeSearchInterval
             uint256 hashProofOfStake = uint256();
-            COutPoint prevoutStake = pcoin.outpoint;
-            bool foundStake = CheckStakeKernelHash(chainstate, nBits, header, prevoutStake.n, tx, prevoutStake, txNew.nTime - n, hashProofOfStake);
+            bool foundStake;
+            {
+                // The kernel check reads the tip and the block index. Hold
+                // cs_main for the check alone, not for the pass: this is
+                // what lets the search run while the node validates blocks
+                // and the GUI reads the chain.
+                LOCK(cs_main);
+                foundStake = CheckStakeKernelHash(chainstate, nBits, header, pcoin.outpoint.n, tx, pcoin.outpoint, nTimeTx - n, hashProofOfStake);
+            }
             if (foundStake)
             {
                 // Found a kernel
@@ -205,7 +219,7 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
                     LogPrintf("CreateCoinStake : kernel found\n");
                 std::vector<valtype> vSolutions;
                 CScript scriptPubKeyOut;
-                scriptPubKeyKernel = pcoin.txout.scriptPubKey;
+                const CScript& scriptPubKeyKernel = pcoin.txout.scriptPubKey;
                 TxoutType whichType = Solver(scriptPubKeyKernel, vSolutions);
                 if (whichType != TxoutType::PUBKEY && whichType != TxoutType::PUBKEYHASH && whichType != TxoutType::WITNESS_V0_KEYHASH) {
                     LogPrintf("CreateCoinStake : no support for kernel type=%s\n", GetTxnOutputType(whichType));
@@ -215,7 +229,14 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
                 {
                     // convert to pay to public key type
                     CKey key;
-                    if (!pwallet->GetLegacyScriptPubKeyMan()->GetKey(CKeyID(uint160(vSolutions[0])), key)) {
+                    bool have_key;
+                    {
+                        // The key store is the only wallet state this
+                        // needs; take the wallet lock for the lookup alone.
+                        LOCK(pwallet->cs_wallet);
+                        have_key = pwallet->GetLegacyScriptPubKeyMan()->GetKey(CKeyID(uint160(vSolutions[0])), key);
+                    }
+                    if (!have_key) {
                         LogPrintf("CreateCoinStake : failed to get key for kernel type=%s\n", GetTxnOutputType(whichType));
                         break;
                     }
@@ -224,46 +245,95 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
                 else
                     scriptPubKeyOut = scriptPubKeyKernel;
 
-                txNew.nTime -= n;
-                txNew.vin.push_back(CTxIn(pcoin.outpoint.hash, pcoin.outpoint.n));
-                nCredit += pcoin.txout.nValue;
-                vwtxPrev.push_back(tx);
-                txNew.vout.push_back(CTxOut(0, scriptPubKeyOut));
-                if (GetCoinAgeWeight(header.GetBlockTime(), (int64_t)txNew.nTime, consensusParams) < nStakeSplitAge && nCredit >= nCombineThreshold)
-                    txNew.vout.push_back(CTxOut(0, scriptPubKeyOut)); // Split stake
-                LogPrintf("CreateCoinStake : added kernel type=%s\n", GetTxnOutputType(whichType));
+                kernel.outpoint = pcoin.outpoint;
+                kernel.txout = pcoin.txout;
+                kernel.header = header;
+                kernel.txPrev = tx;
+                kernel.nTime = nTimeTx - n;
+                kernel.scriptPubKeyOut = scriptPubKeyOut;
+                kernel.type = whichType;
                 fKernelFound = true;
                 break;
             }
         }
     }
     publish_weight();
-    if (nCredit == 0 || nCredit > nBalance - nReserveBalance)
+    return fKernelFound;
+}
+
+bool BuildCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, const StakeCandidates& candidates, const StakeKernel& kernel, CMutableTransaction& txNew, const Consensus::Params& consensusParams)
+{
+    AssertLockHeld(cs_main);
+    AssertLockHeld(pwallet->cs_wallet);
+
+    // The kernel was found without the wallet lock and possibly against an
+    // older tip. Anything that changed since costs this pass, never a block
+    // the node would reject.
+    if (pwallet->IsSpent(kernel.outpoint.hash, kernel.outpoint.n)) {
+        LogPrintf("CreateCoinStake : kernel %s spent by the wallet since it was found\n", kernel.outpoint.ToString());
         return false;
-    for (const auto& pcoin : setCoins)
+    }
     {
-        CDiskTxPos postx;
-        if (!g_txindex->FindTxPosition(pcoin.outpoint.hash, postx))
-            continue;
-
-        // Read block header
-        CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
-        CBlockHeader header;
-        CTransactionRef tx;
-        try {
-            file >> header;
-            fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
-            file >> tx;
-        } catch (std::exception &e) {
-            return error("%s() : deserialize or I/O error in CreateCoinStake()", __PRETTY_FUNCTION__);
+        const Coin& coin = chainstate->CoinsTip().AccessCoin(kernel.outpoint);
+        if (coin.IsSpent()) {
+            LogPrintf("CreateCoinStake : kernel %s spent on the chain since it was found\n", kernel.outpoint.ToString());
+            return false;
         }
+        const int nSpendHeight = chainstate->m_chain.Tip()->nHeight + 1;
+        if ((coin.IsCoinBase() || coin.IsCoinStake()) && nSpendHeight - coin.nHeight < consensusParams.GetCoinbaseMaturity()) {
+            LogPrintf("CreateCoinStake : kernel %s no longer mature at height %d\n", kernel.outpoint.ToString(), nSpendHeight);
+            return false;
+        }
+    }
+    {
+        uint256 hashProofOfStake;
+        if (!CheckStakeKernelHash(chainstate, nBits, kernel.header, kernel.outpoint.n, kernel.txPrev, kernel.outpoint, kernel.nTime, hashProofOfStake)) {
+            LogPrintf("CreateCoinStake : kernel %s no longer meets the target at the current tip\n", kernel.outpoint.ToString());
+            return false;
+        }
+    }
 
+    txNew.vin.clear();
+    txNew.vout.clear();
+    txNew.nTime = kernel.nTime;
 
+    // Mark coin stake transaction
+    CScript scriptEmpty;
+    scriptEmpty.clear();
+    txNew.vout.push_back(CTxOut(0, scriptEmpty));
+
+    std::vector<CTransactionRef> vwtxPrev;
+    CAmount nCredit = 0;
+    const CScript& scriptPubKeyKernel = kernel.txout.scriptPubKey;
+
+    txNew.vin.push_back(CTxIn(kernel.outpoint.hash, kernel.outpoint.n));
+    nCredit += kernel.txout.nValue;
+    vwtxPrev.push_back(kernel.txPrev);
+    txNew.vout.push_back(CTxOut(0, kernel.scriptPubKeyOut));
+    if (GetCoinAgeWeight(kernel.header.GetBlockTime(), (int64_t)txNew.nTime, consensusParams) < nStakeSplitAge && nCredit >= nCombineThreshold)
+        txNew.vout.push_back(CTxOut(0, kernel.scriptPubKeyOut)); // Split stake
+    LogPrintf("CreateCoinStake : added kernel type=%s\n", GetTxnOutputType(kernel.type));
+
+    if (nCredit == 0 || nCredit > candidates.nBalance - candidates.nReserveBalance)
+        return false;
+    for (const CInputCoin& pcoin : candidates.coins)
+    {
         // Attempt to add more inputs
         // Only add coins of the same key/address as kernel
         if (txNew.vout.size() == 2 && ((pcoin.txout.scriptPubKey == scriptPubKeyKernel || pcoin.txout.scriptPubKey == txNew.vout[1].scriptPubKey))
             && pcoin.outpoint.hash != txNew.vin[0].prevout.hash)
         {
+            // The candidates were collected before the search; a coin the
+            // wallet or the chain has spent since would invalidate the block.
+            if (pwallet->IsSpent(pcoin.outpoint.hash, pcoin.outpoint.n) || chainstate->CoinsTip().AccessCoin(pcoin.outpoint).IsSpent())
+                continue;
+            CBlockHeader header;
+            CTransactionRef tx;
+            switch (ReadCoinSource(pcoin.outpoint, header, tx)) {
+            case CoinSource::MISSING: continue;
+            case CoinSource::FAILED: return false;
+            case CoinSource::OK: break;
+            }
             // Stop adding more inputs if already too many inputs
             if (txNew.vin.size() >= 100)
                 break;
@@ -271,7 +341,7 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
             if (nCredit > nCombineThreshold)
                 break;
             // Stop adding inputs if reached reserve limit
-            if (nCredit + pcoin.txout.nValue > nBalance - nReserveBalance)
+            if (nCredit + pcoin.txout.nValue > candidates.nBalance - candidates.nReserveBalance)
                 break;
             // Do not add additional significant input
             if (pcoin.txout.nValue > nCombineThreshold)
@@ -361,4 +431,25 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
 
     // Successfully generated coinstake
     return true;
+}
+
+// Reddcoin: create coin stake transaction
+bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams, StakeWeightSummary* weight)
+{
+    // Transaction index is required to get to block header
+    if (!g_txindex)
+        return error("CreateCoinStake : transaction index unavailable");
+
+    LOCK2(cs_main, pwallet->cs_wallet);
+
+    StakeCandidates candidates;
+    CollectStakeCandidates(pwallet, candidates);
+    if (!candidates.collected)
+        return false; // the reserve balance setting could not be parsed
+
+    // An empty set still runs the search, which reports a known zero weight.
+    StakeKernel kernel;
+    if (!SearchStakeKernel(pwallet, chainstate, candidates, nBits, nSearchInterval, txNew.nTime, consensusParams, kernel, weight))
+        return false;
+    return BuildCoinStake(pwallet, chainstate, nBits, candidates, kernel, txNew, consensusParams);
 }

--- a/src/pos/stake.h
+++ b/src/pos/stake.h
@@ -8,7 +8,11 @@
 #define BITCOIN_POS_STAKE_H
 
 #include <consensus/params.h>
+#include <primitives/block.h>
+#include <script/standard.h>
 #include <wallet/wallet.h>
+
+#include <set>
 
 class CChainState;
 
@@ -21,8 +25,8 @@ static const bool DEFAULT_PRINTCOINSTAKE = false;
  *  it publishes through CWallet::GetPublishedStakeWeight. */
 bool GetStakeWeight(const CWallet* pwallet, uint64_t& nAverageWeight, uint64_t& nTotalWeight, const Consensus::Params& consensusParams);
 
-/** Stake weight of the coins one CreateCoinStake pass examined, summed the
- *  way GetStakeWeight sums it. Complete when the pass ran over every coin,
+/** Stake weight of the coins one search pass examined, summed the way
+ *  GetStakeWeight sums it. Complete when the pass ran over every coin,
  *  whether or not it found a kernel; incomplete only when the pass failed
  *  before it could, in which case the previously published value should
  *  stand. A pass that found nothing to stake is complete with zero weight. */
@@ -32,7 +36,62 @@ struct StakeWeightSummary {
     bool complete{false};
 };
 
+/** The coins one wallet may stake, collected under cs_wallet and reused by
+ *  the staking thread across passes until the wallet's view of the chain
+ *  moves. The set is ordered by outpoint, which is the order the kernel
+ *  search has always run in. */
+struct StakeCandidates {
+    std::set<CInputCoin> coins;
+    //! Trusted balance and reserve at collection; a coinstake may not spend
+    //! more than their difference.
+    CAmount nBalance{0};
+    CAmount nReserveBalance{0};
+    //! The wallet's last processed block when collected. The staking thread
+    //! collects again when this moves.
+    uint256 hashLastBlock;
+    //! False until a collection has run, and false again if the reserve
+    //! balance setting could not be parsed.
+    bool collected{false};
+};
+
+/** Collect the wallet's stakeable coins. Takes cs_wallet for the duration,
+ *  which on a large wallet is seconds, so the staking thread calls this once
+ *  per block rather than once per pass. Returns false when there is nothing
+ *  to stake or the reserve balance setting is invalid; candidates.collected
+ *  tells the two apart. */
+bool CollectStakeCandidates(const CWallet* pwallet, StakeCandidates& candidates);
+
+/** A kernel SearchStakeKernel found, carrying what BuildCoinStake needs to
+ *  place it as the coinstake's first input. */
+struct StakeKernel {
+    COutPoint outpoint;
+    CTxOut txout;
+    CBlockHeader header;      //!< block the coin was created in
+    CTransactionRef txPrev;   //!< transaction that created it
+    uint32_t nTime{0};        //!< coinstake time at which the kernel met the target
+    CScript scriptPubKeyOut;  //!< output script: the coin's own, or its pubkey for a keyhash coin
+    TxoutType type{TxoutType::NONSTANDARD};
+};
+
+/** Search the candidates for a kernel at nTimeTx and up to nSearchInterval
+ *  seconds before it. Takes no wallet lock: each coin's source is read
+ *  through the transaction index and cs_main is held only around the kernel
+ *  check itself, so the search runs while the GUI and RPC use the wallet.
+ *  Reports the stake weight of the coins it examined through weight, if
+ *  given. */
+bool SearchStakeKernel(const CWallet* pwallet, CChainState* chainstate, const StakeCandidates& candidates, unsigned int nBits, int64_t nSearchInterval, uint32_t nTimeTx, const Consensus::Params& consensusParams, StakeKernel& kernel, StakeWeightSummary* weight = nullptr);
+
+/** Build the coinstake around a found kernel. The search ran without the
+ *  locks and possibly against an older tip, so first check the kernel is
+ *  still unspent, mature and meets the target at the current tip; then add
+ *  the combine inputs, the dev output, the reward and the signatures.
+ *  Requires cs_main and cs_wallet. */
+bool BuildCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, const StakeCandidates& candidates, const StakeKernel& kernel, CMutableTransaction& txNew, const Consensus::Params& consensusParams);
+
+/** Collect, search and build in one call, under cs_main and cs_wallet, for
+ *  callers that build a block on demand such as the generate RPCs. The
+ *  staking thread uses the three steps separately so that its search holds
+ *  neither lock. */
 bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams, StakeWeightSummary* weight = nullptr);
 
 #endif // BITCOIN_POS_STAKE_H
-

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -13,9 +13,11 @@
 
 #include <interfaces/chain.h>
 #include <interfaces/wallet.h>
+#include <miner.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <policy/policy.h>
+#include <pos/stake.h>
 #include <rpc/server.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
@@ -992,6 +994,133 @@ BOOST_FIXTURE_TEST_CASE(trusted_and_available_without_finality_check, TestChain1
     // The locked spend stays out until it is final, whatever else changes.
     BOOST_CHECK(!trusted(locked));
     BOOST_CHECK(!is_final(locked));
+}
+
+//! The staking thread collects the wallet's stakeable coins under the wallet
+//! lock, searches them for a kernel without it, and builds the coinstake
+//! under the locks only once it has found one. Regtest cannot stake in this
+//! harness, so pin the contract between the three steps instead: what a
+//! collection records, what a search over nothing reports, and that a kernel
+//! the wallet has spent, the chain does not hold, or the chain no longer
+//! counts mature is refused at the build, whether called directly or through
+//! the block assembler the thread hands it to.
+BOOST_FIXTURE_TEST_CASE(stake_candidates_searched_without_wallet_lock, TestChain100Setup)
+{
+    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(m_node.chain.get(), "", CreateMockWalletDatabase());
+    wallet->LoadWallet();
+    auto spk_man = wallet->GetOrCreateLegacyScriptPubKeyMan();
+    const CBlockIndex* tip = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip());
+    {
+        LOCK2(wallet->cs_wallet, spk_man->cs_KeyStore);
+        BOOST_CHECK(spk_man->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey()));
+        wallet->SetLastBlockProcessed(tip->nHeight, tip->GetBlockHash());
+    }
+    const CScript ours = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
+    const Consensus::Params& params = Params().GetConsensus();
+    CChainState& chainstate = m_node.chainman->ActiveChainstate();
+    const uint32_t search_time = tip->GetBlockTime() + 60;
+
+    // A search over an empty collection finds nothing and reports a zero
+    // weight that is known, which is what lets the GUI say "no mature coins"
+    // rather than "waiting for staking to start".
+    {
+        StakeCandidates none;
+        none.collected = true;
+        StakeKernel kernel;
+        StakeWeightSummary weight;
+        BOOST_CHECK(!SearchStakeKernel(wallet.get(), &chainstate, none, tip->nBits, /* nSearchInterval */ 60, search_time, params, kernel, &weight));
+        BOOST_CHECK(weight.complete);
+        BOOST_CHECK_EQUAL(weight.total, 0U);
+        BOOST_CHECK_EQUAL(weight.average, 0U);
+    }
+
+    // A confirmed transaction paying us twice, recorded in the tip block.
+    CMutableTransaction confirmed_tx;
+    confirmed_tx.vin.emplace_back(COutPoint(GetRandHash(), 0));
+    confirmed_tx.vout.emplace_back(1 * COIN, ours);
+    confirmed_tx.vout.emplace_back(2 * COIN, ours);
+    const CTransactionRef confirmed = MakeTransactionRef(confirmed_tx);
+    wallet->AddToWallet(confirmed, {CWalletTx::Status::CONFIRMED, tip->nHeight, tip->GetBlockHash(), /* index */ 1});
+
+    // The collection records the wallet's view of the chain, its trusted
+    // balance and the coins it may spend, in the order the search runs.
+    StakeCandidates candidates;
+    BOOST_CHECK(CollectStakeCandidates(wallet.get(), candidates));
+    BOOST_CHECK(candidates.collected);
+    BOOST_CHECK(candidates.hashLastBlock == tip->GetBlockHash());
+    BOOST_CHECK_EQUAL(candidates.nBalance, 3 * COIN);
+    BOOST_CHECK_EQUAL(candidates.nReserveBalance, 0);
+    std::set<COutPoint> collected;
+    for (const CInputCoin& coin : candidates.coins) collected.insert(coin.outpoint);
+    BOOST_CHECK((collected == std::set<COutPoint>{COutPoint(confirmed->GetHash(), 0), COutPoint(confirmed->GetHash(), 1)}));
+
+    // A reserve the balance cannot cover leaves nothing to stake. The
+    // collection still counts as done, so the thread does not repeat it
+    // every pass, and records the reserve it applied.
+    gArgs.ForceSetArg("-reservebalance", "4");
+    BOOST_CHECK(!CollectStakeCandidates(wallet.get(), candidates));
+    BOOST_CHECK(candidates.collected);
+    BOOST_CHECK(candidates.coins.empty());
+    BOOST_CHECK_EQUAL(candidates.nReserveBalance, 4 * COIN);
+    gArgs.ForceSetArg("-reservebalance", "0");
+    BOOST_CHECK(CollectStakeCandidates(wallet.get(), candidates));
+    BOOST_CHECK_EQUAL(candidates.coins.size(), 2U);
+
+    // A kernel as the search would report it, on one of our coins.
+    const auto kernel_on = [&](const CTransactionRef& tx, uint32_t n) {
+        StakeKernel kernel;
+        kernel.outpoint = COutPoint(tx->GetHash(), n);
+        kernel.txout = tx->vout[n];
+        kernel.header = tip->GetBlockHeader();
+        kernel.txPrev = tx;
+        kernel.nTime = search_time;
+        kernel.scriptPubKeyOut = ours;
+        kernel.type = TxoutType::PUBKEYHASH;
+        return kernel;
+    };
+    const auto build = [&](const StakeKernel& kernel) {
+        LOCK2(wallet->cs_wallet, ::cs_main);
+        CMutableTransaction txNew;
+        const bool built = BuildCoinStake(wallet.get(), &chainstate, tip->nBits, candidates, kernel, txNew, params);
+        BOOST_CHECK(txNew.vin.empty()); // a refused kernel leaves the transaction untouched
+        return built;
+    };
+
+    // The wallet spends the first output after the collection: the build
+    // finds the spend and refuses the kernel, before asking the chain.
+    CMutableTransaction spend_tx;
+    spend_tx.vin.emplace_back(COutPoint(confirmed->GetHash(), 0));
+    spend_tx.vout.emplace_back(1 * COIN - 1000, ours);
+    wallet->AddToWallet(MakeTransactionRef(spend_tx), {CWalletTx::Status::UNCONFIRMED, /* height */ 0, /* hash */ {}, /* index */ 0});
+    {
+        DebugLogHelper refused("spent by the wallet since it was found");
+        BOOST_CHECK(!build(kernel_on(confirmed, 0)));
+    }
+
+    // The second output is unspent as far as the wallet knows, but the chain
+    // never held this transaction: refused as spent on the chain.
+    {
+        DebugLogHelper refused("spent on the chain since it was found");
+        BOOST_CHECK(!build(kernel_on(confirmed, 1)));
+    }
+
+    // The tip's own coinbase is on the chain and unspent, and not yet mature.
+    {
+        DebugLogHelper refused("no longer mature at height " + ToString(tip->nHeight + 1));
+        BOOST_CHECK(!build(kernel_on(m_coinbase_txns.back(), 0)));
+    }
+
+    // The thread hands a found kernel to the block assembler, which builds
+    // under the locks and reports a refused kernel the way it reports a
+    // search that found nothing: no template, and the pass cancelled.
+    {
+        LOCK(wallet->cs_wallet);
+        bool cancelled = false;
+        const StakeKernel kernel = kernel_on(m_coinbase_txns.back(), 0);
+        std::unique_ptr<CBlockTemplate> tmpl = BlockAssembler(chainstate, *m_node.mempool, Params()).CreateNewBlock(ours, wallet.get(), &cancelled, &candidates, &kernel);
+        BOOST_CHECK(!tmpl);
+        BOOST_CHECK(cancelled);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Tracked as [RED-133](https://reddink.youtrack.cloud/issue/RED-133), part of the [RED-130](https://reddink.youtrack.cloud/issue/RED-130) epic. Follows #562.

## The problem

The staking thread took `cs_wallet` around `CreateNewBlock` for every search pass, and `CreateCoinStake` inside it took `cs_main` as well. The pass itself is the long part: on a large wallet it walks every stakeable coin, reads each one's source block from disk through the transaction index, and runs up to sixty kernel hashes per coin. With RED-134, RED-131 and RED-135 in, that pass had become the largest stall left on the GUI thread: over three minutes on the 1.18M transaction testnet wallet the GUI spent 4 s computing and 13 s blocked on a lock, and every one of the blocked seconds sat on a staker pass.

None of that work needs the wallet lock. The coin set only changes when the wallet processes a block, the disk reads go through the index, and the kernel check needs `cs_main` only for the moment it reads the chain.

## The change

`CreateCoinStake` is split into three steps in `pos/stake.cpp`:

- `CollectStakeCandidates` takes `cs_wallet` and records the wallet's last processed block, its trusted balance, the reserve, and the selected coins. This is the scan that used to run on every pass; the staking thread now runs it once, and again only when the wallet's last block moves or a kernel fails its re-check.
- `SearchStakeKernel` walks the candidates with no wallet lock, reads each coin's source through the index, holds `cs_main` around each kernel check alone, and reports the stake weight of the coins it examined the way the pass already did for RED-131. A keyhash kernel needs one key lookup, taken under a short `cs_wallet` on its own, never nested under `cs_main`.
- `BuildCoinStake` requires both locks and first re-checks the kernel against the tip the block will sit on: unspent in the wallet, unspent on the chain, still mature, and still meeting the target. Then it builds the transaction exactly as before. Combine inputs are checked for spends too, since the candidates may predate the build.

`CreateCoinStake` runs the three in turn under `LOCK2(cs_main, cs_wallet)`, so the generate RPCs behave as they did. `CreateNewBlock` takes an optional candidate set and kernel; given one, it builds around the kernel instead of searching.

`PoSMiner` collects, searches lock-free each pass, publishes the search interval and the weight from the search, and takes `cs_wallet` for the block only once a kernel has been found. A pass that finds nothing never takes either lock. A refused kernel marks the candidates for re-collection so a coin the wallet spent between blocks costs one pass, not a block interval. The search clock is per thread rather than the static shared with the RPCs, and the sleep between passes is sized from the collected candidates instead of a separate coin scan at startup.

## Result

Testnet, `staketest`, 1,182,900 transactions, 459 UTXOs, staking on, `--enable-debug` build. GUI thread sampled at 1 Hz from `/proc`:

| | Before (#562) | After, 300 s window |
|---|---|---|
| Blocks found by this wallet in the window | 3 in 180 s | 4 in 300 s |
| GUI seconds blocked on a lock | 13 | 0 |
| GUI CPU per block found | 0.7 to 1.9 s | 0.6 to 0.7 s |
| Staker thread duty cycle | 11.6 % | 7.4 % |

Four windows were sampled and none held a single lock-wait sample, including the five seconds after each found block during which the thread re-collects its candidates under `cs_wallet`: the GUI's own per-block work no longer takes a hard wallet lock, so nothing waits on it. What remains per found block is the balance rescan that follows a new wallet transaction, which is RED-137.

Staking itself: 59 blocks found and 59 accepted as tip in the first 66 minutes, one every 67 to 68 seconds, zero kernel refusals, signing failures or rejected blocks. `getstakinginfo` reports the published weight and a moving search interval.

## Tests

`wallet_tests/stake_candidates_searched_without_wallet_lock`. Regtest cannot stake in this harness, so it pins the contract between the three steps instead: a collection records the wallet's last block, balance and coins in search order, and reports an uncoverable reserve as done with nothing to stake; a search over an empty collection reports a known zero weight; and the build refuses a kernel the wallet has spent since the collection, one the chain does not hold, and one the chain no longer counts mature, each identified by its log line, directly and through the block assembler, which reports it as a cancelled pass.

The other five `wallet_tests` failures on this line predate the branch and fail identically on a binary built at the #562 merge; they are the Bitcoin fixture numbers tracked in RED-125.

## Notes

- Lock order on this line is `cs_wallet` before `cs_main`, from the staking thread, the generate RPC and the existing wallet tests. The new code never takes `cs_wallet` under `cs_main`, and the measured client is a `DEBUG_LOCKORDER` build.
- A coin the wallet spends between blocks is only noticed at the build, which then re-collects. Locked coins still make the whole-balance coin selection fail; that is pre-existing.
- The develop port is not a cherry-pick: develop has no `pos/stake.cpp` and the block assembler reaches the wallet through `interfaces::StakingWallet`, so the split lands in `wallet/staking.cpp` there.
