### PR TITLE
staker: search for a kernel without holding the wallet lock

### DIFF
--- a/src/interfaces/staking.h
+++ b/src/interfaces/staking.h
@@ -50,8 +50,8 @@ public:
     //!
     //! The node holds cs_wallet across whole operations that call back into the
     //! wallet several times (most importantly BlockAssembler::CreateNewBlock,
-    //! which invokes createCoinStake, setLastCoinStakeSearchInterval and
-    //! finalizeCoinStakeReward in turn), so per-method locking inside the
+    //! which invokes createCoinStake or buildCoinStake and then
+    //! finalizeCoinStakeReward), so per-method locking inside the
     //! implementation cannot reproduce the span.
     //! Callers keep the original scope by holding one of these.
     //!
@@ -112,6 +112,47 @@ public:
     //! returns true.
     virtual bool isUnloading() const = 0;
 
+    //! Collect the coins the kernel search runs over. Takes the wallet lock
+    //! for the duration, seconds on a large wallet, so the staking thread
+    //! calls this once per block the wallet processes rather than once per
+    //! pass. Returns false when there is nothing to stake or the reserve
+    //! balance setting is invalid; stakeCandidatesCurrent() tells the two
+    //! apart, since only the second leaves no collection behind.
+    virtual bool collectStakeCandidates() = 0;
+
+    //! Whether the collected candidates still describe the wallet's view of
+    //! the chain. False before any collection, once the wallet has processed
+    //! a block since the collection, and after buildCoinStake() refused a
+    //! kernel.
+    virtual bool stakeCandidatesCurrent() = 0;
+
+    //! Number of candidates the last collection found, used to scale the
+    //! stake search timeout.
+    virtual size_t stakeCandidateCount() = 0;
+
+    //! Search the candidates for a kernel at nTimeTx and up to
+    //! nSearchInterval seconds before it. Holds no wallet lock and takes
+    //! cs_main only around the chain reads for one coin at a time, so the
+    //! pass runs while the GUI and RPC use the wallet. Publishes the stake
+    //! weight of the coins examined and keeps the kernel for
+    //! buildCoinStake(). Must not be called with lock() held: the point is
+    //! that the pass does not hold it.
+    virtual bool searchStakeKernel(CChainState& chainstate,
+        unsigned int nBits,
+        int64_t nSearchInterval,
+        uint32_t nTimeTx,
+        const Consensus::Params& consensus_params) = 0;
+
+    //! Build the coinstake around the kernel the last search found, after
+    //! re-checking it against the tip the block will sit on: unspent in the
+    //! wallet and on the chain, mature, and still meeting the target. A
+    //! refused kernel invalidates the candidates so the next pass collects
+    //! again. Requires the caller to hold lock() and cs_main.
+    virtual bool buildCoinStake(CChainState& chainstate,
+        unsigned int nBits,
+        CMutableTransaction& tx_new,
+        const Consensus::Params& consensus_params) = 0;
+
     //! Number of spendable coins, used to scale the stake search timeout.
     virtual size_t getAvailableCoinCount() = 0;
 
@@ -156,7 +197,9 @@ public:
     //! Record how far the last kernel search advanced, for getstakinginfo.
     virtual void setLastCoinStakeSearchInterval(int64_t interval) = 0;
 
-    //! Search for a kernel and build the coinstake transaction.
+    //! Collect, search and build in one call, for callers that build a block
+    //! on demand such as the generate RPCs. The staking thread runs the three
+    //! steps separately so that its search holds no lock.
     //! Requires the caller to hold lock().
     virtual bool createCoinStake(CChainState& chainstate,
         unsigned int nBits,

--- a/src/interfaces/staking.h
+++ b/src/interfaces/staking.h
@@ -153,9 +153,6 @@ public:
         CMutableTransaction& tx_new,
         const Consensus::Params& consensus_params) = 0;
 
-    //! Number of spendable coins, used to scale the stake search timeout.
-    virtual size_t getAvailableCoinCount() = 0;
-
     //! Block until the wallet has processed the current chain tip, so a staking
     //! readout reflects blocks the caller could already have seen.
     //!

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -135,7 +135,7 @@ void BlockAssembler::resetBlock()
     nFees = 0;
 }
 
-std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, interfaces::StakingWallet* staking_wallet, bool* pfPoSCancel)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, interfaces::StakingWallet* staking_wallet, bool* pfPoSCancel, bool from_found_kernel)
 {
     int64_t nTimeStart = GetTimeMicros();
 
@@ -184,29 +184,43 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         CMutableTransaction txCoinStake;
         txCoinStake.nVersion = POSV_TX_VERSION;   // Explicit: PoS coinstake stays v2 (BIP68-exempt at consensus)
         txCoinStake.nTime = GetAdjustedTime(); // Initialize to current time for stake search
-        int64_t nSearchTime = txCoinStake.nTime; // search to current time
-        // Handle mock time reset (e.g. between tests) - if time went backwards, reset search time
-        if (nSearchTime < nLastCoinStakeSearchTime) {
-            nLastCoinStakeSearchTime = nSearchTime - 1;
-        }
-        if (nSearchTime > nLastCoinStakeSearchTime)
-        {
-            if (staking_wallet->createCoinStake(m_chainstate, pblock->nBits, nSearchTime-nLastCoinStakeSearchTime, txCoinStake, chainparams.GetConsensus()))
-            {
-                if (txCoinStake.nTime >= std::max(pindexPrev->GetMedianTimePast()+1, pindexPrev->GetBlockTime() - MAX_FUTURE_STAKE_TIME))
-                {   // make sure coinstake would meet timestamp protocol
-                    // as it would be the same as the block timestamp
-                    coinbaseTx.vout[0].SetEmpty();
-                    coinbaseTx.nTime = txCoinStake.nTime;
-                    pblock->vtx.push_back(MakeTransactionRef(CTransaction(txCoinStake)));
-                    // Add placeholder entries for coinstake fee and sigops (updated later)
-                    pblocktemplate->vTxFees.push_back(0);
-                    pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
-                    *pfPoSCancel = false;
-                }
+        const auto accept_coinstake = [&]() {
+            if (txCoinStake.nTime >= std::max(pindexPrev->GetMedianTimePast()+1, pindexPrev->GetBlockTime() - MAX_FUTURE_STAKE_TIME))
+            {   // make sure coinstake would meet timestamp protocol
+                // as it would be the same as the block timestamp
+                coinbaseTx.vout[0].SetEmpty();
+                coinbaseTx.nTime = txCoinStake.nTime;
+                pblock->vtx.push_back(MakeTransactionRef(CTransaction(txCoinStake)));
+                // Add placeholder entries for coinstake fee and sigops (updated later)
+                pblocktemplate->vTxFees.push_back(0);
+                pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
+                *pfPoSCancel = false;
             }
-            staking_wallet->setLastCoinStakeSearchInterval(nSearchTime - nLastCoinStakeSearchTime);
-            nLastCoinStakeSearchTime = nSearchTime;
+        };
+        if (from_found_kernel)
+        {
+            // The staking thread searched its candidates without the locks
+            // and found a kernel. Build around it here, under them, where the
+            // wallet re-checks it against the tip this template is built on.
+            // The thread recorded the search interval and the stake weight
+            // when it searched.
+            if (staking_wallet->buildCoinStake(m_chainstate, pblock->nBits, txCoinStake, chainparams.GetConsensus()))
+                accept_coinstake();
+        }
+        else
+        {
+            int64_t nSearchTime = txCoinStake.nTime; // search to current time
+            // Handle mock time reset (e.g. between tests) - if time went backwards, reset search time
+            if (nSearchTime < nLastCoinStakeSearchTime) {
+                nLastCoinStakeSearchTime = nSearchTime - 1;
+            }
+            if (nSearchTime > nLastCoinStakeSearchTime)
+            {
+                if (staking_wallet->createCoinStake(m_chainstate, pblock->nBits, nSearchTime-nLastCoinStakeSearchTime, txCoinStake, chainparams.GetConsensus()))
+                    accept_coinstake();
+                staking_wallet->setLastCoinStakeSearchInterval(nSearchTime - nLastCoinStakeSearchTime);
+                nLastCoinStakeSearchTime = nSearchTime;
+            }
         }
         if (*pfPoSCancel)
             return nullptr; // reddcoin: there is no point to continue if we failed to create coinstake

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -597,19 +597,29 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
     // ReserveDestination this loop used to keep on its stack.
     CTxDestination dest;
 
-    // Compute timeout for pos as sqrt(numUTXO)
-    unsigned int pos_timio;
     {
         auto wallet_lock = staking_wallet.lock();
 
         std::string strError;
         if (!staking_wallet.reserveDestination(dest, strError))
             throw std::runtime_error("Error: Keypool ran out, please call keypoolrefill first");
-
-        const size_t num_coins = staking_wallet.getAvailableCoinCount();
-        pos_timio = gArgs.GetArg("-staketimio", DEFAULT_STAKETIMIO) + 30 * sqrt(num_coins);
-        LogPrintf("Staker thread [%d]: Set proof-of-stake timeout: %ums for %u UTXOs\n", thread_id, pos_timio, num_coins);
     }
+
+    // The coins to search. Collecting them walks the whole wallet under its
+    // lock, seconds on a large one, so it happens once per block the wallet
+    // processes rather than once per pass; the search itself runs over the
+    // collected set without the lock. The first collection also sizes the
+    // sleep between passes as sqrt(numUTXO).
+    staking_wallet.collectStakeCandidates();
+    const size_t num_coins = staking_wallet.stakeCandidateCount();
+    const unsigned int pos_timio = gArgs.GetArg("-staketimio", DEFAULT_STAKETIMIO) + 30 * sqrt(num_coins);
+    LogPrintf("Staker thread [%d]: Set proof-of-stake timeout: %ums for %u UTXOs\n", thread_id, pos_timio, num_coins);
+
+    // How far the previous search reached, per thread; this used to be the
+    // static CreateNewBlock keeps for its on-demand callers. Starts a full
+    // interval back so that the first pass searches even on a clock that
+    // does not move, as under mock time.
+    int64_t nLastCoinStakeSearchTime = GetAdjustedTime() - 61;
 
     std::string strMintMessage = _("Info: Staking suspended due to locked wallet.").translated;
     std::string strMintSyncMessage = _("Info: Staking suspended while synchronizing wallet.").translated;
@@ -691,7 +701,7 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
             }
 
             //
-            // Create new block
+            // Search for a kernel, then build the block around it
             //
             // Take the tip and the wallet's coin view from the same point in
             // time. A block that arrived while this thread was sleeping reaches
@@ -700,20 +710,68 @@ void PoSMiner(interfaces::StakingWallet& staking_wallet, ChainstateManager* chai
             // StakingWallet. No lock is held here, which is what this needs.
             staking_wallet.blockUntilSyncedToCurrentChain();
 
+            // Collect the candidates again once the wallet's view of the
+            // chain has moved, or the last build refused its kernel: a block
+            // may have matured or spent some of them. This is the only step
+            // that holds the wallet lock for long.
+            if (!staking_wallet.stakeCandidatesCurrent()) {
+                staking_wallet.collectStakeCandidates();
+                if (!staking_wallet.stakeCandidatesCurrent()) {
+                    // The reserve balance setting could not be parsed; the
+                    // collection has logged it, and there is nothing to search.
+                    if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
+                        return;
+                    continue;
+                }
+                LogPrintf("Staker thread [%d]: collected %u stake candidates\n", thread_id, staking_wallet.stakeCandidateCount());
+            }
+
             bool fPoSCancel = false;
             CScript scriptPubKey = GetScriptForDestination(dest);
             CBlock *pblock;
             std::unique_ptr<CBlockTemplate> pblocktemplate;
 
+            // The search holds neither the wallet lock nor cs_main for the
+            // pass; a pass that finds nothing never takes either. The weight
+            // it measures and the interval it covered are published from
+            // here, as CreateNewBlock does for its on-demand callers.
+            const int64_t nSearchTime = GetAdjustedTime();
+            if (nSearchTime < nLastCoinStakeSearchTime) {
+                nLastCoinStakeSearchTime = nSearchTime - 1; // the clock went backwards: mock time was reset
+            }
+            if (nSearchTime <= nLastCoinStakeSearchTime) {
+                if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
+                    return;
+                continue;
+            }
+            unsigned int nBits;
+            {
+                LOCK(cs_main);
+                CBlockHeader next;
+                next.nTime = nSearchTime;
+                nBits = GetNextWorkRequired(chainman->ActiveChain().Tip(), &next, Params().GetConsensus());
+            }
+            const bool found = staking_wallet.searchStakeKernel(chainman->ActiveChainstate(), nBits, nSearchTime - nLastCoinStakeSearchTime, nSearchTime, Params().GetConsensus());
+            staking_wallet.setLastCoinStakeSearchInterval(nSearchTime - nLastCoinStakeSearchTime);
+            nLastCoinStakeSearchTime = nSearchTime;
+            if (!found) {
+                if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
+                    return;
+                continue;
+            }
+
             {
                 auto wallet_lock = staking_wallet.lock();
-                pblocktemplate = BlockAssembler(chainman->ActiveChainstate(), *mempool, Params()).CreateNewBlock(scriptPubKey, &staking_wallet, &fPoSCancel);
+                pblocktemplate = BlockAssembler(chainman->ActiveChainstate(), *mempool, Params()).CreateNewBlock(scriptPubKey, &staking_wallet, &fPoSCancel, /* from_found_kernel= */ true);
             }
 
             if (!pblocktemplate.get())
             {
                 if (fPoSCancel == true)
                 {
+                    // The kernel did not survive the re-check under the
+                    // locks; the wallet has marked its candidates for a new
+                    // collection on the next pass.
                     if (!interrupt.sleep_for(std::chrono::milliseconds(pos_timio)))
                         return;
                     continue;

--- a/src/miner.h
+++ b/src/miner.h
@@ -185,7 +185,14 @@ public:
      * set) if none is found. The caller must hold staking_wallet->lock() for
      * the whole call, since the coinstake is built, then re-signed against the
      * block's fees, in separate trips into the wallet. */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, interfaces::StakingWallet* staking_wallet=nullptr, bool* pfPoSCancel=nullptr);
+    /** Construct a new block template with coinbase to scriptPubKeyIn.
+     *
+     *  With a staking wallet, the template carries a coinstake and the
+     *  coinbase is emptied. With from_found_kernel the coinstake is built
+     *  around the kernel the wallet's last search found, re-checked against
+     *  the tip this template uses; otherwise the kernel search runs here,
+     *  under the locks, which is what the generate RPCs rely on. */
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, interfaces::StakingWallet* staking_wallet=nullptr, bool* pfPoSCancel=nullptr, bool from_found_kernel=false);
 
     inline static std::optional<int64_t> m_last_block_num_txs{};
     inline static std::optional<int64_t> m_last_block_weight{};

--- a/src/wallet/staking.cpp
+++ b/src/wallet/staking.cpp
@@ -823,15 +823,6 @@ public:
         m_wallet->SetLastCoinStakeSearchInterval(interval);
     }
 
-    size_t getAvailableCoinCount() override
-    {
-        LOCK(m_wallet->cs_wallet);
-        std::vector<COutput> coins;
-        CCoinControl coincontrol;
-        m_wallet->AvailableCoins(coins, &coincontrol);
-        return coins.size();
-    }
-
     void blockUntilSyncedToCurrentChain() override { m_wallet->BlockUntilSyncedToCurrentChain(); }
     int64_t getLastCoinStakeSearchInterval() override { return m_wallet->GetLastCoinStakeSearchInterval(); }
 

--- a/src/wallet/staking.cpp
+++ b/src/wallet/staking.cpp
@@ -94,31 +94,192 @@ bool GetStakeWeight(const CWallet* pwallet, uint64_t& nAverageWeight, uint64_t &
   return true;
 }
 
-// Reddcoin: create coin stake transaction
-bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams, StakeWeightSummary* weight)
+namespace {
+
+// The following split & combine thresholds are important to security
+// Should not be adjusted if you don't understand the consequences
+static const unsigned int nStakeSplitAge = (60 * 60 * 24 * 45);
+static const int64_t nCombineThreshold = 2000000 * COIN;
+
+enum class CoinSource { OK, MISSING, FAILED };
+
+//! Read the block header and transaction that created a coin, through the
+//! transaction index. MISSING when the index has no entry for it, FAILED on
+//! a read error; callers skip the first and abandon the pass on the second,
+//! as the search always has.
+CoinSource ReadCoinSource(const COutPoint& outpoint, CBlockHeader& header, CTransactionRef& tx)
 {
-    // The following split & combine thresholds are important to security
-    // Should not be adjusted if you don't understand the consequences
-    static unsigned int nStakeSplitAge = (60 * 60 * 24 * 45);
-    int64_t nCombineThreshold = 2000000 * COIN;
-
-    arith_uint256 bnTargetPerCoinDay;
-    bnTargetPerCoinDay.SetCompact(nBits);
-
     // Transaction index is required to get to block header
-    if (!g_txindex)
-        return error("CreateCoinStake : transaction index unavailable");
+    if (!g_txindex) {
+        error("CreateCoinStake : transaction index unavailable");
+        return CoinSource::FAILED;
+    }
+    CDiskTxPos postx;
+    if (!g_txindex->FindTxPosition(outpoint.hash, postx))
+        return CoinSource::MISSING;
+    CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
+    try {
+        file >> header;
+        fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
+        file >> tx;
+    } catch (const std::exception& e) {
+        error("%s() : deserialize or I/O error reading %s", __func__, outpoint.ToString());
+        return CoinSource::FAILED;
+    }
+    return CoinSource::OK;
+}
 
-    LOCK2(cs_main, pwallet->cs_wallet);
-    txNew.vin.clear();
-    txNew.vout.clear();
-    txNew.nVersion = POSV_TX_VERSION;   // Self-contained invariant: CreateCoinStake produces a v2 tx
+//! Whether an output carries witness data. Such a coin can only be staked
+//! once SegWit is active for the next block: a coinstake spending it before
+//! then makes a block that ContextualCheckBlock rejects for unexpected
+//! witness data.
+bool IsWitnessOutput(const CScript& scriptPubKey)
+{
+    std::vector<valtype> vSolutions;
+    const TxoutType type = Solver(scriptPubKey, vSolutions);
+    return type == TxoutType::WITNESS_V0_KEYHASH ||
+           type == TxoutType::WITNESS_V0_SCRIPTHASH ||
+           type == TxoutType::WITNESS_V1_TAPROOT ||
+           type == TxoutType::WITNESS_UNKNOWN;
+}
 
-    // Mark coin stake transaction
-    CScript scriptEmpty;
-    scriptEmpty.clear();
-    txNew.vout.push_back(CTxOut(0, scriptEmpty));
+//! The coinstake output script for a kernel, and whether the wallet holds
+//! the key to sign for it: a keyhash kernel pays to its public key, a pubkey
+//! or taproot kernel to its own script. Takes cs_wallet for the lookup alone
+//! and must not be called with cs_main held, which is the lock order the
+//! staking path keeps.
+bool KernelOutputScript(const CWallet* pwallet, const CScript& scriptPubKeyKernel, TxoutType& whichType, CScript& scriptPubKeyOut)
+{
+    std::vector<valtype> vSolutions;
+    whichType = Solver(scriptPubKeyKernel, vSolutions);
+    if (whichType != TxoutType::PUBKEY &&
+        whichType != TxoutType::PUBKEYHASH &&
+        whichType != TxoutType::WITNESS_V0_KEYHASH &&
+        whichType != TxoutType::WITNESS_V1_TAPROOT) {
+        LogPrintf("CreateCoinStake : no support for kernel type=%s\n", GetTxnOutputType(whichType));
+        return false;
+    }
 
+    LOCK(pwallet->cs_wallet);
+    scriptPubKeyOut.clear();
+    if (whichType == TxoutType::PUBKEYHASH || whichType == TxoutType::WITNESS_V0_KEYHASH) // pay to address type or witness keyhash
+    {
+        // convert to pay to public key type
+        CKey key;
+        CKeyID keyid{uint160{vSolutions[0]}};
+        bool found_key = false;
+
+        // Try all ScriptPubKeyMans (supports both legacy and descriptor wallets)
+        for (ScriptPubKeyMan* spk_man : pwallet->GetAllScriptPubKeyMans()) {
+            SignatureData sigdata;
+            if (spk_man->CanProvide(scriptPubKeyKernel, sigdata)) {
+                if (auto* legacy = dynamic_cast<LegacyScriptPubKeyMan*>(spk_man)) {
+                    if (legacy->GetKey(keyid, key)) {
+                        found_key = true;
+                        break;
+                    }
+                } else if (auto* desc = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
+                    if (desc->GetKey(scriptPubKeyKernel, keyid, key)) {
+                        found_key = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!found_key) {
+            LogPrintf("CreateCoinStake : failed to get key for kernel type=%s\n", GetTxnOutputType(whichType));
+            return false;
+        }
+        scriptPubKeyOut << ToByteVector(key.GetPubKey()) << OP_CHECKSIG;
+        return true;
+    }
+    if (whichType == TxoutType::WITNESS_V1_TAPROOT)
+    {
+        // Taproot: verify we have the key for key-path spending
+        // vSolutions[0] contains the 32-byte x-only pubkey
+        bool found_key = false;
+
+        // Try all ScriptPubKeyMans (supports both legacy and descriptor wallets)
+        for (ScriptPubKeyMan* spk_man : pwallet->GetAllScriptPubKeyMans()) {
+            SignatureData sigdata;
+            if (spk_man->CanProvide(scriptPubKeyKernel, sigdata)) {
+                found_key = true;
+                break;
+            }
+        }
+
+        if (!found_key) {
+            LogPrintf("CreateCoinStake : failed to get key for kernel type=%s\n", GetTxnOutputType(whichType));
+            return false;
+        }
+        scriptPubKeyOut = scriptPubKeyKernel;
+        return true;
+    }
+
+    // P2PK: verify we have the key
+    // vSolutions[0] contains the pubkey
+    CKeyID keyid = CPubKey(vSolutions[0]).GetID();
+    bool found_key = false;
+
+    // Try all ScriptPubKeyMans (supports both legacy and descriptor wallets)
+    for (ScriptPubKeyMan* spk_man : pwallet->GetAllScriptPubKeyMans()) {
+        if (auto* legacy = dynamic_cast<LegacyScriptPubKeyMan*>(spk_man)) {
+            CKey key;
+            if (legacy->GetKey(keyid, key)) {
+                found_key = true;
+                break;
+            }
+        } else if (auto* desc = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
+            // For descriptor wallets, try with a P2PKH script since that's what they track
+            CScript p2pkh_script = GetScriptForDestination(PKHash(keyid));
+            CKey key;
+            if (desc->GetKey(p2pkh_script, keyid, key)) {
+                found_key = true;
+                break;
+            }
+        }
+    }
+
+    if (!found_key) {
+        LogPrintf("CreateCoinStake : failed to get key for kernel type=%s\n", GetTxnOutputType(whichType));
+        return false;
+    }
+    scriptPubKeyOut = scriptPubKeyKernel;
+    return true;
+}
+
+} // namespace
+
+bool CollectStakeCandidates(const CWallet* pwallet, StakeCandidates& candidates)
+{
+    candidates = StakeCandidates{};
+
+    LOCK(pwallet->cs_wallet);
+    candidates.hashLastBlock = pwallet->GetLastBlockHash();
+    if (gArgs.IsArgSet("-reservebalance") && !ParseMoney(gArgs.GetArg("-reservebalance", ""), candidates.nReserveBalance))
+        return error("CreateCoinStake : invalid reserve balance amount");
+    candidates.collected = true;
+
+    std::vector<COutput> vAvailableCoins;
+    CCoinControl temp;
+    pwallet->AvailableCoins(vAvailableCoins, &temp);
+    // For staking, use all available coins directly: SelectCoins applies
+    // confirmation filters that reject recently-received coins, but staking
+    // only needs any single UTXO with sufficient age to find a valid kernel.
+    for (const COutput& coin : vAvailableCoins) {
+        candidates.coins.insert(coin.GetInputCoin());
+        candidates.nAvailable += coin.GetInputCoin().txout.nValue;
+    }
+    if (candidates.nAvailable <= candidates.nReserveBalance) {
+        candidates.coins.clear();
+        return false;
+    }
+    return !candidates.coins.empty();
+}
+
+bool SearchStakeKernel(const CWallet* pwallet, CChainState* chainstate, const StakeCandidates& candidates, unsigned int nBits, int64_t nSearchInterval, uint32_t nTimeTx, const Consensus::Params& consensusParams, StakeKernel& kernel, StakeWeightSummary* weight)
+{
     // Every pass examines every stakeable coin, so it can report the stake
     // weight GetStakeWeight would compute, at no extra cost: the same value
     // and timestamp feed both. The GUI status and getstakinginfo read the
@@ -132,45 +293,22 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
         *weight = weight_summary;
     };
 
-    // Choose coins to use
-    CAmount nReserveBalance = 0;
-    if (gArgs.IsArgSet("-reservebalance") && !ParseMoney(gArgs.GetArg("-reservebalance", ""), nReserveBalance))
-        return error("CreateCoinStake : invalid reserve balance amount");
-    std::set<CInputCoin> setCoins;
-    std::vector<CTransactionRef> vwtxPrev;
-    CAmount nValueIn = 0;
-    std::vector<COutput> vAvailableCoins;
-    CCoinControl temp;
-    CoinSelectionParams coin_selection_params;
-    pwallet->AvailableCoins(vAvailableCoins, &temp);
-    // For staking, use all available coins directly — SelectCoins applies
-    // confirmation filters that reject recently-received coins, but staking
-    // only needs any single UTXO with sufficient age to find a valid kernel.
-    CAmount nAvailable = 0;
-    for (const auto& coin : vAvailableCoins) {
-        setCoins.insert(coin.GetInputCoin());
-        nAvailable += coin.GetInputCoin().txout.nValue;
+    // The chain context for this pass, read once. The tip can move while the
+    // pass runs; BuildCoinStake re-checks the kernel against the tip the
+    // block is built on.
+    bool fSegwitActive;
+    int nSpendHeight;
+    {
+        LOCK(cs_main);
+        const CBlockIndex* pindexTip = chainstate->m_chain.Tip();
+        // Check if SegWit is active for the next block, needed to filter witness UTXOs
+        fSegwitActive = DeploymentActiveAfter(pindexTip, consensusParams, Consensus::DEPLOYMENT_SEGWIT);
+        // Height the coinstake being built would be spent at.
+        nSpendHeight = pindexTip->nHeight + 1;
     }
-    nValueIn = nAvailable;
-    if (nAvailable <= nReserveBalance) {
-        publish_weight(); // nothing stakeable: zero weight, and known to be zero
-        return false;
-    }
-    if (setCoins.empty()) {
-        publish_weight();
-        return false;
-    }
-    CAmount nCredit = 0;
-    CScript scriptPubKeyKernel;
+
     bool fKernelFound = false;
-    // Check if SegWit is active for the next block — needed to filter witness UTXOs
-    CBlockIndex* pindexTip = chainstate->m_chain.Tip();
-    bool fSegwitActive = DeploymentActiveAfter(pindexTip, consensusParams, Consensus::DEPLOYMENT_SEGWIT);
-
-    // Height the coinstake being built would be spent at.
-    const int nSpendHeight = pindexTip->nHeight + 1;
-
-    for (const auto& pcoin : setCoins)
+    for (const CInputCoin& pcoin : candidates.coins)
     {
         // Re-check maturity against the UTXO set rather than trusting the
         // wallet's cached confirmation depth. BlockDisconnected reaches the
@@ -181,53 +319,36 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
         // Staking one produces a block that fails TestBlockValidity with
         // bad-txns-premature-spend-of-coinbase/coinstake, which is the same
         // rule CheckTxInputs applies. The chainstate is authoritative and
-        // current, so ask it instead.
-        //
-        // Background staking runs off its own thread, so draining the queue in
-        // the RPC path alone would not cover this.
-        const Coin& coin = chainstate->CoinsTip().AccessCoin(pcoin.outpoint);
-        if (coin.IsSpent())
-            continue;
-        if ((coin.IsCoinBase() || coin.IsCoinStake()) &&
-            nSpendHeight - coin.nHeight < consensusParams.GetCoinbaseMaturity())
-            continue;
-
-        // Skip witness UTXOs if SegWit is not yet active — including them in a
-        // coinstake would produce a block with witness data that gets rejected
-        // with "unexpected witness data" during ContextualCheckBlock.
-        if (!fSegwitActive) {
-            std::vector<std::vector<unsigned char>> vSolutions;
-            TxoutType type = Solver(pcoin.txout.scriptPubKey, vSolutions);
-            if (type == TxoutType::WITNESS_V0_KEYHASH ||
-                type == TxoutType::WITNESS_V0_SCRIPTHASH ||
-                type == TxoutType::WITNESS_V1_TAPROOT ||
-                type == TxoutType::WITNESS_UNKNOWN) {
+        // current, so ask it instead. Held for this lookup alone; the disk
+        // read and the age arithmetic below need no lock.
+        {
+            LOCK(cs_main);
+            const Coin& coin = chainstate->CoinsTip().AccessCoin(pcoin.outpoint);
+            if (coin.IsSpent())
                 continue;
-            }
+            if ((coin.IsCoinBase() || coin.IsCoinStake()) &&
+                nSpendHeight - coin.nHeight < consensusParams.GetCoinbaseMaturity())
+                continue;
         }
 
-        CDiskTxPos postx;
-        if (!g_txindex->FindTxPosition(pcoin.outpoint.hash, postx))
+        // Skip witness UTXOs if SegWit is not yet active
+        if (!fSegwitActive && IsWitnessOutput(pcoin.txout.scriptPubKey))
             continue;
 
-        // Read block header
-        CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
         CBlockHeader header;
         CTransactionRef tx;
-        try {
-            file >> header;
-            fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
-            file >> tx;
-        } catch (std::exception &e) {
-            return error("%s() : deserialize or I/O error in CreateCoinStake()", __PRETTY_FUNCTION__);
+        switch (ReadCoinSource(pcoin.outpoint, header, tx)) {
+        case CoinSource::MISSING: continue;
+        case CoinSource::FAILED: return false;
+        case CoinSource::OK: break;
         }
 
         // Weight, before the age gate below: GetStakeWeight counts every coin
         // with positive weight, and a coin can carry a little while still
         // inside the search margin.
         {
-            const unsigned int nTimeTx = tx->nTime ? tx->nTime : header.GetBlockTime();
-            const int64_t nTimeWeight = GetCoinAgeWeight((int64_t)nTimeTx, (int64_t)txNew.nTime, consensusParams);
+            const unsigned int nTimeTxPrev = tx->nTime ? tx->nTime : header.GetBlockTime();
+            const int64_t nTimeWeight = GetCoinAgeWeight((int64_t)nTimeTxPrev, (int64_t)nTimeTx, consensusParams);
             if (nTimeWeight > 0) {
                 const arith_uint512 bnCoinDayWeight = arith_uint512(pcoin.txout.nValue) * nTimeWeight / COIN / (24 * 60 * 60);
                 weight_summary.total += bnCoinDayWeight.GetLow64();
@@ -239,170 +360,143 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
         // whole set: a wallet that finds a kernel on every pass, as a large
         // one does on a quiet network, would otherwise never publish. The
         // remaining coins are read once more here, which the combine loop
-        // below does anyway on a pass that found a kernel.
+        // in BuildCoinStake does anyway on a pass that found a kernel.
         if (fKernelFound)
             continue;
 
-        static int nMaxStakeSearchInterval = 60;
-        if (header.GetBlockTime() + consensusParams.nStakeMinAge > txNew.nTime - nMaxStakeSearchInterval)
+        static const int nMaxStakeSearchInterval = 60;
+        if (header.GetBlockTime() + consensusParams.nStakeMinAge > nTimeTx - nMaxStakeSearchInterval)
             continue; // only count coins meeting min age requirement
 
-        for (unsigned int n=0; n<std::min(nSearchInterval,(int64_t)nMaxStakeSearchInterval) && !fKernelFound; n++)
+        // Search backward in time from the given timestamp, nSearchInterval
+        // seconds back up to nMaxStakeSearchInterval. The kernel check reads
+        // the tip and the block index, so cs_main is held for this coin's
+        // checks and released before the next coin's disk read: that is what
+        // lets the pass run while the node validates blocks and the GUI
+        // reads the chain.
+        bool foundStake = false;
+        unsigned int nKernelOffset = 0;
         {
-            // Search backward in time from the given txNew timestamp
-            // Search nSearchInterval seconds back up to nMaxStakeSearchInterval
-            uint256 hashProofOfStake = uint256();
-            COutPoint prevoutStake = pcoin.outpoint;
+            LOCK(cs_main);
             // When creating a new stake block, use current chain tip as parent
             CBlockIndex* pindexPrev = chainstate->m_chain.Tip();
-            bool foundStake = CheckStakeKernelHash(chainstate, pindexPrev, nBits, header, prevoutStake.n, tx, prevoutStake, txNew.nTime - n, hashProofOfStake);
-            if (foundStake)
+            for (unsigned int n = 0; n < std::min(nSearchInterval, (int64_t)nMaxStakeSearchInterval); n++)
             {
-                // Found a kernel
-                if (gArgs.GetBoolArg("-debug", false) && gArgs.GetBoolArg("-printcoinstake", DEFAULT_PRINTCOINSTAKE))
-                    LogPrintf("CreateCoinStake : kernel found\n");
-                std::vector<valtype> vSolutions;
-                CScript scriptPubKeyOut;
-                scriptPubKeyKernel = pcoin.txout.scriptPubKey;
-                TxoutType whichType = Solver(scriptPubKeyKernel, vSolutions);
-                if (whichType != TxoutType::PUBKEY &&
-                    whichType != TxoutType::PUBKEYHASH &&
-                    whichType != TxoutType::WITNESS_V0_KEYHASH &&
-                    whichType != TxoutType::WITNESS_V1_TAPROOT) {
-                    LogPrintf("CreateCoinStake : no support for kernel type=%s\n", GetTxnOutputType(whichType));
+                uint256 hashProofOfStake = uint256();
+                if (CheckStakeKernelHash(chainstate, pindexPrev, nBits, header, pcoin.outpoint.n, tx, pcoin.outpoint, nTimeTx - n, hashProofOfStake)) {
+                    foundStake = true;
+                    nKernelOffset = n;
                     break;
                 }
-                if (whichType == TxoutType::PUBKEYHASH || whichType == TxoutType::WITNESS_V0_KEYHASH) // pay to address type or witness keyhash
-                {
-                    // convert to pay to public key type
-                    CKey key;
-                    CKeyID keyid{uint160{vSolutions[0]}};
-                    bool found_key = false;
-
-                    // Try all ScriptPubKeyMans (supports both legacy and descriptor wallets)
-                    for (ScriptPubKeyMan* spk_man : pwallet->GetAllScriptPubKeyMans()) {
-                        SignatureData sigdata;
-                        if (spk_man->CanProvide(scriptPubKeyKernel, sigdata)) {
-                            if (auto* legacy = dynamic_cast<LegacyScriptPubKeyMan*>(spk_man)) {
-                                if (legacy->GetKey(keyid, key)) {
-                                    found_key = true;
-                                    break;
-                                }
-                            } else if (auto* desc = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
-                                if (desc->GetKey(scriptPubKeyKernel, keyid, key)) {
-                                    found_key = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    if (!found_key) {
-                        LogPrintf("CreateCoinStake : failed to get key for kernel type=%s\n", GetTxnOutputType(whichType));
-                        break;
-                    }
-                    scriptPubKeyOut << ToByteVector(key.GetPubKey()) << OP_CHECKSIG;
-                }
-                else if (whichType == TxoutType::WITNESS_V1_TAPROOT)
-                {
-                    // Taproot: verify we have the key for key-path spending
-                    // vSolutions[0] contains the 32-byte x-only pubkey
-                    bool found_key = false;
-
-                    // Try all ScriptPubKeyMans (supports both legacy and descriptor wallets)
-                    for (ScriptPubKeyMan* spk_man : pwallet->GetAllScriptPubKeyMans()) {
-                        SignatureData sigdata;
-                        if (spk_man->CanProvide(scriptPubKeyKernel, sigdata)) {
-                            found_key = true;
-                            break;
-                        }
-                    }
-
-                    if (!found_key) {
-                        LogPrintf("CreateCoinStake : failed to get key for kernel type=%s\n", GetTxnOutputType(whichType));
-                        break;
-                    }
-                    scriptPubKeyOut = scriptPubKeyKernel;
-                }
-                else if (whichType == TxoutType::PUBKEY)
-                {
-                    // P2PK: verify we have the key
-                    // vSolutions[0] contains the pubkey
-                    CKeyID keyid = CPubKey(vSolutions[0]).GetID();
-                    bool found_key = false;
-
-                    // Try all ScriptPubKeyMans (supports both legacy and descriptor wallets)
-                    for (ScriptPubKeyMan* spk_man : pwallet->GetAllScriptPubKeyMans()) {
-                        if (auto* legacy = dynamic_cast<LegacyScriptPubKeyMan*>(spk_man)) {
-                            CKey key;
-                            if (legacy->GetKey(keyid, key)) {
-                                found_key = true;
-                                break;
-                            }
-                        } else if (auto* desc = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
-                            // For descriptor wallets, try with a P2PKH script since that's what they track
-                            CScript p2pkh_script = GetScriptForDestination(PKHash(keyid));
-                            CKey key;
-                            if (desc->GetKey(p2pkh_script, keyid, key)) {
-                                found_key = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!found_key) {
-                        LogPrintf("CreateCoinStake : failed to get key for kernel type=%s\n", GetTxnOutputType(whichType));
-                        break;
-                    }
-                    scriptPubKeyOut = scriptPubKeyKernel;
-                }
-
-                txNew.nTime -= n;
-                txNew.vin.push_back(CTxIn(pcoin.outpoint.hash, pcoin.outpoint.n));
-                nCredit += pcoin.txout.nValue;
-                vwtxPrev.push_back(tx);
-                txNew.vout.push_back(CTxOut(0, scriptPubKeyOut));
-                // Age the kernel from the UTXO Coin (single source of truth,
-                // same source GetCoinAge/ConnectBlock use). Value is identical
-                // to the disk header.GetBlockTime(); fall back to it defensively.
-                uint32_t nKernelBlockTime = header.GetBlockTime();
-                uint32_t nKernelTxPrevTime;
-                GetCoinAgeTimes(chainstate, chainstate->CoinsTip(), pcoin.outpoint, nKernelBlockTime, nKernelTxPrevTime);
-                if (GetCoinAgeWeight(nKernelBlockTime, (int64_t)txNew.nTime, consensusParams) < nStakeSplitAge && nCredit >= nCombineThreshold)
-                    txNew.vout.push_back(CTxOut(0, scriptPubKeyOut)); // Split stake
-                LogPrintf("CreateCoinStake : added kernel type=%s\n", GetTxnOutputType(whichType));
-                fKernelFound = true;
-                break;
             }
         }
-    }
-    publish_weight();
-    if (nCredit == 0 || nCredit > nAvailable - nReserveBalance)
-        return false;
-    for (const auto& pcoin : setCoins)
-    {
-        CDiskTxPos postx;
-        if (!g_txindex->FindTxPosition(pcoin.outpoint.hash, postx))
+        if (!foundStake)
             continue;
 
-        // Read block header
-        CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
-        CBlockHeader header;
-        CTransactionRef tx;
-        try {
-            file >> header;
-            fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
-            file >> tx;
-        } catch (std::exception &e) {
-            return error("%s() : deserialize or I/O error in CreateCoinStake()", __PRETTY_FUNCTION__);
+        // Found a kernel
+        if (gArgs.GetBoolArg("-debug", false) && gArgs.GetBoolArg("-printcoinstake", DEFAULT_PRINTCOINSTAKE))
+            LogPrintf("CreateCoinStake : kernel found\n");
+        TxoutType whichType;
+        CScript scriptPubKeyOut;
+        if (!KernelOutputScript(pwallet, pcoin.txout.scriptPubKey, whichType, scriptPubKeyOut))
+            continue; // unsupported type or no key for it: logged, and the search moves on as it always has
+
+        kernel.outpoint = pcoin.outpoint;
+        kernel.txout = pcoin.txout;
+        kernel.header = header;
+        kernel.txPrev = tx;
+        kernel.nTime = nTimeTx - nKernelOffset;
+        kernel.scriptPubKeyOut = scriptPubKeyOut;
+        kernel.type = whichType;
+        fKernelFound = true;
+    }
+    publish_weight();
+    return fKernelFound;
+}
+
+bool BuildCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, const StakeCandidates& candidates, const StakeKernel& kernel, CMutableTransaction& txNew, const Consensus::Params& consensusParams)
+{
+    AssertLockHeld(cs_main);
+    AssertLockHeld(pwallet->cs_wallet);
+
+    CBlockIndex* pindexPrev = chainstate->m_chain.Tip();
+    const int nSpendHeight = pindexPrev->nHeight + 1;
+
+    // The kernel was found without the wallet lock and possibly against an
+    // older tip. Anything that changed since costs this pass, never a block
+    // the node would reject.
+    if (pwallet->IsSpent(kernel.outpoint.hash, kernel.outpoint.n)) {
+        LogPrintf("CreateCoinStake : kernel %s spent by the wallet since it was found\n", kernel.outpoint.ToString());
+        return false;
+    }
+    {
+        const Coin& coin = chainstate->CoinsTip().AccessCoin(kernel.outpoint);
+        if (coin.IsSpent()) {
+            LogPrintf("CreateCoinStake : kernel %s spent on the chain since it was found\n", kernel.outpoint.ToString());
+            return false;
         }
+        if ((coin.IsCoinBase() || coin.IsCoinStake()) && nSpendHeight - coin.nHeight < consensusParams.GetCoinbaseMaturity()) {
+            LogPrintf("CreateCoinStake : kernel %s no longer mature at height %d\n", kernel.outpoint.ToString(), nSpendHeight);
+            return false;
+        }
+    }
+    {
+        uint256 hashProofOfStake;
+        if (!CheckStakeKernelHash(chainstate, pindexPrev, nBits, kernel.header, kernel.outpoint.n, kernel.txPrev, kernel.outpoint, kernel.nTime, hashProofOfStake)) {
+            LogPrintf("CreateCoinStake : kernel %s no longer meets the target at the current tip\n", kernel.outpoint.ToString());
+            return false;
+        }
+    }
 
+    txNew.vin.clear();
+    txNew.vout.clear();
+    txNew.nVersion = POSV_TX_VERSION;   // Self-contained invariant: CreateCoinStake produces a v2 tx
+    txNew.nTime = kernel.nTime;
 
+    // Mark coin stake transaction
+    CScript scriptEmpty;
+    scriptEmpty.clear();
+    txNew.vout.push_back(CTxOut(0, scriptEmpty));
+
+    std::vector<CTransactionRef> vwtxPrev;
+    CAmount nCredit = 0;
+    const CScript& scriptPubKeyKernel = kernel.txout.scriptPubKey;
+
+    txNew.vin.push_back(CTxIn(kernel.outpoint.hash, kernel.outpoint.n));
+    nCredit += kernel.txout.nValue;
+    vwtxPrev.push_back(kernel.txPrev);
+    txNew.vout.push_back(CTxOut(0, kernel.scriptPubKeyOut));
+    // Age the kernel from the UTXO Coin (single source of truth,
+    // same source GetCoinAge/ConnectBlock use). Value is identical
+    // to the disk header.GetBlockTime(); fall back to it defensively.
+    uint32_t nKernelBlockTime = kernel.header.GetBlockTime();
+    uint32_t nKernelTxPrevTime;
+    GetCoinAgeTimes(chainstate, chainstate->CoinsTip(), kernel.outpoint, nKernelBlockTime, nKernelTxPrevTime);
+    if (GetCoinAgeWeight(nKernelBlockTime, (int64_t)txNew.nTime, consensusParams) < nStakeSplitAge && nCredit >= nCombineThreshold)
+        txNew.vout.push_back(CTxOut(0, kernel.scriptPubKeyOut)); // Split stake
+    LogPrintf("CreateCoinStake : added kernel type=%s\n", GetTxnOutputType(kernel.type));
+
+    if (nCredit == 0 || nCredit > candidates.nAvailable - candidates.nReserveBalance)
+        return false;
+    for (const CInputCoin& pcoin : candidates.coins)
+    {
         // Attempt to add more inputs
         // Only add coins of the same key/address as kernel
         if (txNew.vout.size() == 2 && ((pcoin.txout.scriptPubKey == scriptPubKeyKernel || pcoin.txout.scriptPubKey == txNew.vout[1].scriptPubKey))
             && pcoin.outpoint.hash != txNew.vin[0].prevout.hash)
         {
+            // The candidates were collected before the search; a coin the
+            // wallet or the chain has spent since would invalidate the block.
+            if (pwallet->IsSpent(pcoin.outpoint.hash, pcoin.outpoint.n) || chainstate->CoinsTip().AccessCoin(pcoin.outpoint).IsSpent())
+                continue;
+            CBlockHeader header;
+            CTransactionRef tx;
+            switch (ReadCoinSource(pcoin.outpoint, header, tx)) {
+            case CoinSource::MISSING: continue;
+            case CoinSource::FAILED: return false;
+            case CoinSource::OK: break;
+            }
+
             // Stop adding more inputs if already too many inputs
             if (txNew.vin.size() >= 100)
                 break;
@@ -410,7 +504,7 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
             if (nCredit > nCombineThreshold)
                 break;
             // Stop adding inputs if reached reserve limit
-            if (nCredit + pcoin.txout.nValue > nAvailable - nReserveBalance)
+            if (nCredit + pcoin.txout.nValue > candidates.nAvailable - candidates.nReserveBalance)
                 break;
             // Do not add additional significant input
             if (pcoin.txout.nValue > nCombineThreshold)
@@ -511,6 +605,27 @@ bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned i
 
     // Successfully generated coinstake
     return true;
+}
+
+// Reddcoin: create coin stake transaction
+bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams, StakeWeightSummary* weight)
+{
+    // Transaction index is required to get to block header
+    if (!g_txindex)
+        return error("CreateCoinStake : transaction index unavailable");
+
+    LOCK2(cs_main, pwallet->cs_wallet);
+
+    StakeCandidates candidates;
+    CollectStakeCandidates(pwallet, candidates);
+    if (!candidates.collected)
+        return false; // the reserve balance setting could not be parsed
+
+    // An empty set still runs the search, which reports a known zero weight.
+    StakeKernel kernel;
+    if (!SearchStakeKernel(pwallet, chainstate, candidates, nBits, nSearchInterval, txNew.nTime, consensusParams, kernel, weight))
+        return false;
+    return BuildCoinStake(pwallet, chainstate, nBits, candidates, kernel, txNew, consensusParams);
 }
 
 bool FinalizeCoinStakeReward(const CWallet* pwallet, CChainState* chainstate, CMutableTransaction& txCoinStake, const CAmount& nFees, const Consensus::Params& consensusParams)
@@ -748,6 +863,50 @@ public:
         if (m_reservedest) m_reservedest->KeepDestination();
     }
 
+    bool collectStakeCandidates() override
+    {
+        return CollectStakeCandidates(m_wallet.get(), m_candidates);
+    }
+
+    bool stakeCandidatesCurrent() override
+    {
+        if (!m_candidates.collected) return false;
+        return WITH_LOCK(m_wallet->cs_wallet, return m_wallet->GetLastBlockHash()) == m_candidates.hashLastBlock;
+    }
+
+    size_t stakeCandidateCount() override { return m_candidates.coins.size(); }
+
+    bool searchStakeKernel(CChainState& chainstate,
+        unsigned int nBits,
+        int64_t nSearchInterval,
+        uint32_t nTimeTx,
+        const Consensus::Params& consensus_params) override
+    {
+        // Publish what the pass measured, so the GUI and getstakinginfo need
+        // not rescan the wallet. A pass that failed before it could examine
+        // the set leaves the previous value standing.
+        StakeWeightSummary weight;
+        m_kernel_found = SearchStakeKernel(m_wallet.get(), &chainstate, m_candidates, nBits, nSearchInterval, nTimeTx, consensus_params, m_kernel, &weight);
+        if (weight.complete) m_wallet->PublishStakeWeight(weight.average, weight.total);
+        return m_kernel_found;
+    }
+
+    bool buildCoinStake(CChainState& chainstate,
+        unsigned int nBits,
+        CMutableTransaction& tx_new,
+        const Consensus::Params& consensus_params) override NO_THREAD_SAFETY_ANALYSIS
+    {
+        if (!m_kernel_found) return false;
+        m_kernel_found = false;
+        if (BuildCoinStake(m_wallet.get(), &chainstate, nBits, m_candidates, m_kernel, tx_new, consensus_params)) return true;
+        // The kernel did not survive the re-check under the locks, most often
+        // because the wallet spent the coin since the candidates were
+        // collected. Have the next pass collect again rather than wait for a
+        // block to move the wallet's view.
+        m_candidates.collected = false;
+        return false;
+    }
+
     bool createCoinStake(CChainState& chainstate,
         unsigned int nBits,
         int64_t nSearchInterval,
@@ -779,6 +938,13 @@ private:
     //! is called. Held for this object's lifetime, matching the ReserveDestination
     //! that PoSMiner used to keep on its stack for the whole staking loop.
     std::unique_ptr<ReserveDestination> m_reservedest;
+    //! The coins the staking thread searches, collected under cs_wallet once
+    //! per block, and the kernel its last search found, handed to the block
+    //! assembler through buildCoinStake(). Owned here rather than by the
+    //! thread so that libbitcoin_server never names a wallet type.
+    StakeCandidates m_candidates;
+    StakeKernel m_kernel;
+    bool m_kernel_found{false};
 };
 
 //! interfaces::StakingSupport over the process's loaded wallets.

--- a/src/wallet/staking.h
+++ b/src/wallet/staking.h
@@ -6,12 +6,19 @@
 #define BITCOIN_WALLET_STAKING_H
 
 #include <interfaces/staking.h>
+#include <primitives/block.h>
+#include <script/standard.h>
+#include <sync.h>
+#include <uint256.h>
+#include <wallet/coinselection.h>
 
 #include <memory>
+#include <set>
 #include <stdint.h>
 #include <string>
 
 class CWallet;
+extern RecursiveMutex cs_main;
 
 //! Wallet-side implementation of the node's staking interfaces.
 //!
@@ -36,7 +43,61 @@ struct StakeWeightSummary {
     bool complete{false};
 };
 
-//! Search for a kernel among the wallet's coins and build the coinstake.
+//! The coins one wallet may stake, collected under cs_wallet and reused by
+//! the staking thread across passes until the wallet's view of the chain
+//! moves. The set is ordered by outpoint, which is the order the kernel
+//! search has always run in.
+struct StakeCandidates {
+    std::set<CInputCoin> coins;
+    //! Value of the coins and the reserve at collection; a coinstake may not
+    //! spend more than their difference.
+    CAmount nAvailable{0};
+    CAmount nReserveBalance{0};
+    //! The wallet's last processed block when collected. The staking thread
+    //! collects again when this moves.
+    uint256 hashLastBlock;
+    //! False until a collection has run, and false again if the reserve
+    //! balance setting could not be parsed.
+    bool collected{false};
+};
+
+//! Collect the wallet's stakeable coins. Takes cs_wallet for the duration,
+//! which on a large wallet is seconds, so the staking thread calls this once
+//! per block rather than once per pass. Returns false when there is nothing
+//! to stake or the reserve balance setting is invalid; candidates.collected
+//! tells the two apart.
+bool CollectStakeCandidates(const CWallet* pwallet, StakeCandidates& candidates);
+
+//! A kernel SearchStakeKernel found, carrying what BuildCoinStake needs to
+//! place it as the coinstake's first input.
+struct StakeKernel {
+    COutPoint outpoint;
+    CTxOut txout;
+    CBlockHeader header;      //!< block the coin was created in
+    CTransactionRef txPrev;   //!< transaction that created it
+    uint32_t nTime{0};        //!< coinstake time at which the kernel met the target
+    CScript scriptPubKeyOut;  //!< output script: the coin's own, or its pubkey for a keyhash coin
+    TxoutType type{TxoutType::NONSTANDARD};
+};
+
+//! Search the candidates for a kernel at nTimeTx and up to nSearchInterval
+//! seconds before it. Takes no wallet lock: each coin's source is read
+//! through the transaction index, and cs_main is held only around the chain
+//! reads for one coin at a time, so the search runs while the GUI and RPC
+//! use the wallet and the node validates blocks. Reports the stake weight of
+//! the coins it examined through weight, if given.
+bool SearchStakeKernel(const CWallet* pwallet, CChainState* chainstate, const StakeCandidates& candidates, unsigned int nBits, int64_t nSearchInterval, uint32_t nTimeTx, const Consensus::Params& consensusParams, StakeKernel& kernel, StakeWeightSummary* weight = nullptr);
+
+//! Build the coinstake around a found kernel. The search ran without the
+//! locks and possibly against an older tip, so first check the kernel is
+//! still unspent, mature and meets the target at the current tip; then add
+//! the combine inputs, the dev output, the reward and the signatures.
+bool BuildCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, const StakeCandidates& candidates, const StakeKernel& kernel, CMutableTransaction& txNew, const Consensus::Params& consensusParams) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, pwallet->cs_wallet);
+
+//! Collect, search and build in one call, under cs_main and cs_wallet, for
+//! callers that build a block on demand such as the generate RPCs. The
+//! staking thread uses the three steps separately, through
+//! interfaces::StakingWallet, so that its search holds neither lock.
 //! Reports the weight of the coins it examined through weight, if given.
 bool CreateCoinStake(const CWallet* pwallet, CChainState* chainstate, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, const Consensus::Params& consensusParams, StakeWeightSummary* weight = nullptr);
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -13,12 +13,15 @@
 
 #include <interfaces/chain.h>
 #include <interfaces/wallet.h>
+#include <miner.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <policy/policy.h>
+#include <pow.h>
 #include <rpc/server.h>
 #include <test/util/logging.h>
 #include <test/util/setup_common.h>
+#include <timedata.h>
 #include <util/translation.h>
 #include <validation.h>
 #include <interfaces/staking.h>
@@ -1366,6 +1369,167 @@ BOOST_FIXTURE_TEST_CASE(trusted_and_available_without_finality_check, TestChain1
     // The locked spend stays out until it is final, whatever else changes.
     BOOST_CHECK(!trusted(locked));
     BOOST_CHECK(!is_final(locked));
+}
+
+//! The staking thread collects the wallet's stakeable coins under the wallet
+//! lock, searches them for a kernel without it, and builds the coinstake
+//! under the locks only once it has found one. The three steps must produce
+//! the coinstake the one-shot path produces, and the build must refuse a
+//! kernel the world has moved under: one the wallet has spent since the
+//! collection, one the chain does not hold, one the chain no longer counts
+//! mature. Both the functions and the staking interface the thread drives
+//! them through are checked, on the fixture's staking wallet, which has just
+//! built the proof-of-stake tail of the chain.
+BOOST_FIXTURE_TEST_CASE(stake_candidates_searched_without_wallet_lock, TestChain100Setup)
+{
+    BOOST_REQUIRE(m_wallet);
+    const Consensus::Params& params = Params().GetConsensus();
+    CChainState& chainstate = m_node.chainman->ActiveChainstate();
+    const CBlockIndex* tip = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Tip());
+    const uint32_t nTimeTx = GetAdjustedTime(); // the mocked clock, held still by the fixture
+    unsigned int nBits;
+    {
+        LOCK(cs_main);
+        CBlockHeader next;
+        next.nTime = nTimeTx;
+        nBits = GetNextWorkRequired(m_node.chainman->ActiveChain().Tip(), &next, params);
+    }
+    const CScript ours = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+
+    // The collection records the wallet's view of the chain and every coin
+    // it may spend, in search order.
+    StakeCandidates candidates;
+    BOOST_REQUIRE(CollectStakeCandidates(m_wallet.get(), candidates));
+    BOOST_CHECK(candidates.collected);
+    BOOST_CHECK(candidates.hashLastBlock == tip->GetBlockHash());
+    BOOST_CHECK_EQUAL(candidates.nReserveBalance, 0);
+    {
+        LOCK(m_wallet->cs_wallet);
+        std::vector<COutput> available;
+        m_wallet->AvailableCoins(available);
+        BOOST_CHECK_EQUAL(candidates.coins.size(), available.size());
+        CAmount sum = 0;
+        for (const COutput& coin : available) sum += coin.GetInputCoin().txout.nValue;
+        BOOST_CHECK_EQUAL(candidates.nAvailable, sum);
+    }
+    BOOST_REQUIRE(!candidates.coins.empty());
+
+    // The search finds a kernel with no wallet lock held (regtest's target is
+    // met by the first eligible coin) and reports the weight of the set.
+    StakeKernel kernel;
+    StakeWeightSummary weight;
+    BOOST_REQUIRE(SearchStakeKernel(m_wallet.get(), &chainstate, candidates, nBits, 60, nTimeTx, params, kernel, &weight));
+    BOOST_CHECK(weight.complete);
+    BOOST_CHECK(weight.total > 0);
+    BOOST_CHECK(kernel.nTime <= nTimeTx);
+    BOOST_CHECK(kernel.nTime > nTimeTx - 60);
+    bool kernel_is_a_candidate = false;
+    for (const CInputCoin& coin : candidates.coins) kernel_is_a_candidate |= coin.outpoint == kernel.outpoint;
+    BOOST_CHECK(kernel_is_a_candidate);
+
+    // Built under the locks, the coinstake is the one the one-shot path
+    // builds at the same clock: same kernel, same inputs, same outputs, same
+    // signatures.
+    CMutableTransaction built;
+    CMutableTransaction oneshot;
+    oneshot.nTime = nTimeTx;
+    StakeWeightSummary oneshot_weight;
+    {
+        LOCK2(m_wallet->cs_wallet, ::cs_main);
+        BOOST_REQUIRE(BuildCoinStake(m_wallet.get(), &chainstate, nBits, candidates, kernel, built, params));
+        BOOST_REQUIRE(CreateCoinStake(m_wallet.get(), &chainstate, nBits, 60, oneshot, params, &oneshot_weight));
+    }
+    BOOST_CHECK_EQUAL(built.nTime, oneshot.nTime);
+    BOOST_CHECK(built.vin[0].prevout == kernel.outpoint);
+    BOOST_CHECK(CTransaction(built).GetHash() == CTransaction(oneshot).GetHash());
+    BOOST_CHECK_EQUAL(weight.total, oneshot_weight.total);
+    BOOST_CHECK_EQUAL(weight.average, oneshot_weight.average);
+
+    // The staking thread drives the same three steps through the interface,
+    // which keeps the candidates and the kernel on the wallet side, and hands
+    // the kernel to the block assembler.
+    std::unique_ptr<interfaces::StakingWallet> staking_wallet = MakeStakingWallet(m_wallet);
+    BOOST_REQUIRE(staking_wallet);
+    BOOST_CHECK(!staking_wallet->stakeCandidatesCurrent());
+    BOOST_CHECK(staking_wallet->collectStakeCandidates());
+    BOOST_CHECK(staking_wallet->stakeCandidatesCurrent());
+    BOOST_CHECK_EQUAL(staking_wallet->stakeCandidateCount(), candidates.coins.size());
+    BOOST_REQUIRE(staking_wallet->searchStakeKernel(chainstate, nBits, 60, nTimeTx, params));
+    {
+        uint64_t published_average = 0;
+        uint64_t published_total = 0;
+        BOOST_CHECK(m_wallet->GetPublishedStakeWeight(published_average, published_total));
+        BOOST_CHECK_EQUAL(published_total, weight.total);
+    }
+
+    // The wallet spends the kernel coin between the search and the build, as
+    // a user sending coins would. The assembler asks the wallet to build,
+    // the wallet finds the spend and refuses, and the assembler reports it
+    // the way it reports a search that found nothing: no template, and the
+    // pass cancelled. The refusal marks the candidates for a new collection.
+    CMutableTransaction spend_tx;
+    spend_tx.vin.emplace_back(kernel.outpoint);
+    spend_tx.vout.emplace_back(kernel.txout.nValue - 1000, ours);
+    m_wallet->AddToWallet(MakeTransactionRef(spend_tx), {CWalletTx::Status::UNCONFIRMED, /* height */ 0, /* hash */ {}, /* index */ 0});
+    {
+        DebugLogHelper refused("spent by the wallet since it was found");
+        auto wallet_lock = staking_wallet->lock();
+        bool cancelled = false;
+        std::unique_ptr<CBlockTemplate> tmpl = BlockAssembler(chainstate, *m_node.mempool, Params()).CreateNewBlock(ours, staking_wallet.get(), &cancelled, /* from_found_kernel= */ true);
+        BOOST_CHECK(!tmpl);
+        BOOST_CHECK(cancelled);
+    }
+    BOOST_CHECK(!staking_wallet->stakeCandidatesCurrent());
+
+    // The next collection leaves the spent coin out.
+    BOOST_CHECK(staking_wallet->collectStakeCandidates());
+    BOOST_CHECK(staking_wallet->stakeCandidatesCurrent());
+    BOOST_CHECK_EQUAL(staking_wallet->stakeCandidateCount(), candidates.coins.size() - 1);
+
+    // The same refusals, directly. A refused kernel leaves the transaction
+    // untouched, so the assembler's template is not half built.
+    const auto build = [&](const StakeKernel& k) {
+        LOCK2(m_wallet->cs_wallet, ::cs_main);
+        CMutableTransaction txNew;
+        const bool ok = BuildCoinStake(m_wallet.get(), &chainstate, nBits, candidates, k, txNew, params);
+        BOOST_CHECK(txNew.vin.empty());
+        return ok;
+    };
+    const auto kernel_on = [&](const CTransactionRef& tx, uint32_t n) {
+        StakeKernel k = kernel;
+        k.outpoint = COutPoint(tx->GetHash(), n);
+        k.txout = tx->vout[n];
+        k.txPrev = tx;
+        k.scriptPubKeyOut = tx->vout[n].scriptPubKey;
+        return k;
+    };
+    {
+        DebugLogHelper refused("spent by the wallet since it was found");
+        BOOST_CHECK(!build(kernel));
+    }
+    {
+        // A coin the chain never held.
+        CMutableTransaction unknown_tx;
+        unknown_tx.vin.emplace_back(COutPoint(GetRandHash(), 0));
+        unknown_tx.vout.emplace_back(1 * COIN, ours);
+        DebugLogHelper refused("spent on the chain since it was found");
+        BOOST_CHECK(!build(kernel_on(MakeTransactionRef(unknown_tx), 0)));
+    }
+    {
+        // The tip's own coinstake output: on the chain, unspent, not yet mature.
+        const CTransactionRef& tip_coinstake = m_coinbase_txns.back();
+        BOOST_REQUIRE(tip_coinstake->IsCoinStake());
+        DebugLogHelper refused("no longer mature at height " + ToString(tip->nHeight + 1));
+        BOOST_CHECK(!build(kernel_on(tip_coinstake, 1)));
+    }
+
+    // A block the wallet processes moves its view, and the candidates are
+    // stale until the thread collects again.
+    stakeBlocks(1);
+    m_wallet->BlockUntilSyncedToCurrentChain();
+    BOOST_CHECK(!staking_wallet->stakeCandidatesCurrent());
+    BOOST_CHECK(staking_wallet->collectStakeCandidates());
+    BOOST_CHECK(staking_wallet->stakeCandidatesCurrent());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -275,6 +275,7 @@ BASE_SCRIPTS = [
     'feature_descriptor_legacy_staking.py',
     # RPCs that the --coverage gate reported as untested.
     'rpc_staking.py',
+    'wallet_staking_thread.py',
     'wallet_interest.py',
     'rpc_inflation.py',
     'rpc_checkupdates.py',

--- a/test/functional/wallet_staking_thread.py
+++ b/test/functional/wallet_staking_thread.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Reddcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the staking thread's candidate collection and lock-free kernel search.
+
+The staking thread collects the wallet's stakeable coins once per block the
+wallet processes, searches them for a kernel without holding the wallet lock,
+and takes the lock only to build the block around a kernel it has found. That
+build re-checks the kernel against the wallet and the chain, so a coin spent
+after the collection is refused rather than staked, and the refusal makes the
+thread collect again before its next pass.
+
+Pinned here, through the RPC and log surface the thread has:
+
+- the thread collects the wallet's coins when it starts and again after each
+  block it processes
+- it stakes blocks on its own, so the split search finds and builds kernels
+  end to end
+- the search publishes its interval and weight, so getstakinginfo reports
+  them while the thread runs
+- spending every coin after a collection makes the next kernel a refused one;
+  the thread then collects again, finds nothing, and publishes a known zero
+  weight instead of staking a spent coin
+
+Mock time is held still between steps, so the thread searches only when the
+test moves the clock: each step is one search interval.
+"""
+import os
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    set_node_times,
+)
+
+# One kernel search interval. The thread sleeps well under a second between
+# passes on a wallet of this size, so a step per second of real time gives it
+# fresh seconds to search on every pass.
+SEARCH_STEP = 60
+
+
+class StakingThreadTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        # Staking is switched on deliberately once the test is watching. The
+        # thread reserves a destination for its coinstake as it starts and
+        # ends if the keypool cannot cover it.
+        self.extra_args = [["-staking=0", "-keypool=100"], []]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def log_size(self, node):
+        with open(os.path.join(node.datadir, node.chain, "debug.log"), encoding="utf-8") as log:
+            log.seek(0, 2)
+            return log.tell()
+
+    def log_since(self, node, offset):
+        with open(os.path.join(node.datadir, node.chain, "debug.log"), encoding="utf-8") as log:
+            log.seek(offset)
+            return log.read()
+
+    def step_until(self, predicate, steps=40):
+        """Give the thread a search pass at a time, by moving the clock one
+        interval, until predicate holds."""
+        for _ in range(steps):
+            if predicate():
+                return True
+            set_node_times(self.nodes, self.nodes[0].mocktime + SEARCH_STEP)
+            time.sleep(1)
+        return predicate()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("The thread collects the wallet's coins when it starts")
+        coins = len(node.listunspent())
+        assert_greater_than(coins, 0)
+        # Taken before the thread exists: its first pass searches a whole
+        # interval and on regtest stakes within milliseconds of starting.
+        height = node.getblockcount()
+        started = self.log_size(node)
+        # The node-wide switch first: setstaking only starts a thread while
+        # it is on, and the node came up with it off.
+        node.staking(True)
+        with node.assert_debug_log(["proof-of-stake timeout: ", f"for {coins} UTXOs"], timeout=10):
+            node.setstaking(True)
+
+        self.log.info("The thread stakes on its own: the split search finds and builds a kernel")
+        assert self.step_until(lambda: node.getblockcount() > height), "the thread staked no block"
+        assert "proof-of-stake block found" in self.log_since(node, started)
+        after_block = self.log_size(node)
+        self.sync_blocks()
+
+        self.log.info("The search publishes its interval and weight while the thread runs")
+        info = node.getstakinginfo()
+        assert_greater_than(info["search-interval"], 0)
+        assert_greater_than(info["totalweight"], 0)
+
+        self.log.info("After the block the thread collects again")
+        # It rests after a found block, then collects because the wallet's
+        # view of the chain has moved. The clock stays still meanwhile, so
+        # the thread searches nothing until the next step.
+        self.wait_until(lambda: "stake candidates" in self.log_since(node, after_block), timeout=60)
+
+        self.log.info("A coin spent after the collection is refused at the build, not staked")
+        spent = self.log_size(node)
+        node.sendtoaddress(self.nodes[1].getnewaddress(), node.getbalance(), "", "", True)
+        assert self.step_until(lambda: "spent by the wallet since it was found" in self.log_since(node, spent)), \
+            "no kernel on a spent coin was refused"
+
+        self.log.info("The thread collects again, finds nothing to stake, and says so")
+        assert self.step_until(lambda: node.getstakinginfo()["totalweight"] == 0), "the empty collection was never published"
+        assert "collected 0 stake candidates" in self.log_since(node, spent)
+        assert_equal(node.getblockcount(), height + 1)
+        assert "not accepted" not in self.log_since(node, spent)
+
+        node.setstaking(False)
+        node.staking(False)
+
+
+if __name__ == "__main__":
+    StakingThreadTest().main()


### PR DESCRIPTION
Port of #564 to `develop`. Tracked as [RED-133](https://reddink.youtrack.cloud/issue/RED-133), part of the [RED-130](https://reddink.youtrack.cloud/issue/RED-130) epic. Not a cherry-pick: on this line the block assembler reaches the wallet only through `interfaces::StakingWallet`, so the split lands in `wallet/staking.cpp` and the interface grows the three steps.

## The problem

The staking thread took the wallet lock around `CreateNewBlock` for every search pass, and `CreateCoinStake` inside it took `cs_main` as well. The pass is the long part: on a large wallet it walks every stakeable coin, reads each one's source block from disk through the transaction index, and runs up to sixty kernel hashes per coin. With RED-134, RED-131 and RED-135 in, that pass was the largest stall left on the GUI thread: over three minutes on the 1.18M transaction testnet wallet the GUI spent 4 s computing and 13 s blocked on a lock, every blocked second on a staker pass.

None of that work needs the wallet lock. The coin set only changes when the wallet processes a block, the disk reads go through the index, and the chain reads for a coin need `cs_main` only for the moment they run.

## The change

`CreateCoinStake` is split into three steps in `wallet/staking.cpp`:

- `CollectStakeCandidates` takes `cs_wallet` and records the wallet's last processed block, the available coins and their value. This is the scan that used to run on every pass; the staking thread now runs it once, and again only when the wallet's last block moves or a kernel fails its re-check.
- `SearchStakeKernel` walks the candidates with no wallet lock. develop's search already re-checked each coin's UTXO entry for spends and maturity, which needs `cs_main`, so the lock is held once per coin around that check and the kernel loop, and released before the next coin's disk read. The stake weight is reported the way the pass already did for RED-131. The key lookup for a keyhash kernel, across every script pubkey manager as before, takes a short `cs_wallet` on its own, never nested under `cs_main`.
- `BuildCoinStake` requires both locks and first re-checks the kernel against the tip the block will sit on: unspent in the wallet, unspent on the chain, still mature, and still meeting the target. Then it builds the transaction exactly as before, coin-age helpers, taproot kernels, multi-keyman signing and all. Combine inputs are checked for spends too, since the candidates may predate the build.

`CreateCoinStake` runs the three in turn under `LOCK2(cs_main, cs_wallet)`, so the generate RPCs behave as they did.

`interfaces::StakingWallet` gains `collectStakeCandidates`, `stakeCandidatesCurrent`, `stakeCandidateCount`, `searchStakeKernel` and `buildCoinStake`. The candidates and the found kernel live in the wallet-side implementation, so `libbitcoin_server` never names a wallet type; a refused kernel invalidates the candidates there. The old available-coin count method is gone, the candidate count replaces it. `CreateNewBlock` takes a `from_found_kernel` flag under which it builds around the wallet's kernel instead of searching.

`PoSMiner` collects, searches lock-free each pass, publishes the search interval and the weight from the search, and takes the wallet lock for the block only once a kernel has been found. A pass that finds nothing never takes either lock. The search clock is per thread rather than the static shared with the RPCs, and starts a full interval back as develop's on-demand path already did, so the first pass searches even under frozen mock time. Each collection logs one line with the candidate count.

## Result

Measured on the 4.22.9 build of the same change (#564), testnet, `staketest`, 1,182,900 transactions, 459 UTXOs, staking on, GUI thread sampled at 1 Hz from `/proc`:

| | Before (#562) | After, 300 s window |
|---|---|---|
| Blocks found by this wallet in the window | 3 in 180 s | 4 in 300 s |
| GUI seconds blocked on a lock | 13 | 0 |
| GUI CPU per block found | 0.7 to 1.9 s | 0.6 to 0.7 s |
| Staker thread duty cycle | 11.6 % | 7.4 % |

Four windows sampled and none held a single lock-wait sample. 59 blocks found and 59 accepted as tip in the first 66 minutes, zero kernel refusals, signing failures or rejected blocks.

## Tests

`wallet_tests/stake_candidates_searched_without_wallet_lock` runs the three steps on the fixture's staking wallet, which has just built the proof-of-stake tail of the chain: a collection records the wallet's last block and every available coin; a search with no wallet lock held finds a kernel and reports the weight of the set; the build under the locks produces a transaction with the same hash as the one-shot `CreateCoinStake` at the same clock. Through the staking interface, a wallet spend of the kernel coin between the search and the build makes the block assembler report a cancelled pass and marks the candidates for a new collection, which leaves the coin out. The build also refuses a coin the chain does not hold and one it no longer counts mature, each identified by its log line, and a block the wallet processes makes the candidates stale.

`wallet_staking_thread.py` watches the thread itself, stepping mock time one search interval at a time: it collects the wallet's coins as it starts, stakes a block on its own, publishes its search interval and weight, collects again after the block, refuses the kernel it finds on a coin the wallet spent after that collection, and then collects once more, finds nothing, and publishes a known zero weight rather than staking a spent coin. Runs in about 75 seconds.

`wallet_tests` (19 cases), `wallet_staking_thread.py` (twice) and `rpc_staking.py` pass on this branch.

## Notes

- Lock order on the staking path stays `cs_wallet` before `cs_main`, which `StakingWalletLock` enforces under `DEBUG_LOCKORDER`. The new code never takes `cs_wallet` under `cs_main`.
- A coin the wallet spends between blocks is only noticed at the build, which then re-collects; the functional test pins that path.
